### PR TITLE
exec terraform init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,18 @@ RUN curl -fsSLO "${HELM_URL}" \
     && mv "$HELM" "/usr/local/bin/helm-${HELM_VERSION}" \
     && ln -s "/usr/local/bin/helm-${HELM_VERSION}" /usr/local/bin/helm
 
+ENV TERRAFORM_VERSION=0.11.7
+ENV TERRAFORM_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
+ENV TERRAFORM_ZIP="terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
+ENV TERRAFORM_SHA256SUM=6b8ce67647a59b2a3f70199c304abca0ddec0e49fd060944c26f666298e23418
+
+RUN curl -fsSLO "$TERRAFORM_URL" \
+	&& echo "${TERRAFORM_SHA256SUM} ${TERRAFORM_ZIP}" | sha256sum -c - \
+	&& apt-get install -y unzip \
+	&& unzip "$TERRAFORM_ZIP" \
+	&& mv "terraform" "/usr/local/bin/terraform-${TERRAFORM_VERSION}" \
+	&& ln -s "/usr/local/bin/terraform-${TERRAFORM_VERSION}" /usr/local/bin/terraform
+
 ENV DEP_URL=https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64
 ENV DEP_BIN=dep-linux-amd64
 ENV DEP_SHA256SUM=31144e465e52ffbc0035248a10ddea61a09bf28b00784fd3fdd9882c8cbb2315

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -13,7 +13,20 @@ RUN curl -fsSLO "${HELM_URL}" \
     && echo "${HELM_SHA256SUM}  ${HELM_TGZ}" | sha256sum -c - \
     && tar xvf "$HELM_TGZ" \
     && mv "$HELM" "/usr/local/bin/helm-${HELM_VERSION}" \
-    && ln -s "/usr/local/bin/helm-${HELM_VERSION}" /usr/local/bin/helm
+    && ln -s "/usr/local/bin/helm-${HELM_VERSION}" /usr/local/bin/helm \
+    && rm "$HELM_TGZ"
+
+ENV TERRAFORM_VERSION=0.11.7
+ENV TERRAFORM_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
+ENV TERRAFORM_ZIP="terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
+ENV TERRAFORM_SHA256SUM=6b8ce67647a59b2a3f70199c304abca0ddec0e49fd060944c26f666298e23418
+
+RUN curl -fsSLO "${TERRAFORM_URL}" \
+	&& echo "${TERRAFORM_SHA256SUM}  ${TERRAFORM_ZIP}" | sha256sum -c - \
+	&& unzip "$TERRAFORM_ZIP" \
+	&& mv "terraform" "/usr/local/bin/terraform-${TERRAFORM_VERSION}" \
+	&& ln -s "/usr/local/bin/terraform-${TERRAFORM_VERSION}" /usr/local/bin/terraform \
+	&& rm "$TERRAFORM_ZIP"
 
 
 LABEL "com.replicated.ship"="true"

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -18,11 +18,23 @@ RUN curl -fsSLO "${HELM_URL}" \
     && mv "$HELM" "/usr/local/bin/helm-${HELM_VERSION}" \
     && cp "/usr/local/bin/helm-${HELM_VERSION}" /usr/local/bin/helm
 
+ENV TERRAFORM_VERSION=0.11.7
+ENV TERRAFORM_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
+ENV TERRAFORM_ZIP="terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
+ENV TERRAFORM_SHA256SUM=6b8ce67647a59b2a3f70199c304abca0ddec0e49fd060944c26f666298e23418
+
+RUN curl -fsSLO "$TERRAFORM_URL" \
+	&& echo "${TERRAFORM_SHA256SUM} ${TERRAFORM_ZIP}" | sha256sum -c - \
+	&& unzip "$TERRAFORM_ZIP" \
+	&& mv "terraform" "/usr/local/bin/terraform-${TERRAFORM_VERSION}" \
+	&& ln -s "/usr/local/bin/terraform-${TERRAFORM_VERSION}" /usr/local/bin/terraform
+
 # package things up
 FROM alpine
 WORKDIR /test
 
 COPY --from=build-step /usr/local/bin/helm /usr/local/bin/helm
