### PR TITLE
switch from 'laverya/eks/aws' to 'terraform-aws-modules/eks/aws'

### DIFF
--- a/integration/base/amazonElasticKubernetesService/expected/installer/empty/empty.tf
+++ b/integration/base/amazonElasticKubernetesService/expected/installer/empty/empty.tf
@@ -27,8 +27,7 @@ variable "eks-cluster-name" {
 }
 
 module "eks" {
-  #source = "terraform-aws-modules/eks/aws"
-  source  = "laverya/eks/aws"
+  source  = "terraform-aws-modules/eks/aws"
   version = "1.4.0"
 
   cluster_name = "${var.eks-cluster-name}"

--- a/integration/base/amazonElasticKubernetesService/expected/installer/existing/existing_vpc.tf
+++ b/integration/base/amazonElasticKubernetesService/expected/installer/existing/existing_vpc.tf
@@ -40,8 +40,7 @@ variable "eks-cluster-name" {
 }
 
 module "eks" {
-  #source = "terraform-aws-modules/eks/aws"
-  source  = "laverya/eks/aws"
+  source  = "terraform-aws-modules/eks/aws"
   version = "1.4.0"
 
   cluster_name = "${var.eks-cluster-name}"

--- a/integration/base/amazonElasticKubernetesService/expected/installer/new/new_vpc.tf
+++ b/integration/base/amazonElasticKubernetesService/expected/installer/new/new_vpc.tf
@@ -86,8 +86,7 @@ variable "eks-cluster-name" {
 }
 
 module "eks" {
-  #source = "terraform-aws-modules/eks/aws"
-  source  = "laverya/eks/aws"
+  source  = "terraform-aws-modules/eks/aws"
   version = "1.4.0"
 
   cluster_name = "${var.eks-cluster-name}"

--- a/pkg/lifecycle/render/amazonElasticKubernetesService/render_templates.go
+++ b/pkg/lifecycle/render/amazonElasticKubernetesService/render_templates.go
@@ -90,8 +90,7 @@ variable "eks-cluster-name" {
 }
 
 module "eks" {
-  #source = "terraform-aws-modules/eks/aws"
-  source  = "laverya/eks/aws"
+  source  = "terraform-aws-modules/eks/aws"
   version = "1.4.0"
 
   cluster_name = "${var.eks-cluster-name}"

--- a/pkg/lifecycle/render/amazonElasticKubernetesService/render_test.go
+++ b/pkg/lifecycle/render/amazonElasticKubernetesService/render_test.go
@@ -110,8 +110,7 @@ variable "eks-cluster-name" {
 }
 
 module "eks" {
-  #source = "terraform-aws-modules/eks/aws"
-  source  = "laverya/eks/aws"
+  source  = "terraform-aws-modules/eks/aws"
   version = "1.4.0"
 
   cluster_name = "${var.eks-cluster-name}"
@@ -168,8 +167,7 @@ variable "eks-cluster-name" {
 }
 
 module "eks" {
-  #source = "terraform-aws-modules/eks/aws"
-  source  = "laverya/eks/aws"
+  source  = "terraform-aws-modules/eks/aws"
   version = "1.4.0"
 
   cluster_name = "${var.eks-cluster-name}"
@@ -240,8 +238,7 @@ variable "eks-cluster-name" {
 }
 
 module "eks" {
-  #source = "terraform-aws-modules/eks/aws"
-  source  = "laverya/eks/aws"
+  source  = "terraform-aws-modules/eks/aws"
   version = "1.4.0"
 
   cluster_name = "${var.eks-cluster-name}"
@@ -548,8 +545,7 @@ variable "eks-cluster-name" {
 }
 
 module "eks" {
-  #source = "terraform-aws-modules/eks/aws"
-  source  = "laverya/eks/aws"
+  source  = "terraform-aws-modules/eks/aws"
   version = "1.4.0"
 
   cluster_name = "${var.eks-cluster-name}"
@@ -623,8 +619,7 @@ variable "eks-cluster-name" {
 }
 
 module "eks" {
-  #source = "terraform-aws-modules/eks/aws"
-  source  = "laverya/eks/aws"
+  source  = "terraform-aws-modules/eks/aws"
   version = "1.4.0"
 
   cluster_name = "${var.eks-cluster-name}"
@@ -756,8 +751,7 @@ variable "eks-cluster-name" {
 }
 
 module "eks" {
-  #source = "terraform-aws-modules/eks/aws"
-  source  = "laverya/eks/aws"
+  source  = "terraform-aws-modules/eks/aws"
   version = "1.4.0"
 
   cluster_name = "${var.eks-cluster-name}"


### PR DESCRIPTION
What I Did
------------
Updated the AWS EKS generation script to use the 'terraform-aws-modules/eks/aws' module instead of the 'laverya/eks/aws' module.

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------



![image](https://user-images.githubusercontent.com/2318911/43616926-e508d3d6-9673-11e8-9e74-a93c1329bd6e.png)









<!-- (thanks https://github.com/docker/docker for this template) -->

