### PR TITLE
Update integration tests to use app command

### DIFF
--- a/integration/base/integration_test.go
+++ b/integration/base/integration_test.go
@@ -78,11 +78,12 @@ var _ = Describe("basic", func() {
 					os.Chdir(integrationDir)
 				}, 20)
 
-				It("Should output files matching those expected when running in local mode", func() {
+				It("Should output files matching those expected when running app command in local mode", func() {
 					cmd := cli.RootCmd()
 					buf := new(bytes.Buffer)
 					cmd.SetOutput(buf)
 					cmd.SetArgs([]string{
+						"app",
 						"--headless",
 						fmt.Sprintf("--studio-file=%s", path.Join(testInputPath, ".ship/release.yml")),
 						fmt.Sprintf("--state-file=%s", path.Join(testInputPath, ".ship/state.json")),
@@ -108,6 +109,7 @@ var _ = Describe("basic", func() {
 					buf := new(bytes.Buffer)
 					cmd.SetOutput(buf)
 					cmd.SetArgs(append([]string{
+						"app",
 						"--headless",
 						fmt.Sprintf("--state-file=%s", path.Join(testInputPath, ".ship/state.json")),
 						"--customer-endpoint=https://pg.staging.replicated.com/graphql",


### PR DESCRIPTION
What I Did
------------
Fix the integration-tests

How I Did it
------------
The integration-tests need to specify the `app` command now

How to verify it
------------
Run the integration tests.

Description for the Changelog
------------

Picture of a Boat (not required but encouraged)
------------
![59426-5-1414416238](https://user-images.githubusercontent.com/173451/43372452-f58de564-9355-11e8-8870-66a8566bcb2b.jpg)











<!-- (thanks https://github.com/linuxkit/linuxkit for this template) -->

