### PR TITLE
accept overlay contents

### DIFF
--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -102,3 +102,22 @@ func (s *Manager) TryLoad() (State, error) {
 	level.Debug(s.Logger).Log("event", "state.resolve", "type", "raw")
 	return V0(mapState), nil
 }
+func (m *Manager) SaveKustomize(kustomize *Kustomize) error {
+	state, err := m.TryLoad()
+	if err != nil {
+		return errors.Wrapf(err, "load state")
+	}
+
+	newState := VersionedState{
+		V1: &V1{
+			Config:    state.CurrentConfig(),
+			Kustomize: kustomize,
+		},
+	}
+
+	if err := m.serializeAndWriteState(newState); err != nil {
+		return errors.Wrap(err, "write state")
+	}
+
+	return nil
+}


### PR DESCRIPTION
What I Did
------------

Implement /kustomize/save endpoint to store overlay contents to state.

TODO still:

- return overlays to client
- probably some tests
- apply overlay state to file tree object we send to client

How I Did it
------------

- Add state.Manager#SaveKustomize()

How to verify it
------------

1. run `ship init` with `--raw`
1. `curl -v -X POST --data-binary '{"path": "k8s/service.yml", "contents": "lololol"}' localhost:8880/api/v1/kustomize/save`
1. `cat .ship/state.json` and see overlay in state

Description for the Changelog
------------

none, wip feature

![](https://www.nrcc.org/wp-content/uploads/2014/03/sinking-ship.jpg)