### PR TITLE
Use a unique temp directory for terraform

### DIFF
--- a/pkg/lifecycle/terraform/terraformer_test.go
+++ b/pkg/lifecycle/terraform/terraformer_test.go
@@ -70,6 +70,11 @@ func TestTerraformer(t *testing.T) {
 			if err := os.MkdirAll(d, 0755); err != nil {
 				t.Fatal(err)
 			}
+			f, err := os.Create(filepath.Join(d, "main.tf"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			f.Close()
 			req := require.New(t)
 			mc := gomock.NewController(t)
 			mockDaemon := daemon.NewMockDaemon(mc)
@@ -107,7 +112,7 @@ func TestTerraformer(t *testing.T) {
 					Return(false, nil)
 			}
 
-			err := tf.Execute(
+			err = tf.Execute(
 				context.Background(),
 				api.Release{},
 				api.Terraform{},


### PR DESCRIPTION
Integration test flakiness was from using a tmp directory based on
epoch. The stuio and remote test runs could be attempting to run
terraform init and terraform plan simultaneously in the same directory.

What I Did
------------
Unique tmp directory for terraform.

How I Did it
------------
ioutil.TempDir

How to verify it
------------
Run the integration tests repeatedly without flake

Description for the Changelog
------------
Terraform runs in a unique temporary workspace.


Picture of a Boat (not required but encouraged)
------------












<!-- (thanks https://github.com/linuxkit/linuxkit for this template) -->

