### PR TITLE
kustomize support for state

### DIFF
--- a/pkg/api/lifecycle.go
+++ b/pkg/api/lifecycle.go
@@ -29,7 +29,7 @@ type Render struct {
 type Terraform struct {
 }
 
-// Kustomize is a lifeycle step to generate overlays for generated assets.
+// CurrentKustomize is a lifeycle step to generate overlays for generated assets.
 // It does not take a kustomization.yml, rather it will generate one in the .ship/ folder
 type Kustomize struct {
 	BasePath string `json:"base_path,omitempty" yaml:"base_path,omitempty" hcl:"base_path,omitempty"`

--- a/pkg/state/models.go
+++ b/pkg/state/models.go
@@ -1,0 +1,51 @@
+package state
+
+type State interface {
+	CurrentConfig() map[string]interface{}
+	CurrentKustomize() *Kustomize
+}
+
+var _ State = VersionedState{}
+var _ State = empty{}
+var _ State = V0{}
+
+type empty struct{}
+
+func (empty) CurrentKustomize() *Kustomize          { return nil }
+func (empty) CurrentConfig() map[string]interface{} { return make(map[string]interface{}) }
+
+type V0 map[string]interface{}
+
+func (v V0) CurrentConfig() map[string]interface{} { return v }
+func (v V0) CurrentKustomize() *Kustomize          { return nil }
+
+type VersionedState struct {
+	V1 *V1 `json:"v1,omitempty" yaml:"v1,omitempty" hcl:"v1,omitempty"`
+}
+
+type V1 struct {
+	Config     map[string]interface{} `json:"config" yaml:"config" hcl:"config"`
+	Terraform  interface{}            `json:"terraform,omitempty" yaml:"terraform,omitempty" hcl:"terraform,omitempty"`
+	HelmValues string                 `json:"helmValues,omitempty" yaml:"helmValues,omitempty" hcl:"helmValues,omitempty"`
+	Kustomize  *Kustomize             `json:"kustomize,omitempty" yaml:"kustomize,omitempty" hcl:"kustomize,omitempty"`
+}
+
+type Overlay struct {
+	Files             map[string]string `json:"files,omitempty" yaml:"files,omitempty" hcl:"files,omitempty"`
+	KustomizationYAML string            `json:"kustomization_yaml,omitempty" yaml:"kustomization_yaml,omitempty" hcl:"kustomization_yaml,omitempty"`
+}
+
+type Kustomize struct {
+	Overlays map[string]Overlay `json:"overlays,omitempty" yaml:"overlays,omitempty" hcl:"overlays,omitempty"`
+}
+
+func (u VersionedState) CurrentKustomize() *Kustomize {
+	return u.V1.Kustomize
+}
+
+func (u VersionedState) CurrentConfig() map[string]interface{} {
+	if u.V1 != nil && u.V1.Config != nil {
+		return u.V1.Config
+	}
+	return make(map[string]interface{})
+}


### PR DESCRIPTION
What I Did
------------

Add Kustomize support to state types

How I Did it
------------

- add `Kustomize` to `state.V1`, with overlays and config yaml fields
- add `CurrentKustomize` to `state.State` interface, implement on implementation

Other stuff

- rename `state/serialize.go` to `state/manager.go`
- move a few `state` things out of `serialize.go` into `models.go`

How to verify it
------------

make sure it still works

Description for the Changelog
------------

none