### PR TITLE
fix how saved state interacts with template functions

### DIFF
--- a/pkg/lifecycle/render/config/headless_daemon_test.go
+++ b/pkg/lifecycle/render/config/headless_daemon_test.go
@@ -380,7 +380,7 @@ func TestHeadlessDaemon(t *testing.T) {
 		},
 		{
 			Name:  "beta value resolves to alpha value",
-			State: []byte(`{"alpha": "100"}`),
+			State: []byte(`{"alpha": "101"}`),
 			Release: &api.Release{
 				Spec: api.Spec{
 					Config: api.Config{
@@ -399,14 +399,45 @@ func TestHeadlessDaemon(t *testing.T) {
 									Value:    `{{repl ConfigOption "alpha" }}`,
 									Default:  "",
 									Required: false,
-									Hidden:   true,
+									ReadOnly: true,
 								},
 							},
 						}},
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"alpha":"100","beta":"100"}`),
+			ExpectedValue: []byte(`{"alpha":"101","beta":"101"}`),
+			ExpectedError: false,
+		},
+		{
+			Name:  "beta value resolves to alpha value when wrong beta value is presented",
+			State: []byte(`{"alpha": "101", "beta":"abc"}`),
+			Release: &api.Release{
+				Spec: api.Spec{
+					Config: api.Config{
+						V1: []libyaml.ConfigGroup{{
+							Name: "testing",
+							Items: []*libyaml.ConfigItem{
+								{
+									Name:     "alpha",
+									Value:    "100",
+									Default:  "",
+									Required: false,
+									Hidden:   false,
+								},
+								{
+									Name:     "beta",
+									Value:    `{{repl ConfigOption "alpha" }}`,
+									Default:  "",
+									Required: false,
+									ReadOnly: true,
+								},
+							},
+						}},
+					},
+				},
+			},
+			ExpectedValue: []byte(`{"alpha":"101","beta":"101"}`),
 			ExpectedError: false,
 		},
 		{
@@ -430,14 +461,14 @@ func TestHeadlessDaemon(t *testing.T) {
 									Value:    `{{repl ConfigOption "alpha" }}`,
 									Default:  "",
 									Required: false,
-									Hidden:   true,
+									ReadOnly: true,
 								},
 								{
 									Name:     "charlie",
 									Value:    `{{repl ConfigOption "beta" }}`,
 									Default:  "",
 									Required: false,
-									Hidden:   true,
+									ReadOnly: true,
 								},
 							},
 						}},

--- a/pkg/lifecycle/render/config/test-cases/api/hidden-default.yml
+++ b/pkg/lifecycle/render/config/test-cases/api/hidden-default.yml
@@ -97,3 +97,83 @@
                   "when": ""
               }
           ]
+
+- name: hidden + default writes to value, unless a prior item was set in the state. Dependent template functions show correct value.
+  input:
+    - {}
+  state:
+    two_plus_two: "100"
+  config:
+    - name: maths
+      items:
+        - name: two_plus_two
+          title: two plus two
+          hidden: true
+          default: '{{repl Add 2 3}}'
+        - name: two_plus_two_plus_5
+          title: two plus two plus 5
+          readonly: true
+          value: '{{repl Add (ParseInt (ConfigOption "two_plus_two")) 5}}'
+
+  responses:
+    json: |
+      [
+              {
+                  "description": "",
+                  "filters": null,
+                  "items": [
+                      {
+                          "affix": "",
+                          "data_cmd": null,
+                          "default": "5",
+                          "default_cmd": null,
+                          "filters": null,
+                          "help_text": "",
+                          "hidden": true,
+                          "is_excluded_from_support": false,
+                          "items": null,
+                          "multi_value": null,
+                          "multiple": false,
+                          "name": "two_plus_two",
+                          "props": null,
+                          "readonly": false,
+                          "recommended": false,
+                          "required": false,
+                          "test_proc": null,
+                          "title": "two plus two",
+                          "type": "text",
+                          "value": "100",
+                          "value_cmd": null,
+                          "when": ""
+                      },
+                      {
+                          "affix": "",
+                          "data_cmd": null,
+                          "default": "",
+                          "default_cmd": null,
+                          "filters": null,
+                          "help_text": "",
+                          "hidden": false,
+                          "is_excluded_from_support": false,
+                          "items": null,
+                          "multi_value": null,
+                          "multiple": false,
+                          "name": "two_plus_two_plus_5",
+                          "props": null,
+                          "readonly": true,
+                          "recommended": false,
+                          "required": false,
+                          "test_proc": null,
+                          "title": "two plus two plus 5",
+                          "type": "text",
+                          "value": "105",
+                          "value_cmd": null,
+                          "when": ""
+                      }
+                  ],
+                  "name": "maths",
+                  "test_proc": null,
+                  "title": "",
+                  "when": ""
+              }
+          ]


### PR DESCRIPTION
What I Did
------------
Fix how saved state and template functions interact

How I Did it
------------
I changed how saved state was applied to override values, making it so that it only overrode values that were not read-only. Hidden values no longer qualify as read-only. (unless they have the readonly flag set)

How to verify it
------------
The included unit tests

Description for the Changelog
------------
Saved state will override editable fields but not read only config options. Read only options are those with the `readonly` flag set or that are not naturally editable, such as labels. Not all hidden config options are read only.


Picture of a ~Boat~Ship (not required but encouraged)
------------
![image](https://user-images.githubusercontent.com/2318911/41569656-95a04d54-7320-11e8-910b-643bc5a4b0fb.png)












<!-- (thanks https://github.com/linuxkit/linuxkit for this template) -->

