### PR TITLE
Fix for rendering fields with `when`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ state.json
 .idea
 .vscode
 installer/
+.ship/

--- a/pkg/lifecycle/render/config/test-cases/api/ch9821-hidden-default-when.yml
+++ b/pkg/lifecycle/render/config/test-cases/api/ch9821-hidden-default-when.yml
@@ -1,0 +1,239 @@
+- name: checkbox with when on item -- hidden false
+  input:
+    - { airgap_install: "1" }
+  config:
+    - name: cluster_info
+      title: Kubernetes cluster info
+      items:
+      - name: airgap_install
+        title: Airgap cluster
+        type: bool
+        value: '1'
+      - name: docker_registry_address
+        title: Docker registry address
+        type: text
+        when: '{{repl ConfigOptionEquals "airgap_install" "1" }}'
+  responses:
+    json: |
+
+      [
+          {
+              "description": "",
+              "filters": null,
+              "items": [
+                  {
+                      "affix": "",
+                      "data_cmd": null,
+                      "default": "",
+                      "default_cmd": null,
+                      "filters": null,
+                      "help_text": "",
+                      "hidden": false,
+                      "is_excluded_from_support": false,
+                      "items": null,
+                      "multi_value": null,
+                      "multiple": false,
+                      "name": "airgap_install",
+                      "props": null,
+                      "readonly": false,
+                      "recommended": false,
+                      "required": false,
+                      "test_proc": null,
+                      "title": "Airgap cluster",
+                      "type": "bool",
+                      "value": "1",
+                      "value_cmd": null,
+                      "when": ""
+                  },
+                  {
+                      "affix": "",
+                      "data_cmd": null,
+                      "default": "",
+                      "default_cmd": null,
+                      "filters": null,
+                      "help_text": "",
+                      "hidden": false,
+                      "is_excluded_from_support": false,
+                      "items": null,
+                      "multi_value": null,
+                      "multiple": false,
+                      "name": "docker_registry_address",
+                      "props": null,
+                      "readonly": false,
+                      "recommended": false,
+                      "required": false,
+                      "test_proc": null,
+                      "title": "Docker registry address",
+                      "type": "text",
+                      "value": "",
+                      "value_cmd": null,
+                      "when": "true"
+                  }
+              ],
+              "name": "cluster_info",
+              "test_proc": null,
+              "title": "Kubernetes cluster info",
+              "when": ""
+          }
+      ]
+
+
+- name: checkbox with when on item -- hidden should be true
+  input:
+    - { airgap_install: "0" }
+  config:
+    - name: cluster_info
+      title: Kubernetes cluster info
+      items:
+      - name: airgap_install
+        title: Airgap cluster
+        type: bool
+        default: '1'
+      - name: docker_registry_address
+        title: Docker registry address
+        type: text
+        when: '{{repl ConfigOptionEquals "airgap_install" "1" }}'
+  responses:
+    json: |
+
+      [
+          {
+              "description": "",
+              "filters": null,
+              "items": [
+                  {
+                      "affix": "",
+                      "data_cmd": null,
+                      "default": "1",
+                      "default_cmd": null,
+                      "filters": null,
+                      "help_text": "",
+                      "hidden": false,
+                      "is_excluded_from_support": false,
+                      "items": null,
+                      "multi_value": null,
+                      "multiple": false,
+                      "name": "airgap_install",
+                      "props": null,
+                      "readonly": false,
+                      "recommended": false,
+                      "required": false,
+                      "test_proc": null,
+                      "title": "Airgap cluster",
+                      "type": "bool",
+                      "value": "0",
+                      "value_cmd": null,
+                      "when": ""
+                  },
+                  {
+                      "affix": "",
+                      "data_cmd": null,
+                      "default": "",
+                      "default_cmd": null,
+                      "filters": null,
+                      "help_text": "",
+                      "hidden": true,
+                      "is_excluded_from_support": false,
+                      "items": null,
+                      "multi_value": null,
+                      "multiple": false,
+                      "name": "docker_registry_address",
+                      "props": null,
+                      "readonly": false,
+                      "recommended": false,
+                      "required": false,
+                      "test_proc": null,
+                      "title": "Docker registry address",
+                      "type": "text",
+                      "value": "",
+                      "value_cmd": null,
+                      "when": "false"
+                  }
+              ],
+              "name": "cluster_info",
+              "test_proc": null,
+              "title": "Kubernetes cluster info",
+              "when": ""
+          }
+      ]
+
+# this is wild -- ensures we do a deep copy of the config group, and re-render `when` on every POST /config/live call
+- name: checkbox with when on item -- hidden should be true after toggling
+  input:
+    - { airgap_install: "1" }
+    - { airgap_install: "0" }
+  config:
+    - name: cluster_info
+      title: Kubernetes cluster info
+      items:
+      - name: airgap_install
+        title: Airgap cluster
+        type: bool
+        default: '1'
+      - name: docker_registry_address
+        title: Docker registry address
+        type: text
+        when: '{{repl ConfigOptionEquals "airgap_install" "1" }}'
+  responses:
+    json: |
+
+      [
+          {
+              "description": "",
+              "filters": null,
+              "items": [
+                  {
+                      "affix": "",
+                      "data_cmd": null,
+                      "default": "1",
+                      "default_cmd": null,
+                      "filters": null,
+                      "help_text": "",
+                      "hidden": false,
+                      "is_excluded_from_support": false,
+                      "items": null,
+                      "multi_value": null,
+                      "multiple": false,
+                      "name": "airgap_install",
+                      "props": null,
+                      "readonly": false,
+                      "recommended": false,
+                      "required": false,
+                      "test_proc": null,
+                      "title": "Airgap cluster",
+                      "type": "bool",
+                      "value": "0",
+                      "value_cmd": null,
+                      "when": ""
+                  },
+                  {
+                      "affix": "",
+                      "data_cmd": null,
+                      "default": "",
+                      "default_cmd": null,
+                      "filters": null,
+                      "help_text": "",
+                      "hidden": true,
+                      "is_excluded_from_support": false,
+                      "items": null,
+                      "multi_value": null,
+                      "multiple": false,
+                      "name": "docker_registry_address",
+                      "props": null,
+                      "readonly": false,
+                      "recommended": false,
+                      "required": false,
+                      "test_proc": null,
+                      "title": "Docker registry address",
+                      "type": "text",
+                      "value": "",
+                      "value_cmd": null,
+                      "when": "false"
+                  }
+              ],
+              "name": "cluster_info",
+              "test_proc": null,
+              "title": "Kubernetes cluster info",
+              "when": ""
+          }
+      ]

