### PR TITLE
Explicitly set the entrypoint for the integration test container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,8 @@ jobs:
       - checkout
       - setup_remote_docker
       - run: make build_ship_integration_test
-      - run: docker run --net="host" -it -v /var/run/docker.sock:/var/run/docker.sock replicated/ship-e2e-test:latest
+      #the entrypoint is set explicitly here because that file is expected by other circle builds
+      - run: docker run --net="host" -it -v /var/run/docker.sock:/var/run/docker.sock --entrypoint /test/integration_docker_start.sh replicated/ship-e2e-test:latest
 
   deploy_unstable:
     docker:


### PR DESCRIPTION
Other circle builds require that entrypoint to be present

What I Did
------------
Changed the ship integration test run to not rely on the container's entrypoint and set it explicitly, since other CircleCI builds rely on that entrypoint's existence. 

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------


![image](https://user-images.githubusercontent.com/2318911/43544941-547d51d8-9589-11e8-82e8-04f026f6456c.png)










<!-- (thanks https://github.com/docker/docker for this template) -->

