### PR TITLE
enable online integration tests for the AWS EKS asset

### DIFF
--- a/integration/base/amazonElasticKubernetesService/expected/.ship/release.yml
+++ b/integration/base/amazonElasticKubernetesService/expected/.ship/release.yml
@@ -2,8 +2,13 @@ assets:
   v1:
     - amazon_elastic_kubernetes_service:
         dest: empty/empty.tf
+        cluster_name: ""
+        region: ""
+        autoscaling_groups: []
         existing_vpc:
-          vpc_id: abc123
+          vpc_id: ""
+          public_subnets: []
+          private_subnets: []
     - amazon_elastic_kubernetes_service:
         dest: existing/existing_vpc.tf
         cluster_name: "existing-vpc-cluster"

--- a/integration/base/amazonElasticKubernetesService/expected/installer/empty/empty.tf
+++ b/integration/base/amazonElasticKubernetesService/expected/installer/empty/empty.tf
@@ -1,6 +1,6 @@
 
 locals {
-  "eks_vpc"                 = "abc123"
+  "eks_vpc"                 = ""
   "eks_vpc_public_subnets"  = [
   ]
   "eks_vpc_private_subnets" = [

--- a/integration/base/amazonElasticKubernetesService/input/.ship/release.yml
+++ b/integration/base/amazonElasticKubernetesService/input/.ship/release.yml
@@ -2,8 +2,13 @@ assets:
   v1:
     - amazon_elastic_kubernetes_service:
         dest: empty/empty.tf
+        cluster_name: ""
+        region: ""
+        autoscaling_groups: []
         existing_vpc:
-          vpc_id: abc123
+          vpc_id: ""
+          public_subnets: []
+          private_subnets: []
     - amazon_elastic_kubernetes_service:
         dest: existing/existing_vpc.tf
         cluster_name: "existing-vpc-cluster"

--- a/integration/base/amazonElasticKubernetesService/metadata.yaml
+++ b/integration/base/amazonElasticKubernetesService/metadata.yaml
@@ -1,2 +1,6 @@
-disable_online: true
+customer_id: "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G"
+installation_id: "Jn0nK8OlT3k9AYqpnq6SGqzo_srKjzjQ"
+release_version: "0.0.1-a"
+
+disable_online: false
 skip_cleanup: false


### PR DESCRIPTION
What I Did
------------
Added an online integration test for the newly added https://github.com/replicatedhq/ship/pull/207 AWS EKS asset

How I Did it
------------


How to verify it
------------
The integration tests pass and `disable_online` is set to false

Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------

![image](https://user-images.githubusercontent.com/2318911/43553329-4cd8b0e8-95a3-11e8-82db-ff29fe9e16f7.png)











<!-- (thanks https://github.com/docker/docker for this template) -->