--- a/pkg/lifecycle/render/config/test-cases/api/data-references.yml
+++ b/pkg/lifecycle/render/config/test-cases/api/data-references.yml
@@ -1,6 +1,7 @@
 ##Alpha is a file, represented by a base64 encoded blob. Bravo references this and should receive the decoded value
 - name: Referencing file contents
-  input: {alpha: "dGVzdGluZ3Rlc3RpbmcxMjM="}
+  input:
+    - {alpha: "dGVzdGluZ3Rlc3RpbmcxMjM="}
   config:
     - name: alpha_group
       description: Alpha Group

--- a/pkg/lifecycle/render/config/test-cases/api/defaults.yml
+++ b/pkg/lifecycle/render/config/test-cases/api/defaults.yml
@@ -1,5 +1,6 @@
 - name: options with defaults and options with values
-  input: {}
+  input:
+    - {}
   config:
     - name: group_one
       items:

--- a/pkg/lifecycle/render/config/test-cases/api/failing/hidden-group.yml
+++ b/pkg/lifecycle/render/config/test-cases/api/failing/hidden-group.yml
@@ -3,7 +3,8 @@
 ## now visible
 
 - name: a when that defaults to false with select_one
-  input: {}
+  input:
+    - {}
   config:
     - name: external_service_enable
       title: Enable Some External Service

