### PR TITLE
initial scaffolding (sic) for kustomize lifecycle step

### DIFF
--- a/examples/kustomize/ship.yml
+++ b/examples/kustomize/ship.yml
@@ -1,0 +1,29 @@
+assets:
+  v1:
+    - inline:
+         dest: jasper_values.yaml
+         contents: |
+           two_plus_two: {{repl Add 2 3}}
+           service_type: {{repl ConfigOption "service_type"}}
+    - helm:
+        dest: charts
+        github:
+          repo: kubernetes/charts
+          path: stable/jasperreports
+          ref: fd35ab34bfd26878fb5970fbc7c3e75760df10ec
+          source: public
+        helm_opts:
+          - --values
+          - installer/jasper_values.yaml
+
+
+config:
+  v1: []
+
+lifecycle:
+  v1:
+    - message:
+       contents: "hi"
+    - render: {}
+    - kustomize:
+        base_path: charts/templates/

--- a/pkg/api/lifecycle.go
+++ b/pkg/api/lifecycle.go
@@ -10,6 +10,7 @@ type Step struct {
 	Message   *Message   `json:"message,omitempty" yaml:"message,omitempty" hcl:"message,omitempty"`
 	Render    *Render    `json:"render,omitempty" yaml:"render,omitempty" hcl:"render,omitempty"`
 	Terraform *Terraform `json:"terraform,omitempty" yaml:"terraform,omitempty" hcl:"terraform,omitempty"`
+	Kustomize *Kustomize `json:"kustomize,omitempty" yaml:"kustomize,omitempty" hcl:"kustomize,omitempty"`
 }
 
 // Message is a lifeycle step to print a message
@@ -24,4 +25,10 @@ type Render struct {
 
 // Terraform is a lifeycle step to execute `apply` for a runbook's terraform asset
 type Terraform struct {
+}
+
+// Kustomize is a lifeycle step to generate overlays for generated assets.
+// It does not take a kustomization.yml, rather it will generate one in the .ship/ folder
+type Kustomize struct {
+	BasePath string `json:"base_path,omitempty" yaml:"base_path,omitempty" hcl:"base_path,omitempty"`
 }

--- a/pkg/api/lifecycle_test.go
+++ b/pkg/api/lifecycle_test.go
@@ -54,6 +54,22 @@ lifecycle:
 				Terraform: &Terraform{},
 			},
 		},
