### PR TITLE
return saved overlays to the client

### DIFF
--- a/pkg/state/models.go
+++ b/pkg/state/models.go
@@ -3,6 +3,7 @@ package state
 type State interface {
 	CurrentConfig() map[string]interface{}
 	CurrentKustomize() *Kustomize
+	CurrentKustomizeOverlay(filename string) string
 	CurrentHelmValues() string
 }
 
@@ -13,6 +14,7 @@ var _ State = V0{}
 type Empty struct{}
 
 func (Empty) CurrentKustomize() *Kustomize          { return nil }
+func (Empty) CurrentKustomizeOverlay(string) string { return "" }
 func (Empty) CurrentConfig() map[string]interface{} { return make(map[string]interface{}) }
 func (Empty) CurrentHelmValues() string             { return "" }
 
@@ -20,6 +22,7 @@ type V0 map[string]interface{}
 
 func (v V0) CurrentConfig() map[string]interface{} { return v }
 func (v V0) CurrentKustomize() *Kustomize          { return nil }
+func (v V0) CurrentKustomizeOverlay(string) string { return "" }
 func (v V0) CurrentHelmValues() string             { return "" }
 
 type VersionedState struct {
@@ -44,6 +47,32 @@ type Kustomize struct {
 
 func (u VersionedState) CurrentKustomize() *Kustomize {
 	return u.V1.Kustomize
+}
+
+func (u VersionedState) CurrentKustomizeOverlay(filename string) string {
+	if u.V1.Kustomize == nil {
+		return ""
+	}
+
+	if u.V1.Kustomize.Overlays == nil {
+		return ""
+	}
+
+	overlay, ok := u.V1.Kustomize.Overlays["ship"]
+	if !ok {
+		return ""
+	}
+
+	if overlay.Files == nil {
+		return ""
+	}
+
+	file, ok := overlay.Files[filename]
+	if ok {
+		return file
+	}
+
+	return ""
 }
 
 func (u VersionedState) CurrentConfig() map[string]interface{} {


### PR DESCRIPTION
What I Did
------------

Add logic to load the saved overlay contents from state, and return when the client requests a file.

How I Did it
------------

New method on State interface, mostly for convenience -- `CurrentKustomizeOverlay(string) string` that returns the overlay for a file.


How to verify it
------------

Run `ship init` or `ship init --raw`, change some kustomize files, reload page, see overlays preserved.


Description for the Changelog
------------


Still a WIP feature, so no CL












<!-- (thanks https://github.com/docker/docker for this template) -->