### PR TITLE
Fix CircleCI badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Ship
 
 [![Test Coverage](https://api.codeclimate.com/v1/badges/7e19355b20109fd50ada/test_coverage)](https://codeclimate.com/repos/5b217b8b536ddc029d005c48/test_coverage)
 [![Maintainability](https://api.codeclimate.com/v1/badges/7e19355b20109fd50ada/maintainability)](https://codeclimate.com/repos/5b217b8b536ddc029d005c48/maintainability)
-[![CircleCI](https://circleci.com/gh/replicatedhq/ship.svg?style=svg)](https://circleci.com/gh/replicatedhq/ship)
+[![CircleCI](https://circleci.com/gh/replicatedhq/ship.svg?style=svg&circle-token=471765bf5ec85ede48fcf02ea6a886dc6c5a73f1)](https://circleci.com/gh/replicatedhq/ship)
 [![Docker Image](https://images.microbadger.com/badges/image/replicated/ship.svg)](https://microbadger.com/images/replicated/ship)
 
 


### PR DESCRIPTION
What I Did
------------
Added a status-only api token to the CircleCI badge so it can be seen before the project is public

How I Did it
------------


How to verify it
------------
Look at the rich diff

Description for the Changelog
------------
None


Picture of a Boat (not required but encouraged)
------------
![image](https://user-images.githubusercontent.com/2318911/43347001-721906a4-91a8-11e8-939e-308199b8f522.png)












<!-- (thanks https://github.com/linuxkit/linuxkit for this template) -->

