### PR TITLE
store helm chart url

### DIFF
--- a/pkg/api/asset.go
+++ b/pkg/api/asset.go
@@ -77,8 +77,6 @@ type HelmAsset struct {
 	GitHub *GitHubAsset `json:"github" yaml:"github" hcl:"github"`
 	// Local is an escape hatch, most impls will use github or some sort of ChartMuseum thing
 	Local *LocalHelmOpts `json:"local,omitempty" yaml:"local,omitempty" hcl:"local,omitempty"`
-	// ChartPath is the URL from which to pull the chart
-	ChartPath string `json:"chart_path" yaml:"chart_path" hcl:"chart_path"`
 }
 
 // LocalHelmOpts specifies a helm chart that should be templated

--- a/pkg/api/spec.go
+++ b/pkg/api/spec.go
@@ -37,6 +37,7 @@ type HelmChartMetadata struct {
 	Icon        string `json:"icon" yaml:"icon" hcl:"icon" meta:"icon"`
 	Name        string `json:"name" yaml:"name" hcl:"name" meta:"name"`
 	Readme      string `json:"readme" yaml:"readme" hcl:"readme" meta:"readme"`
+	URL         string `json:"url" yaml:"url" hcl:"url" meta:"url"`
 }
 
 // ReleaseMetadata

--- a/pkg/ship/kustomize.go
+++ b/pkg/ship/kustomize.go
@@ -108,7 +108,6 @@ func (s *Ship) Init(ctx context.Context) error {
 								"--values",
 								path.Join(constants.TempHelmValuesPath, "values.yaml"),
 							},
-							ChartPath: helmChartPath,
 						},
 					},
 				},

--- a/pkg/specs/chart.go
+++ b/pkg/specs/chart.go
@@ -146,6 +146,9 @@ func (r *Resolver) ResolveChartMetadata(ctx context.Context, path string) (api.H
 		return api.HelmChartMetadata{}, errors.Wrapf(err, "get chart and read me at %s", path)
 	}
 
+	debug.Log("phase", "save-chart-url", "url", path)
+	md.URL = path
+
 	localChartPath := filepath.Join(constants.KustomizeHelmPath, "Chart.yaml")
 	debug.Log("phase", "read-chart", "from", localChartPath)
 	chart, err := r.FS.ReadFile(localChartPath)


### PR DESCRIPTION
What I Did
------------
`ship init` should store the URL of the helm chart

How I Did it
------------
- add a `URL` field to the `HelmChartMetadata` type. the value is specified by the `[CHART]` field of the `ship init [CHART]` command

How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------
⛵️ 











<!-- (thanks https://github.com/docker/docker for this template) -->

