### PR TITLE
dynamic UI thing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ _mockgen:
 mockgen: _mockgen fmt
 
 deps:
-	dep ensure -v; dep prune -v
+	dep ensure -v
 
 
 fmt:

--- a/pkg/lifecycle/render/config/daemon.go
+++ b/pkg/lifecycle/render/config/daemon.go
@@ -231,6 +231,24 @@ func (d *ShipDaemon) getCurrentStep(c *gin.Context) {
 		"currentStep": d.currentStep,
 		"phase":       d.currentStepName,
 	}
+
+	// a bit of a hack, we're migrating UI to
+	// render dynamic buttons
+	if d.currentStepName == "message" {
+		result["actions"] = []map[string]interface{}{
+			{
+				"buttonType":  "primary",
+				"text":        "Confirm",
+				"loadingText": "Confirming",
+				"onclick": map[string]string{
+					"uri":    "/message/confirm",
+					"method": "POST",
+					"body":   `{"step_name": "message"}`,
+				},
+			},
+		}
+	}
+
 	if d.stepProgress != nil {
 		result["progress"] = d.stepProgress
 	}


### PR DESCRIPTION
dynamic UI thing

What I Did
------------

Modify daemon `getCurrentStep` endpoint to send down `actions` in the payload. The frontend will use these as directives to render buttons. Goes with https://github.com/replicatedcom/replicated-onprem-ui/pull/37


How I Did it
------------

- kludge in a hack for now, just to get fe->api communication working again. Actions should have a static type not just a map.


How to verify it
------------

Ensure no regressions


Description for the Changelog
------------

Transparent refactoring of how `lifecycle.v1.message` steps are displayed and confirmed

![](https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/Bridge_of_the_RV_Sikuliaq.jpg/1200px-Bridge_of_the_RV_Sikuliaq.jpg)
