### PR TITLE
refactor makefile so that the embed-ui step no longer requires yarn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,10 +206,7 @@ build_yoonit_docker_image:
 build_ship_integration_test:
 	docker build -t $(DOCKER_REPO)/ship-e2e-test:latest -f ./integration/base/Dockerfile .
 
-web/.state/build_ship:
-	$(MAKE) -C web .state/build_ship
-
-pkg/lifeycle/daemon/ui.bindatafs.go: .state/build-deps $(UI) web/.state/build_ship
+pkg/lifeycle/daemon/ui.bindatafs.go: .state/build-deps $(UI)
 	cd web; go-bindata-assetfs -pkg daemon \
 	  -o ../pkg/lifecycle/daemon/ui.bindatafs.go \
 	  dist/...
@@ -217,5 +214,4 @@ pkg/lifeycle/daemon/ui.bindatafs.go: .state/build-deps $(UI) web/.state/build_sh
 embed-ui: pkg/lifeycle/daemon/ui.bindatafs.go
 
 build-ui:
-	cd web; yarn install --force
-	cd web; `yarn bin`/webpack --config webpack.config.js --env ship --mode production
+	$(MAKE) -C web build_ship


### PR DESCRIPTION
What I Did
------------

Removed the `embed-ui` dependency on yarn that broke `deploy_unstable` on Circle

(also change `build-ui` to use the makefile within web rather than maintaining a copy of the command here)

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------








![image](https://user-images.githubusercontent.com/2318911/43488816-c195f5aa-94cf-11e8-8241-136f648ea2e5.png)




<!-- (thanks https://github.com/docker/docker for this template) -->

