### PR TITLE
build an integration test image with unstable releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - checkout
       - run: make build-deps citest ci-upload-coverage
+
   test_yoonit:
     docker:
       - image: replicated/yoonit:latest
@@ -25,6 +26,15 @@ jobs:
       - run: git remote -v; echo $CIRCLE_REPOSITORY_URL
       # requires YOONIT_AUTH set to a valid token
       - run: /usr/local/bin/yoonit wait
+
+  integration:
+    docker:
+      - image: circleci/golang:1.10
+    working_directory: /go/src/github.com/replicatedhq/ship
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run: make integration-test
 
   deploy_unstable:
     docker:
@@ -39,14 +49,18 @@ jobs:
       - run: docker login -u="$DOCKERHUB_DOCKER_USER" -p="$DOCKERHUB_DOCKER_PASS"
       - deploy:
           command: docker push replicated/ship:unstable
-  integration:
+
+  deploy_integration:
     docker:
       - image: circleci/golang:1.10
     working_directory: /go/src/github.com/replicatedhq/ship
     steps:
       - checkout
       - setup_remote_docker
-      - run: make integration-test
+      - run: make build_ship_integration_test
+      - run: docker login -u="$DOCKERHUB_DOCKER_USER" -p="$DOCKERHUB_DOCKER_PASS"
+      - deploy:
+          command: docker push replicated/ship-e2e-test:latest
 
   deploy:
     docker:
@@ -70,6 +84,7 @@ workflows:
           filters:
             tags:
               only: /.*/
+
       - deploy_unstable:
           requires:
             - test
@@ -77,9 +92,19 @@ workflows:
           filters:
             branches:
               only: /master/
+
+      - deploy_integration:
+          requires:
+            - integration
+            - deploy_unstable
+          filters:
+            branches:
+              only: /master/
+
       - deploy:
           requires:
             - test
+            - integration
           filters:
             tags:
               only: /^v[0-9]+(\.[0-9]+)*(-.*)*/

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
-.PHONY: build-deps -dep-deps docker shell githooks dep fmt _vet vet _lint lint _test test build e2e run build_yoonit_docker_image _build citest ci-upload-coverage goreleaser integration-test
+.PHONY: build-deps -dep-deps docker shell githooks dep fmt _vet vet _lint lint _test test build e2e run build_yoonit_docker_image _build citest ci-upload-coverage goreleaser integration-test build_ship_integration_test
 
 
 SHELL := /bin/bash
 SRC = $(shell find . -name "*.go")
+
+DOCKER_REPO ?= replicated
 
 build-deps:
 	go get -u github.com/golang/lint/golint
@@ -174,3 +176,6 @@ run: bin/ship
 # this should really be in a different repo
 build_yoonit_docker_image:
 	docker build -t replicated/yoonit:latest -f deploy/Dockerfile-yoonit .
+
+build_ship_integration_test:
+	docker build -t $(DOCKER_REPO)/ship-e2e-test:latest -f ./integration/Dockerfile .

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -1,0 +1,15 @@
+# build the test
+FROM golang:1.10-alpine as build-step
+ENV GOPATH=/go/
+ADD . /go/src/github.com/replicatedhq/ship
+RUN cd /go/src/github.com/replicatedhq/ship && go test -c ./integration
+
+# package things up
+FROM alpine
+WORKDIR /test
+RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
+ADD ./integration /test
+RUN cd /test && rm *.go
+COPY --from=build-step /go/src/github.com/replicatedhq/ship/integration.test /test/
+ENTRYPOINT ./integration.test
+

--- a/integration/README.md
+++ b/integration/README.md
@@ -4,9 +4,23 @@
 make integration-test
 ```
 
+#Running the integration tests (from a docker image)
+
+The integration test docker image can be built with
+
+```shell
+make build_ship_integration_test
+```
+
+The resulting image can be run with
+
+```shell
+docker run -it -v /var/run/docker.sock:/var/run/docker.sock replicated/ship-e2e-test:latest
+```
+
 #Adding a new integration test
 
-Each integration test is a folder containing a text file with the 
+Each integration test is a folder containing a text file with the
 desired customer ID, installation ID, release version, a folder 'testfiles' containing
-`.ship/release.yml` and `.ship/state.yml`, and a folder 'expected' 
+`.ship/release.yml` and `.ship/state.yml`, and a folder 'expected'
 containing the expected output of running ship with that state file, customer ID and release.yml.


### PR DESCRIPTION
What I Did
------------
When making an unstable release, an integration test docker image will be created and released. This image can be run with `docker run -v /var/run/docker.sock:/var/run/docker.sock replicated/ship-e2e-test:latest`.

How I Did it
------------
A 2 stage docker image build - first stage makes a compiled test case with `docker test -c <package>` and the second is an alpine container with the test binary and external test files.

How to verify it
------------


Description for the Changelog
------------



Picture of a ~Boat~Ship (not required but encouraged)
------------
![image](https://user-images.githubusercontent.com/2318911/41558872-208501f0-72f7-11e8-8241-ce8305e9f59c.png)












<!-- (thanks https://github.com/linuxkit/linuxkit for this template) -->