--- a/pkg/lifecycle/render/config/test-cases/api/failing/hidden-password.yaml
+++ b/pkg/lifecycle/render/config/test-cases/api/failing/hidden-password.yaml
@@ -1,5 +1,6 @@
 - name: more than one group, hidden password
-  input: {}
+  input:
+    - {}
   config:
     - name: alpha_group
       description: Alpha Group

--- a/pkg/lifecycle/render/config/test-cases/api/failing/simple-hidden-password.yml
+++ b/pkg/lifecycle/render/config/test-cases/api/failing/simple-hidden-password.yml
@@ -1,5 +1,6 @@
 - name: one group, hidden password
-  input: {}
+  input:
+    - {}
   config:
     - name: alpha_group
       description: Alpha Group

--- a/pkg/lifecycle/render/config/test-cases/api/hidden-default.yml
+++ b/pkg/lifecycle/render/config/test-cases/api/hidden-default.yml
@@ -1,5 +1,6 @@
 - name: hidden + default writes to value
-  input: {}
+  input:
+    - {}
   config:
     - name: maths
       items:
@@ -47,7 +48,8 @@
           ]
 
 - name: hidden + default writes to value, unless a prior item was set in the state
-  input: {}
+  input:
+    - {}
   state:
     two_plus_two: "100"
   config:

--- a/pkg/lifecycle/render/config/test-cases/api/nested-references-with-input.yml
+++ b/pkg/lifecycle/render/config/test-cases/api/nested-references-with-input.yml
@@ -3,7 +3,8 @@
 ## an input for alpha is provided
 
 - name: Refrencing hidden const templated config items with input
-  input: {alpha: "a test input"}
+  input:
+    - {alpha: "a test input"}
   config:
     - name: alpha_group
       description: Alpha Group

--- a/pkg/lifecycle/render/config/test-cases/api/simple-input.yml
+++ b/pkg/lifecycle/render/config/test-cases/api/simple-input.yml
@@ -1,5 +1,6 @@
 - name: one option, implied type, with input
-  input: {namespace: "abc123"}
+  input:
+    - {namespace: "abc123"}
   config:
     - name: Kubernetes Cluster
       items:

--- a/pkg/lifecycle/render/config/test-cases/api/simple.yml
+++ b/pkg/lifecycle/render/config/test-cases/api/simple.yml
@@ -1,5 +1,6 @@
 - name: one option, implied type
-  input: {}
+  input:
+    - {}
   config:
     - name: Kubernetes Cluster
       items:


### PR DESCRIPTION
### what was broken
Example YAML:

```yaml
  config:
    - name: cluster_info
      title: Kubernetes cluster info
      items:
      - name: airgap_install
        title: Airgap cluster
        type: bool
        value: '1'
      - name: docker_registry_address
        title: Docker registry address
        type: text
        when: '{{repl ConfigOptionEquals "airgap_install" "1" }}'
```

When the `airgap_install` box was unchecked, the `Docker Registry` field would not hide.
Upon closer investigation, it appears the `Docker Registry` field was always receiving `when: "true"`.

Turns out this was because the first time we went through the "use the builder to render all the templatable fields of the config item", we were doing that to a global copy of `*api.Release`, so the `when: true` persisted across ConfigLivePost calls, even though it should have been recomputed from the value of `airgap_install` on every LiveRender call.


### How I fixed it
- Changed APIResolver test cases to allow for multiple rounds of
  rendering
- Added a test that sends `airgap_install=1` followed by
  `airgap_install=0`, verified that this test fails to hide the field
  with `when: {{repl ConfigOptionEquals "airgap_install" "1"}}`
- Made that test pass by adding a `deepCopyConfig` at the top of
  `APIConfigResolver`