### PR TITLE
Add a docker image layers badge to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Ship
 
 [![Test Coverage](https://api.codeclimate.com/v1/badges/7e19355b20109fd50ada/test_coverage)](https://codeclimate.com/repos/5b217b8b536ddc029d005c48/test_coverage)
 [![Maintainability](https://api.codeclimate.com/v1/badges/7e19355b20109fd50ada/maintainability)](https://codeclimate.com/repos/5b217b8b536ddc029d005c48/maintainability)
-
+[![Docker Image](https://images.microbadger.com/badges/image/replicated/ship.svg)](https://microbadger.com/images/replicated/ship)
 
 Deploy 3rd-party applications using modern pipelines.
 


### PR DESCRIPTION
What I Did
------------
Added a badge showing docker image size and layers count to the readme.

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------
![image](https://user-images.githubusercontent.com/2318911/41683011-4fee2bd6-748e-11e8-8c98-27f99a1e8c37.png)












<!-- (thanks https://github.com/linuxkit/linuxkit for this template) -->

