### PR TITLE
send progress while saving

### DIFF
--- a/examples/terraform/ship.yml
+++ b/examples/terraform/ship.yml
@@ -1,5 +1,9 @@
 assets:
   v1:
+    - docker:
+       image: postgres:8
+       dest: pg.tar
+       source: public
     - terraform:
         inline: |
           provider "google" {
@@ -67,6 +71,6 @@ lifecycle:
     - message:
        contents: "hi"
     - render: {}
-    - terraform: {}
+#    - terraform: {}
     - message:
        contents: "hi"

--- a/pkg/images/save.go
+++ b/pkg/images/save.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	"fmt"
+
 	"github.com/docker/docker/api/types"
 	docker "github.com/docker/docker/client"
 	"github.com/go-kit/kit/log"
@@ -108,6 +110,11 @@ func (s *CLISaver) saveImage(ctx context.Context, saveOpts SaveOpts, progressCh 
 	defer outFile.Close()
 
 	debug.Log("stage", "save")
+
+	progressCh <- Progress{
+		ID:     saveOpts.SaveURL,
+		Status: fmt.Sprintf("Saving %s", saveOpts.SaveURL),
+	}
 
 	imageReader, err := s.client.ImageSave(ctx, []string{saveOpts.SaveURL})
 	if err != nil {


### PR DESCRIPTION
What I Did
------------

- Send a progress message while running the `docker save` for docker assets


How I Did it
------------

- Send an `images.Project` object on `progressCh` in `lifecycle/render/docker` before we excute the save operation


How to verify it
------------

- run a spec with a `docker` asset, enjoy improved status messages


Description for the Changelog
------------

- Improve status messages in the Deployment Generator while saving `docker` assets


![](https://i.etsystatic.com/5897782/r/il/8e5b1d/358262914/il_fullxfull.358262914_b0c9.jpg)