+		{
+			name: "kustomize",
+
+			yaml: `
+---
+lifecycle:
+  v1:
+    - kustomize: 
+         base_path: "k8s/"`,
+
+			expect: Step{
+				Kustomize: &Kustomize{
+					BasePath: "k8s/",
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/lifecycle/kustomize/kustomizer.go
+++ b/pkg/lifecycle/kustomize/kustomizer.go
@@ -1,0 +1,30 @@
+package kustomize
+
+import (
+	"context"
+
+	"github.com/replicatedhq/ship/pkg/api"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon"
+)
+
+type Kustomizer interface {
+	Execute(ctx context.Context, release api.Release, step api.Kustomize) error
+}
+
+func NewKustomizer(daemon daemon.Daemon) Kustomizer {
+	return &kustomizer{
+		Daemon: daemon,
+	}
+
+}
+
+// kustomizer will *try* to pull in the Kustomizer libs from kubernetes-sigs/kustomize,
+// if not we'll have to fork. for now it just explodes
+type kustomizer struct {
+	Daemon daemon.Daemon
+}
+
+func (l *kustomizer) Execute(ctx context.Context, release api.Release, step api.Kustomize) error {
+	panic("I'm not implemented yet!")
+}
+

--- a/pkg/lifecycle/step.go
+++ b/pkg/lifecycle/step.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/lifecycle/daemon"
+	"github.com/replicatedhq/ship/pkg/lifecycle/kustomize"
 	"github.com/replicatedhq/ship/pkg/lifecycle/message"
 	"github.com/replicatedhq/ship/pkg/lifecycle/render"
 	"github.com/replicatedhq/ship/pkg/lifecycle/terraform"
@@ -22,6 +23,7 @@ type StepExecutor struct {
 	Messenger   message.Messenger
 	Terraformer terraform.Terraformer
 	Daemon      daemon.Daemon
+	Kustomizer  kustomize.Kustomizer
 }
 
 func (s *StepExecutor) Execute(ctx context.Context, release *api.Release, step *api.Step) error {
@@ -42,6 +44,11 @@ func (s *StepExecutor) Execute(ctx context.Context, release *api.Release, step *
 		err := s.Terraformer.Execute(ctx, *release, *step.Terraform)
 		debug.Log("event", "step.complete", "type", "terraform", "err", err)
 		return errors.Wrap(err, "execute terraform step")
+	} else if step.Kustomize != nil {
+		debug.Log("event", "step.resolve", "type", "kustomize")
+		err := s.Kustomizer.Execute(ctx, *release, *step.Kustomize)
+		debug.Log("event", "step.complete", "type", "kustomize", "err", err)
+		return errors.Wrap(err, "execute kustomize step")
 	}
 
 	debug.Log("event", "step.unknown")

--- a/pkg/lifecycle/terraform/terraformer.go
+++ b/pkg/lifecycle/terraform/terraformer.go
@@ -24,7 +24,6 @@ const tfNoChanges = "No changes. Infrastructure is up-to-date."
 
 type Terraformer interface {
 	Execute(ctx context.Context, release api.Release, step api.Terraform) error
-	WithDaemon(d daemon.Daemon) Terraformer
 }
 
 type ForkTerraformer struct {
@@ -49,13 +48,6 @@ func NewTerraformer(
 			return exec.Command("/usr/local/bin/terraform")
 		},
 		Viper: viper,
-	}
-}
-
-func (t *ForkTerraformer) WithDaemon(daemon daemon.Daemon) Terraformer {
-	return &ForkTerraformer{
-		Logger: t.Logger,
-		Daemon: daemon,
 	}
 }
 

--- a/pkg/ship/dig.go
+++ b/pkg/ship/dig.go
@@ -11,6 +11,7 @@ import (
 	"github.com/replicatedhq/ship/pkg/images"
 	"github.com/replicatedhq/ship/pkg/lifecycle"
 	"github.com/replicatedhq/ship/pkg/lifecycle/daemon"
+	"github.com/replicatedhq/ship/pkg/lifecycle/kustomize"
 	"github.com/replicatedhq/ship/pkg/lifecycle/message"
 	"github.com/replicatedhq/ship/pkg/lifecycle/render"
 	"github.com/replicatedhq/ship/pkg/lifecycle/render/config"
@@ -50,6 +51,7 @@ func buildInjector() (*dig.Container, error) {
 		config.NewResolver,
 		resolve.NewRenderer,
 		terraform2.NewTerraformer,
+		kustomize.NewKustomizer,
 		tfplan.NewPlanner,
 
 		state.NewManager,


### PR DESCRIPTION
What I Did
------------

Add YAML type for kustomize lifeycle step. The kustomize step will take
a base path for the K8s YAMLs being kustomized.

How I Did it
------------

Add types and a test to `pkg/api/`, add an `if` block that explodes,
but will eventualy do stuff.


How to verify it
------------

Run example in `examples/kustomize`, ensure it gets to the kustomize LC step before blowing up (can check `--log-level=debug` to confirm)


Description for the Changelog
------------

Add Kustomize Step to lifecycle types (still unimplemented, real changelog will have actual description)


![](https://static1.squarespace.com/static/5849ccb2ff7c5026f7bdc110/t/590a2ee9db29d60889f81b7b/1493839705759/Jess+Kaelblein+4671.JPG?format=750w)










<!-- (thanks https://github.com/linuxkit/linuxkit for this template) -->