+COPY --from=build-step /usr/local/bin/terraform /usr/local/bin/terraform
 RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 
 ADD ./integration /test

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -153,6 +153,7 @@ var _ = Describe("basic", func() {
 						fmt.Sprintf("--studio-channel-name=%s", testMetadata.StudioChannelName),
 						fmt.Sprintf("--release-semver=%s", testMetadata.ReleaseVersion),
 						"--log-level=off",
+						"--terraform-yes",
 					})
 					err := cmd.Execute()
 					Expect(err).NotTo(HaveOccurred())
@@ -176,6 +177,7 @@ var _ = Describe("basic", func() {
 						fmt.Sprintf("--customer-id=%s", testMetadata.CustomerID),
 						fmt.Sprintf("--installation-id=%s", testMetadata.InstallationID),
 						fmt.Sprintf("--release-semver=%s", testMetadata.ReleaseVersion),
+						"--terraform-yes",
 					}))
 					err := cmd.Execute()
 					Expect(err).NotTo(HaveOccurred())

--- a/integration/terraform/expected/.ship/release.yml
+++ b/integration/terraform/expected/.ship/release.yml
@@ -1,0 +1,42 @@
+assets:
+  v1:
+    - terraform:
+        inline: |
+          provider "google" {
+            project     = "{{repl ConfigOption "gce_project"}}"
+            region      = "{{repl ConfigOption "gce_region"}}"
+          }
+          
+          resource "google_compute_disk" "test-disk" {
+            name = "test-disk"
+            size = "1"
+            zone = "{{repl ConfigOption "gce_zone"}}"
+          }
+
+config:
+  v1:
+    - name: gce
+      items:
+         - name: gce_project
+           title: Google Cloud project name
+           type: text
+           required: true
+         - name: gce_region
+           title: Google Cloud compute region
+           type: text
+           default: us-central1
+           required: true
+         - name: gce_zone
+           title: Google Cloud compute zone
+           type: text
+           default: us-central1-a
+           required: true
+
+lifecycle:
+  v1:
+    - message:
+       contents: "hi"
+    - render: {}
+    - terraform: {}
+    - message:
+       contents: "bye"

--- a/integration/terraform/expected/.ship/state.json
+++ b/integration/terraform/expected/.ship/state.json
@@ -1,0 +1,1 @@
+{"v1":{"config":{"gce_project":"replicated-qa","gce_region":"us-central1","gce_zone":"us-central1-a"}}}

--- a/integration/terraform/input/.ship/release.yml
+++ b/integration/terraform/input/.ship/release.yml
@@ -1,0 +1,42 @@
+assets:
+  v1:
+    - terraform:
+        inline: |
+          provider "google" {
+            project     = "{{repl ConfigOption "gce_project"}}"
+            region      = "{{repl ConfigOption "gce_region"}}"
+          }
+          
+          resource "google_compute_disk" "test-disk" {
+            name = "test-disk"
+            size = "1"
+            zone = "{{repl ConfigOption "gce_zone"}}"
+          }
+
+config:
+  v1:
+    - name: gce
+      items:
+         - name: gce_project
+           title: Google Cloud project name
+           type: text
+           required: true
+         - name: gce_region
+           title: Google Cloud compute region
+           type: text
+           default: us-central1
+           required: true
+         - name: gce_zone
+           title: Google Cloud compute zone
+           type: text
+           default: us-central1-a
+           required: true
+
+lifecycle:
+  v1:
+    - message:
+       contents: "hi"
+    - render: {}
+    - terraform: {}
+    - message:
+       contents: "bye"

--- a/integration/terraform/input/.ship/state.json
+++ b/integration/terraform/input/.ship/state.json
@@ -1,0 +1,1 @@
+{"v1":{"config":{"gce_project":"replicated-qa","gce_region":"us-central1","gce_zone":"us-central1-a"}}}

