### PR TITLE
Use GitHub archive link instead of file walking to prevent rate limit

### DIFF
--- a/pkg/specs/chart.go
+++ b/pkg/specs/chart.go
@@ -1,12 +1,13 @@
 package specs
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -68,69 +69,68 @@ func (g *GithubClient) GetChartAndReadmeContents(ctx context.Context, chartURLSt
 		}
 	}
 
-	return g.getAllFiles(ctx, owner, repo, path, "/")
+	return g.downloadAndExtractFiles(ctx, owner, repo, path, "/")
 }
 
-func (g *GithubClient) getAllFiles(ctx context.Context, owner string, repo string, basePath string, filePath string) error {
-	debug := level.Debug(log.With(g.logger, "method", "getAllFiles"))
+func (g *GithubClient) downloadAndExtractFiles(ctx context.Context, owner string, repo string, basePath string, filePath string) error {
+	debug := level.Debug(log.With(g.logger, "method", "downloadAndExtractFiles"))
 
 	debug.Log("event", "getContents", "path", basePath)
-	_, dirContent, _, err := g.client.Repositories.GetContents(ctx, owner, repo, basePath, &github.RepositoryContentGetOptions{})
+
+	url, _, err := g.client.Repositories.GetArchiveLink(ctx, owner, repo, github.Tarball, &github.RepositoryContentGetOptions{})
 	if err != nil {
-		return errors.Wrapf(err, "initial get contents of owner - %s repo - %s", owner, repo)
+		return errors.Wrapf(err, "get archive link for owner - %s repo - %s", owner, repo)
 	}
 
-	for _, gitContent := range dirContent {
-		if gitContent.GetType() == "file" {
-			debug.Log("event", "git.download", "file", gitContent.GetName())
-			savePath := filepath.Join(constants.KustomizeHelmPath, filePath)
-			downloadURL := gitContent.GetDownloadURL()
-			err := g.downloadFile(savePath, gitContent.GetName(), downloadURL)
-			if err != nil {
-				return errors.Wrapf(err, "download file %q", gitContent.GetName())
-			}
-		}
-		if gitContent.GetType() == "dir" {
-			debug.Log("event", "git.getAllFiles", "dir", gitContent.GetName())
-			newBase := path.Join(basePath, gitContent.GetName())
-			newFilePath := path.Join(filePath, gitContent.GetName())
-			err := g.getAllFiles(ctx, owner, repo, newBase, newFilePath)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-func (g *GithubClient) downloadFile(path string, saveName string, url string) error {
-	debug := level.Debug(log.With(g.logger, "method", "downloadFile"))
-
-	debug.Log("event", "mkdir", "path", path)
-	err := g.fs.MkdirAll(path, 0700)
+	resp, err := http.Get(url.String())
 	if err != nil {
-		return err
-	}
-
-	debug.Log("event", "download", "url", url)
-	resp, err := http.Get(url)
-	if err != nil {
-		return err
+		return errors.Wrapf(err, "downloading archive")
 	}
 	defer resp.Body.Close()
 
-	debug.Log("event", "read.resp")
-	bytes, err := ioutil.ReadAll(resp.Body)
+	uncompressedStream, err := gzip.NewReader(resp.Body)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "create uncompressed stream")
 	}
 
-	debug.Log("event", "write.file", "path", path)
-	fullPath := filepath.Join(path, saveName)
-	err = g.fs.WriteFile(fullPath, bytes, 0644)
-	if err != nil {
-		return err
+	tarReader := tar.NewReader(uncompressedStream)
+
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return errors.Wrapf(err, "extract tar gz, next()")
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			dirName := strings.Join(strings.Split(header.Name, "/")[1:], "/")
+			if !strings.HasPrefix(dirName, basePath) {
+				continue
+			}
+
+			dirName = strings.TrimPrefix(dirName, basePath)
+			if err := g.fs.MkdirAll(filepath.Join(constants.KustomizeHelmPath, filePath, dirName), 0755); err != nil {
+				return errors.Wrapf(err, "extract tar gz, mkdir")
+			}
+		case tar.TypeReg:
+			fileName := strings.Join(strings.Split(header.Name, "/")[1:], "/")
+			if !strings.HasPrefix(fileName, basePath) {
+				continue
+			}
+			fileName = strings.TrimPrefix(fileName, basePath)
+			outFile, err := g.fs.Create(filepath.Join(constants.KustomizeHelmPath, filePath, fileName))
+			if err != nil {
+				return errors.Wrapf(err, "extract tar gz, create")
+			}
+			defer outFile.Close()
+			if _, err := io.Copy(outFile, tarReader); err != nil {
+				return errors.Wrapf(err, "extract tar gz, copy")
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
What I Did
------------
Changed the GitHub client used to download a Helm chart to use the GitHub "Get Archive" link instead of walking the file tree and downloading each file.

Some charts contain enough files that we were hitting the unauthenticated GitHub rate limits while downloading files individually. The trade off with this approach is that larger repos that contain files that are not part of the chart will be downloaded and then discarded. This doesn't have a noticeable impact on performance, and the implementation here continues to extract only the relevant parts of the Chart.

How I Did it
------------
Replaced the GitHub API calls with a single method that gets the archive link and downloads and extracts it. This will now be fixed number of API calls and will work on any repo.

How to verify it
------------
ship init github.com/sourcegraph/deploy-sourcegraph contains too many files and failed before. This method works. Also continues to work for the github.com/helm/charts repo.

Also: run the tests. They are updated to mock and test this method.

Description for the Changelog
------------
Changed the API methods used to download Helm charts from GitHub to lower the request count, and be compatible with charts that contain many files.


Picture of a Boat (not required but encouraged)
------------

![tray2_full](https://user-images.githubusercontent.com/173451/43359020-4c9de496-9250-11e8-9f86-439afb57d95f.jpg)











<!-- (thanks https://github.com/linuxkit/linuxkit for this template) -->

