### PR TITLE
make makefile deps explicit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
     working_directory: /go/src/github.com/replicatedhq/ship
     steps:
       - checkout
-      - run: make build-deps citest ci-build-deps ci-upload-coverage
+      - run: make build-deps citest ci-upload-coverage
   test_yoonit:
     docker:
       - image: replicated/yoonit:latest

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ state.json
 .vscode
 installer/
 .ship/
-coverage.out
-coverage/
+
+.state/


### PR DESCRIPTION
we can make these make dependencies explicit, so why wouldn't we
also reduce clutter

What I Did
------------
1. moved all temporary files to `.state/`, which is gitignored (`coverage.out`, `cc-test-reporter`, and `codeclimate/codeclimate.json`)
2. made makefile steps depend on these files instead of on phony names that happened to create those files (or in some cases, there was no dependency at all)

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------
No external changes, internal only


Picture of a ~Boat~Ship (not required but encouraged)
------------

![image](https://user-images.githubusercontent.com/2318911/41428402-ddbb3820-6fbe-11e8-86bf-0984cbc6aeab.png)











<!-- (thanks https://github.com/linuxkit/linuxkit for this template) -->

