### PR TITLE
Create app subcommand, rename kustomize command to init

### DIFF
--- a/integration/kustomize/integration_test.go
+++ b/integration/kustomize/integration_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/docker/docker/client"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/replicatedhq/ship/integration"
 	"github.com/replicatedhq/ship/pkg/cli"
 	"gopkg.in/yaml.v2"
-	"github.com/replicatedhq/ship/integration"
 )
 
 type TestMetadata struct {
@@ -28,7 +28,6 @@ func TestKustomize(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "integration")
 }
-
 
 var _ = Describe("basic", func() {
 	dockerClient, err := client.NewEnvClient()
@@ -74,8 +73,8 @@ var _ = Describe("basic", func() {
 					os.Chdir(integrationDir)
 				}, 20)
 
-				It("Should output files matching those expected when running in kustomize mode", func() {
-					cmd := cli.Kustomize()
+				It("Should output files matching those expected when running in init mode", func() {
+					cmd := cli.Init()
 					buf := new(bytes.Buffer)
 					cmd.SetOutput(buf)
 					args := []string{

--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"context"
+	"strings"
+
+	"github.com/replicatedhq/ship/pkg/ship"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func App() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "app",
+		Short: "Download and configure a licensed third party application",
+		Long:  `Download and configure a third party application using a supplied customer id.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ship.RunE(context.Background())
+		},
+	}
+
+	// required
+	cmd.Flags().String("customer-id", "", "Customer ID for which to query app specs. Required for all ship operations.")
+	cmd.Flags().StringP("installation-id", "i", "", "Installation ID for which to query app specs")
+
+	// optional
+	cmd.Flags().String("channel-id", "", "ship channel to install from")
+	cmd.Flags().StringP("customer-endpoint", "e", "https://pg.replicated.com/graphql", "Upstream application spec server address")
+	cmd.Flags().String("release-id", "", "specific Release ID to pin installation to.")
+	cmd.Flags().String("release-semver", "", "specific release version to pin installation to. Requires channel-id")
+	cmd.Flags().Bool("terraform-yes", false, "Automatically answer \"yes\" to all terraform prompts")
+
+	// optional, devloper-tools
+	cmd.Flags().String("studio-file", "", "Useful for debugging your specs on the command line, without having to make round trips to the server")
+	cmd.Flags().String("studio-channel-name", "", "Useful for debugging your specs on the command line, without having to make round trips to the server")
+	cmd.Flags().String("studio-channel-icon", "", "Useful for debugging your specs on the command line, without having to make round trips to the server")
+
+	viper.BindPFlags(cmd.Flags())
+	viper.AutomaticEnv()
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	return cmd
+}

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -13,13 +13,12 @@ import (
 	"github.com/spf13/viper"
 )
 
-func Kustomize() *cobra.Command {
+func Init() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "kustomize [CHART]",
-		Aliases: []string{"init"},
-		Short:   "Build and deploy kustomize configured helm charts",
+		Use:   "init [CHART]",
+		Short: "Build and deploy kustomize configured helm charts",
 		Long: `Build and deploy kustomize configured helm charts to be integrated
-with a git ops style workflow.`,
+with a gitops style workflow.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 0 {
 				viper.Set("chart", args[0])

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -6,11 +6,7 @@ import (
 
 	"strings"
 
-	"context"
-
-	"github.com/replicatedhq/ship/pkg/cli/devtoolreleaser"
 	"github.com/replicatedhq/ship/pkg/e2e"
-	"github.com/replicatedhq/ship/pkg/ship"
 	"github.com/replicatedhq/ship/pkg/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -23,45 +19,31 @@ func RootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ship",
 		Short: "manage and serve on-prem ship data",
-		Long: `ship allows for managing and securely delivering
-application specs to be used in on-prem installations.
-`,
+		Long:  `ship allows for configuring and updating third party application in modern pipelines (gitops).`,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			version.Init()
 		},
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return ship.RunE(context.Background())
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+			os.Exit(1)
 		},
 	}
 	cobra.OnInitialize(initConfig)
 
 	cmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is /etc/replicated/ship.yaml)")
 	cmd.PersistentFlags().String("log-level", "off", "Log level")
-	cmd.PersistentFlags().StringP("customer-endpoint", "e", "https://pg.replicated.com/graphql", "Upstream application spec server address")
-
-	// required
-	cmd.PersistentFlags().String("customer-id", "", "Customer ID for which to query app specs. Required for all ship operations.")
 
 	// optional
-	cmd.PersistentFlags().String("release-id", "", "specific Release ID to pin installation to.")
-	cmd.PersistentFlags().String("release-semver", "", "specific release version to pin installation to. Requires channel-id")
-	cmd.PersistentFlags().String("channel-id", "", "ship channel to install from")
-	cmd.PersistentFlags().StringP("installation-id", "i", "", "Installation ID for which to query app specs")
 	cmd.PersistentFlags().IntP("api-port", "p", 8880, "port to start the API server on.")
-	cmd.PersistentFlags().Bool("ship-compose-ui", false, "using UI in docker-compose")
 	cmd.PersistentFlags().BoolP("headless", "", false, "run ship in headless mode")
 
-	cmd.PersistentFlags().String("studio-file", "", "Useful for debugging your specs on the command line, without having to make round trips to the server")
 	cmd.PersistentFlags().String("state-file", "", "path to the state file to read from, defaults to .ship/state.json")
-	cmd.PersistentFlags().String("studio-channel-name", "", "Useful for debugging your specs on the command line, without having to make round trips to the server")
-	cmd.PersistentFlags().String("studio-channel-icon", "", "Useful for debugging your specs on the command line, without having to make round trips to the server")
-	cmd.PersistentFlags().Bool("terraform-yes", false, "Automatically answer \"yes\" to all terraform prompts")
 
 	cmd.AddCommand(e2e.Cmd())
-	cmd.AddCommand(devtoolreleaser.Cmd())
-	cmd.AddCommand(Kustomize())
+	cmd.AddCommand(Init())
+	cmd.AddCommand(App())
 	cmd.AddCommand(Version())
 	viper.BindPFlags(cmd.Flags())
 	viper.BindPFlags(cmd.PersistentFlags())

--- a/pkg/e2e/cmd.go
+++ b/pkg/e2e/cmd.go
@@ -11,8 +11,9 @@ import (
 
 func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "e2e",
-		Short: "e2e testing for ship",
+		Use:    "e2e",
+		Short:  "e2e testing for ship",
+		Hidden: true,
 		Long: `
 
 `,

--- a/pkg/lifecycle/daemon/daemon.go
+++ b/pkg/lifecycle/daemon/daemon.go
@@ -235,10 +235,8 @@ func (d *ShipDaemon) Serve(ctx context.Context, release *api.Release) error {
 		errChan <- server.ListenAndServe()
 	}()
 
-	uiPortToDisplay := 8800
-	if serveUIFromAPIDaemon(d) {
-		uiPortToDisplay = 8880
-	}
+	uiPortToDisplay := 8880
+
 	d.UI.Info(fmt.Sprintf(
 		"Please visit the following URL in your browser to continue the installation\n\n        http://localhost:%d\n\n ",
 		uiPortToDisplay, // todo param this
@@ -269,9 +267,7 @@ func (d *ShipDaemon) locker() func() {
 func (d *ShipDaemon) configureRoutes(g *gin.Engine, release *api.Release) {
 
 	root := g.Group("/")
-	if serveUIFromAPIDaemon(d) {
-		g.Use(static.Serve("/", d.WebUIFactory("dist")))
-	}
+	g.Use(static.Serve("/", d.WebUIFactory("dist")))
 
 	root.GET("/healthz", d.Healthz)
 	root.GET("/metricz", d.Metricz)
@@ -302,11 +298,6 @@ func (d *ShipDaemon) configureRoutes(g *gin.Engine, release *api.Release) {
 	v1.POST("/kustomize/file", d.requireKustomize(), d.kustomizeGetFile)
 	v1.POST("/kustomize/save", d.requireKustomize(), d.kustomizeSaveOverlay)
 	v1.POST("/kustomize/finalize", d.requireKustomize(), d.kustomizeFinalize)
-}
-
-// if not, we're hosting the UI separately
-func serveUIFromAPIDaemon(d *ShipDaemon) bool {
-	return !d.Viper.GetBool("ship-compose-ui")
 }
 
 func (d *ShipDaemon) SetProgress(p Progress) {


### PR DESCRIPTION
What I Did
------------
Changed the command structure a bit to separate the replicated vendor apps from the ship init helm usage. To use ship to deploy a licensed app, this used to be `ship --customer-id...` and now it's under an `app` command. So it's `ship app --customer-id --installation-id`. Also the UI is only served from this binary now.

I also renamed `kustomize` to `init`.

The `e2e` subcommand is hidden now.

Finally, the devtool releaser should be moved to replicatedhq/studio, because it's a vendor tool to create and deploy updates using the Replicated APIs. For now, I removed the command, but the code has not been migrated yet.

How I Did it
------------
Created app command, moved code around a lot.

How to verify it
------------
`ship` has no default action now, other than to print help.

Description for the Changelog
------------
Created `vendor` command for third party, licensed applications.
Renamed `kustomize` command to `init`.

Picture of a Boat (not required but encouraged)
------------
![download-1](https://user-images.githubusercontent.com/173451/43360209-37a17344-9266-11e8-9936-0eeae594decb.jpg)











<!-- (thanks https://github.com/linuxkit/linuxkit for this template) -->