--- a/integration/terraform/metadata.yaml
+++ b/integration/terraform/metadata.yaml
@@ -1,0 +1,3 @@
+customer_id: "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G"
+installation_id: "lZk73HnLmatQ-s1nk7l3Q3QKA45orDFi"
+release_version: "0.0.2-alpha"

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -56,6 +56,7 @@ application specs to be used in on-prem installations.
 	cmd.PersistentFlags().String("state-file", "", "path to the state file to read from, defaults to .ship/state.json")
 	cmd.PersistentFlags().String("studio-channel-name", "", "Useful for debugging your specs on the command line, without having to make round trips to the server")
 	cmd.PersistentFlags().String("studio-channel-icon", "", "Useful for debugging your specs on the command line, without having to make round trips to the server")
+	cmd.PersistentFlags().Bool("terraform-yes", false, "Automatically answer \"yes\" to all terraform prompts")
 
 	cmd.AddCommand(e2e.Cmd())
 	cmd.AddCommand(devtoolreleaser.Cmd())

--- a/pkg/lifecycle/terraform/terraformer.go
+++ b/pkg/lifecycle/terraform/terraformer.go
@@ -1,16 +1,21 @@
 package terraform
 
 import (
+	"bytes"
 	"context"
+	"os/exec"
+	"path/filepath"
 
 	"path"
 
 	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/lifecycle/daemon"
 	"github.com/replicatedhq/ship/pkg/lifecycle/terraform/tfplan"
 	"github.com/replicatedhq/ship/pkg/version"
+	"github.com/spf13/viper"
 )
 
 type Terraformer interface {
@@ -22,17 +27,24 @@ type ForkTerraformer struct {
 	Logger        log.Logger
 	Daemon        daemon.Daemon
 	PlanConfirmer tfplan.PlanConfirmer
+	Terraform     func() *exec.Cmd
+	Viper         *viper.Viper
 }
 
 func NewTerraformer(
 	logger log.Logger,
 	daemon daemon.Daemon,
 	planner tfplan.PlanConfirmer,
+	viper *viper.Viper,
 ) Terraformer {
 	return &ForkTerraformer{
 		Logger:        logger,
 		Daemon:        daemon,
 		PlanConfirmer: planner,
+		Terraform: func() *exec.Cmd {
+			return exec.Command("/usr/local/bin/terraform")
+		},
+		Viper: viper,
 	}
 }
 
@@ -45,7 +57,12 @@ func (t *ForkTerraformer) WithDaemon(daemon daemon.Daemon) Terraformer {
 
 func (t *ForkTerraformer) Execute(ctx context.Context, release api.Release, step api.Terraform) error {
 
-	assetsPath := path.Join("/tmp", "ship-terraform", version.RunAtEpoch, "asset")
+	assetsPath := filepath.Join("/tmp", "ship-terraform", version.RunAtEpoch, "asset")
+
+	if err := t.init(assetsPath); err != nil {
+		return errors.Wrapf(err, "init %s", assetsPath)
+	}
+
 	_, err := t.plan(assetsPath)
 	if err != nil {
 		return errors.Wrapf(err, "create plan for %s", assetsPath)
@@ -56,16 +73,39 @@ func (t *ForkTerraformer) Execute(ctx context.Context, release api.Release, step
 	// set progress applying
 
 	fakePlan := "We're gonna make you some servers"
-	shouldApply, err := t.PlanConfirmer.ConfirmPlan(ctx, fakePlan, release)
-	if err != nil {
-		return errors.Wrapf(err, "confirm plan for %s", assetsPath)
-	}
 
-	if !shouldApply {
-		return nil
+	if !viper.GetBool("terraform-yes") {
+		shouldApply, err := t.PlanConfirmer.ConfirmPlan(ctx, fakePlan, release)
+		if err != nil {
+			return errors.Wrapf(err, "confirm plan for %s", assetsPath)
+		}
+
+		if !shouldApply {
+			return nil
+		}
 	}
 
 	// next: apply plan
+	return nil
+}
+
+func (t *ForkTerraformer) init(assetsPath string) error {
+	debug := level.Debug(log.With(t.Logger, "step.type", "terraform", "terraform.phase", "init"))
+
+	cmd := t.Terraform()
+	cmd.Args = append(cmd.Args, "init", "-input=false")
+	cmd.Dir = assetsPath
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	out, err := cmd.Output()
+	debug.Log("stdout", string(out))
+	debug.Log("stderr", stderr.String())
+	if err != nil {
+		return errors.Wrap(err, "exec terraform init")
+	}
+
 	return nil
 }
 

--- a/pkg/lifecycle/terraform/terraformer_test.go
+++ b/pkg/lifecycle/terraform/terraformer_test.go
@@ -2,6 +2,11 @@ package terraform
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -9,19 +14,30 @@ import (
 	"github.com/replicatedhq/ship/pkg/test-mocks/daemon"
 	mocktf "github.com/replicatedhq/ship/pkg/test-mocks/tfplan"
 	"github.com/replicatedhq/ship/pkg/testing/logger"
+	"github.com/replicatedhq/ship/pkg/version"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTerraformer(t *testing.T) {
 	tests := []struct {
-		name string
+		name          string
+		terraformFail bool
 	}{
 		{
 			name: "zero",
 		},
+		{
+			name:          "one",
+			terraformFail: true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			//req := require.New(t)
+			d := filepath.Join("/tmp", "ship-terraform", version.RunAtEpoch, "asset")
+			if err := os.MkdirAll(d, 0755); err != nil {
+				t.Fatal(err)
+			}
+			req := require.New(t)
 			mc := gomock.NewController(t)
 			mockDaemon := daemon.NewMockDaemon(mc)
 			mockPlanner := mocktf.NewMockPlanConfirmer(mc)
@@ -29,6 +45,25 @@ func TestTerraformer(t *testing.T) {
 				Logger:        &logger.TestLogger{T: t},
 				Daemon:        mockDaemon,
 				PlanConfirmer: mockPlanner,
+				Terraform: func() *exec.Cmd {
+					cmd := exec.Command(os.Args[0], "-test.run=TestMockTerraform")
+					cmd.Env = append(os.Environ(), "GOTEST_SUBPROCESS_MOCK=1")
+					if test.terraformFail {
+						cmd.Env = append(cmd.Env, "CRASHING_TERRAFORM_ERROR=1")
+					}
+					return cmd
+				},
+			}
+
+			if test.terraformFail {
+				err := tf.Execute(
+					context.Background(),
+					api.Release{},
+					api.Terraform{},
+				)
+				req.Error(err)
+				mc.Finish()
+				return
 			}
 
 			mockPlanner.
@@ -36,14 +71,30 @@ func TestTerraformer(t *testing.T) {
 				ConfirmPlan(gomock.Any(), "We're gonna make you some servers", gomock.Any()).
 				Return(false, nil)
 
-			//err := tf.Execute(
-			tf.Execute(
+			err := tf.Execute(
 				context.Background(),
 				api.Release{},
 				api.Terraform{},
 			)
-			//req.NoError(err)
+			req.NoError(err)
 			mc.Finish()
 		})
+	}
+}
+
+func TestMockTerraform(t *testing.T) {
+	if os.Getenv("GOTEST_SUBPROCESS_MOCK") == "" {
+		return
+	}
+
+	if os.Getenv("CRASHING_TERRAFORM_ERROR") != "" {
+		fmt.Fprintf(os.Stderr, os.Getenv("CRASHING_TERRAFORM_ERROR"))
+		os.Exit(1)
+	}
+
+	receivedArgs := os.Args[2:]
+	expectInit := []string{"init", "-input=false"}
+	if reflect.DeepEqual(receivedArgs, expectInit) {
+		os.Exit(0)
 	}
 }


### PR DESCRIPTION
terraform integration test

What I Did
------------
Terraform init a terraform asset

How I Did it
------------
Fork out to the terraform command in the directory where the terraform asset has been saved.
Include the terraform command in all images.
Added a `--yes` flag to bypass the plan confirm prompt for integration tests.

How to verify it
------------
Run the integration tests, then check for `/tmp/ship-terraform/{epoch}/assets/.terraform`

Description for the Changelog
------------
The terraform lifecycle step runs `terraform init` on an inline terraform asset.



Picture of a Boat (not required but encouraged)
------------












<!-- (thanks https://github.com/linuxkit/linuxkit for this template) -->

