### PR TITLE
fix update base bug

### DIFF
--- a/pkg/lifecycle/render/helm/template.go
+++ b/pkg/lifecycle/render/helm/template.go
@@ -138,8 +138,7 @@ func (f *ForkTemplater) Template(
 	tempRenderedChartTemplatesDir := path.Join(tempRenderedChartDir, "templates")
 	tempRenderedSubChartsDir := path.Join(tempRenderedChartDir, subChartsDirName)
 
-	debug.Log("event", "renderedHelmValues.remove", "path", constants.RenderedHelmPath)
-	if err := f.FS.RemoveAll(constants.RenderedHelmPath); err != nil {
+	if err := f.tryRemoveRenderedHelmPath(); err != nil {
 		return errors.Wrap(err, "removeAll failed while trying to remove rendered Helm values base dir")
 	}
 
@@ -166,6 +165,17 @@ func (f *ForkTemplater) Template(
 	}
 
 	// todo link up stdout/stderr debug logs
+	return nil
+}
+
+func (f *ForkTemplater) tryRemoveRenderedHelmPath() error {
+	debug := level.Debug(log.With(f.Logger, "method", "tryRemoveRenderedHelmPath"))
+
+	if err := f.FS.RemoveAll(constants.RenderedHelmPath); err != nil {
+		return err
+	}
+	debug.Log("event", "renderedHelmPath.remove", "path", constants.RenderedHelmPath)
+
 	return nil
 }
 

--- a/pkg/lifecycle/render/helm/template_test.go
+++ b/pkg/lifecycle/render/helm/template_test.go
@@ -11,6 +11,8 @@ import (
 	"reflect"
 	"strings"
 
+	"path"
+
 	"github.com/replicatedhq/libyaml"
 	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/constants"
@@ -231,4 +233,65 @@ func TestMockHelm(t *testing.T) {
 		os.Exit(0)
 	}
 
+}
+
+func TestTryRemoveRenderedHelmPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		describe    string
+		baseDir     string
+		expectError bool
+	}{
+		{
+			name:        "base exists",
+			describe:    "ensure base is removed and removeAll doesn't error",
+			baseDir:     constants.RenderedHelmPath,
+			expectError: false,
+		},
+		{
+			name:        "base does not exist",
+			describe:    "missing base, ensure removeAll doesn't error",
+			baseDir:     "",
+			expectError: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := require.New(t)
+
+			testLogger := &logger.TestLogger{T: t}
+
+			fakeFS := afero.Afero{Fs: afero.NewMemMapFs()}
+
+			// create the base directory
+			err := fakeFS.MkdirAll(path.Join(test.baseDir, "myCoolManifest.yaml"), 0777)
+			req.NoError(err)
+
+			// verify path actually exists
+			successfulMkdirAll, err := fakeFS.DirExists(path.Join(test.baseDir, "myCoolManifest.yaml"))
+			req.True(successfulMkdirAll)
+			req.NoError(err)
+
+			ft := &ForkTemplater{
+				FS:     fakeFS,
+				Logger: testLogger,
+			}
+
+			removeErr := ft.tryRemoveRenderedHelmPath()
+
+			if test.expectError {
+				req.Error(removeErr)
+			} else {
+				if dirExists, existErr := ft.FS.DirExists(constants.RenderedHelmPath); dirExists {
+					req.NoError(existErr)
+					// if dir exists, we expect tryRemoveRenderedHelmPath to have err'd
+					req.Error(removeErr)
+				} else {
+					// if dir does not exist, we expect tryRemoveRenderedHelmPath to have succeeded without err'ing
+					req.NoError(removeErr)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
What I Did
------------
- fixed a bug in `ship update` where an existing `Base` directory would cause `render` to throw a `rename` error

How I Did it
------------
- `template.go`: created a function, `tryRemoveRenderedHelmPath()`, that tries to remove the old `Base` directory (and it's children) before returning

- `template_test.go`: added some unit tests, `TestTryRemoveRenderedHelmPath()`, to validate 

How to verify it
------------
- run the `TestTryRemoveRenderedHelmPath()` unit test in `template_test.go`

Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------
⛵️ 











<!-- (thanks https://github.com/docker/docker for this template) -->

