### PR TITLE
Update kustomize.go

### DIFF
--- a/pkg/cli/kustomize.go
+++ b/pkg/cli/kustomize.go
@@ -16,7 +16,9 @@ func Kustomize() *cobra.Command {
 		Long: `Build and deploy kustomize configured helm charts to be integrated
 with a git ops style workflow.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			viper.Set("chart", args[0])
+			if len(args) != 0 {
+				viper.Set("chart", args[0])
+			}
 			s, err := ship.Get()
 			if err != nil {
 				return err


### PR DESCRIPTION
What I Did
------------
fix panic in kustomize.go with no chart path

How I Did it
------------

put a band-aid on it with `if`, we need something a little more flexible in the future

How to verify it
------------

run `ship kustomize --raw xxx` (i.e. without a positional arg), ensure no panic

Description for the Changelog
------------

Fix panic when using `--raw` flag without a chart


![](https://78.media.tumblr.com/tumblr_lvas278AIX1qabnl2.jpg)