### PR TITLE
fix bug with percentages

### DIFF
--- a/web/src/components/shared/StepBuildingAssets.jsx
+++ b/web/src/components/shared/StepBuildingAssets.jsx
@@ -34,7 +34,11 @@ export default class StepBuildingAssets extends React.Component {
     const { status } = this.props;
     const isJSON = status.type === "json";
     const progressDetail = isJSON ? JSON.parse(status.detail).progressDetail : null;
-    const percent = progressDetail ? `${Utilities.calcPercent(progressDetail.current, progressDetail.total, 0)}` : 0;
+    let percent = progressDetail ? `${Utilities.calcPercent(progressDetail.current, progressDetail.total, 0)}` : 0;
+    if (percent > 100) {
+      percent = 100;
+
+    }
     return (
       <div className="flex1 flex-column justifyContent--center alignItems--center">
         <Loader size="60" />


### PR DESCRIPTION
<!-- (thanks https://github.com/docker/docker for this template) -->

What I Did
------------

Fix an issue where docker would give us weird values during pushes,
causing push progress to render as 1000+ percent done.

```
{"id":"f806e88023e8","status":"Pushing","progressDetail":{"current":512,"total":13}}
{"id":"f806e88023e8","status":"Pushing","progressDetail":{"current":2048,"total":13}}
```

How I Did it
------------

Cap percent at 100

How to verify it
------------

Run example in integration/base/docker-push