### PR TITLE
Handle invalid github urls on the init command

### DIFF
--- a/pkg/specs/chart.go
+++ b/pkg/specs/chart.go
@@ -49,11 +49,11 @@ func (g *GithubClient) GetChartAndReadmeContents(ctx context.Context, chartURLSt
 	if err != nil {
 		return err
 	}
-	chartPath := chartURL.Path
-	splitPath := strings.Split(chartPath, "/")
-	owner := splitPath[1]
-	repo := splitPath[2]
-	path := strings.Join(splitPath[3:], "/")
+
+	owner, repo, path, err := decodeGitHubUrl(chartURL.Path)
+	if err != nil {
+		return err
+	}
 
 	debug.Log("event", "checkExists", "path", constants.KustomizeHelmPath)
 	saveDirExists, err := g.fs.Exists(constants.KustomizeHelmPath)
@@ -167,4 +167,21 @@ func (r *Resolver) ResolveChartMetadata(ctx context.Context, path string) (api.H
 
 	md.Readme = string(readme)
 	return md, nil
+}
+
+func decodeGitHubUrl(chartPath string) (string, string, string, error) {
+	splitPath := strings.Split(chartPath, "/")
+
+	if len(splitPath) < 3 {
+		return "", "", "", errors.Wrapf(errors.New("unable to decode github url"), chartPath)
+	}
+
+	owner := splitPath[1]
+	repo := splitPath[2]
+	path := ""
+	if len(splitPath) > 3 {
+		path = strings.Join(splitPath[3:], "/")
+	}
+
+	return owner, repo, path, nil
 }

--- a/pkg/specs/chart_test.go
+++ b/pkg/specs/chart_test.go
@@ -86,7 +86,7 @@ var _ = Describe("GithubClient", func() {
 
 		Context("With a url not prefixed with http", func() {
 			It("should fetch and persist README.md and Chart.yaml", func() {
-				validGitURLWithoutPrefix := "github.com/o/r/"
+				validGitURLWithoutPrefix := "github.com/o/r"
 				mockFs := afero.Afero{Fs: afero.NewMemMapFs()}
 				gitClient := GithubClient{
 					client: client,
@@ -108,6 +108,46 @@ var _ = Describe("GithubClient", func() {
 				Expect(string(chart)).To(Equal("bar"))
 				Expect(string(deployment)).To(Equal("deployment"))
 				Expect(string(service)).To(Equal("service"))
+			})
+		})
+	})
+
+	Describe("decodeGitHubUrl", func() {
+		Context("With a valid github url", func() {
+			It("should decode a valid url without a path", func() {
+				chartPath := "github.com/o/r"
+				o, r, p, err := decodeGitHubUrl(chartPath)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(o).To(Equal("o"))
+				Expect(r).To(Equal("r"))
+				Expect(p).To(Equal(""))
+			})
+
+			It("should decode a valid url with a path", func() {
+				chartPath := "github.com/o/r/stable/chart"
+				o, r, p, err := decodeGitHubUrl(chartPath)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(o).To(Equal("o"))
+				Expect(r).To(Equal("r"))
+				Expect(p).To(Equal("stable/chart"))
+			})
+		})
+
+		Context("With an invalid github url", func() {
+			It("should failed to decode a url without a path", func() {
+				chartPath := "github.com"
+				_, _, _, err := decodeGitHubUrl(chartPath)
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).To(Equal("github.com: unable to decode github url"))
+			})
+
+			It("should failed to decode a url with a path", func() {
+				chartPath := "github.com/o"
+				_, _, _, err := decodeGitHubUrl(chartPath)
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).To(Equal("github.com/o: unable to decode github url"))
 			})
 		})
 	})


### PR DESCRIPTION
What I Did
------------
Made the string splitting around github urls more robust (well, not panic).

How I Did it
------------
Moved it to a separate function, added test cases that were causing panics to be handled better.

How to verify it
------------
Try `ship init` with bad github urls and it won't panic. Or run the tests.

Description for the Changelog
------------
Better handling (no panic) on invalid chart urls.

Picture of a Boat (not required but encouraged)
------------
![gopher-on-boat](https://user-images.githubusercontent.com/173451/43370020-8ad834a0-932c-11e8-8042-0244c9a28604.png)











<!-- (thanks https://github.com/linuxkit/linuxkit for this template) -->

