### PR TITLE
make the generated docs be closer to the currently published docs

### DIFF
--- a/hack/docs/mutations.json
+++ b/hack/docs/mutations.json
@@ -400,6 +400,12 @@
     }
   },
   {
+    "path": "properties.assets.properties.v1.items.properties.web.properties.dest",
+    "merge": {
+      "description": "A path to which the file should be written when generating assets"
+    }
+  },
+  {
     "path": "properties.assets.properties.v1.items.properties.web.properties.url",
     "merge": {
       "description": "A public or private URL to pull content from"

--- a/hack/docs/schema.json
+++ b/hack/docs/schema.json
@@ -522,6 +522,7 @@
                     "type": "string"
                   },
                   "dest": {
+                    "description": "A path to which the file should be written when generating assets",
                     "type": "string"
                   },
                   "headers": {

--- a/hack/docs/src/markdown.ts
+++ b/hack/docs/src/markdown.ts
@@ -21,7 +21,7 @@ function maybeRenderParameters(paramType, param: any[], typeOf) {
   let doc = "";
   if (param.length !== 0) {
     doc += `
-    
+
 ### ${typeOf} Parameters
 
 `;
@@ -39,7 +39,7 @@ function maybeRenderParameters(paramType, param: any[], typeOf) {
 `;
         for (const childDescr of requiredSubParam) {
           doc += `
-    - ${"`" + childDescr.field + "`"} - ${childDescr.description}
+  - ${"`" + childDescr.field + "`"} - ${childDescr.description}
 `;
         }
       }
@@ -49,7 +49,7 @@ function maybeRenderParameters(paramType, param: any[], typeOf) {
 `;
         for (const childDescr of optionalSubParam) {
           doc += `
-    - ${"`" + childDescr.field + "`"} - ${childDescr.description}
+  - ${"`" + childDescr.field + "`"} - ${childDescr.description}
 `;
         }
       }
@@ -129,6 +129,9 @@ function parseSubParameters(paramType: any, spec: string) {
 function maybeRenderExamples(specTypes: any, specType, subgroup: string) {
   let doc = "";
   if (specTypes[specType].examples) {
+    doc += `
+### Examples
+`;
     for (const example of specTypes[specType].examples) {
       console.log("EXAMPLE", subgroup, specType);
       doc += `
@@ -181,7 +184,6 @@ export const handler = (argv) => {
 
       let doc = "";
       doc += writeHeader(specTypes, specType, subgroup);
-      doc += maybeRenderExamples(specTypes, specType, subgroup);
 
       const {required, optional} = parseParameters(specTypes, specType);
 
@@ -190,9 +192,7 @@ export const handler = (argv) => {
       doc += maybeRenderParameters(subTypes, required, `Required`);
       doc += maybeRenderParameters(subTypes, optional, `Optional`);
 
-      doc += `
-    
-    `;
+      doc += maybeRenderExamples(specTypes, specType, subgroup);
 
       fs.writeFileSync(`${subgroup}/${cleanProperty}.md`, doc);
     }


### PR DESCRIPTION
What I Did
------------
Updated the docs generation code to more closely match what is currently live in [help center](https://github.com/replicatedhq/help-center/tree/master/content/api/ship-assets)

How I Did it
------------


How to verify it
------------
Check out the help center PR https://github.com/replicatedhq/help-center/pull/581

Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------





![image](https://user-images.githubusercontent.com/2318911/43490732-b00e5898-94d6-11e8-9330-2736deb942c9.png)







<!-- (thanks https://github.com/docker/docker for this template) -->

