### PR TITLE
move daemon types to package

### DIFF
--- a/pkg/lifecycle/daemon/actions.go
+++ b/pkg/lifecycle/daemon/actions.go
@@ -1,12 +1,14 @@
 package daemon
 
-func MessageActions() []Action {
-	return []Action{
+import "github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
+
+func MessageActions() []daemontypes.Action {
+	return []daemontypes.Action{
 		{
 			ButtonType:  "primary",
 			Text:        "Confirm",
 			LoadingText: "Confirming",
-			OnClick: ActionRequest{
+			OnClick: daemontypes.ActionRequest{
 				URI:    "/message/confirm",
 				Method: "POST",
 				Body:   `{"step_name": "message"}`,
@@ -15,13 +17,13 @@ func MessageActions() []Action {
 	}
 }
 
-func HelmIntroActions() []Action {
-	return []Action{
+func HelmIntroActions() []daemontypes.Action {
+	return []daemontypes.Action{
 		{
 			ButtonType:  "primary",
 			Text:        "Get started",
 			LoadingText: "Confirming",
-			OnClick: ActionRequest{
+			OnClick: daemontypes.ActionRequest{
 				URI:    "/message/confirm",
 				Method: "POST",
 				Body:   `{"step_name": "helm.intro"}`,
@@ -30,14 +32,14 @@ func HelmIntroActions() []Action {
 	}
 }
 
-func HelmValuesActions() []Action {
-	return []Action{
+func HelmValuesActions() []daemontypes.Action {
+	return []daemontypes.Action{
 		{
 			Sort:        0,
 			ButtonType:  "primary",
 			Text:        "Save values",
 			LoadingText: "Saving",
-			OnClick: ActionRequest{
+			OnClick: daemontypes.ActionRequest{
 				URI:    "/helm-values",
 				Method: "POST",
 				Body:   `{"step_name": "helm.values"}`,
@@ -48,7 +50,7 @@ func HelmValuesActions() []Action {
 			ButtonType:  "primary",
 			Text:        "Continue",
 			LoadingText: "Continuing",
-			OnClick: ActionRequest{
+			OnClick: daemontypes.ActionRequest{
 				URI:    "/message/confirm",
 				Method: "POST",
 				Body:   `{"step_name": "helm.values"}`,

--- a/pkg/lifecycle/daemon/constructors.go
+++ b/pkg/lifecycle/daemon/constructors.go
@@ -4,27 +4,13 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/mitchellh/cli"
 	"github.com/replicatedhq/ship/pkg/filetree"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 	"github.com/replicatedhq/ship/pkg/lifecycle/render/config/resolve"
 	"github.com/replicatedhq/ship/pkg/patch"
 	"github.com/replicatedhq/ship/pkg/state"
-	"github.com/replicatedhq/ship/pkg/ui"
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
 )
-
-func NewHeadlessDaemon(
-	v *viper.Viper,
-	logger log.Logger,
-	renderer *resolve.APIConfigRenderer,
-	stateManager state.Manager,
-) Daemon {
-	return &HeadlessDaemon{
-		StateManager:   stateManager,
-		Logger:         logger,
-		UI:             ui.FromViper(v),
-		ConfigRenderer: renderer,
-	}
-}
 
 func NewHeadedDaemon(
 	logger log.Logger,
@@ -32,12 +18,12 @@ func NewHeadedDaemon(
 	webUIFactory WebUIBuilder,
 	v1Router *V1Routes,
 	v2Router *V2Routes,
-) Daemon {
+) daemontypes.Daemon {
 	return &ShipDaemon{
 		Logger:       log.With(logger, "struct", "daemon"),
 		WebUIFactory: webUIFactory,
 		Viper:        v,
-		exitChan:     make(chan error),
+		ExitChan:     make(chan error),
 		V1Routes:     v1Router,
 		V2Routes:     v2Router,
 	}

--- a/pkg/lifecycle/daemon/daemon.go
+++ b/pkg/lifecycle/daemon/daemon.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/ship/pkg/api"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 	"github.com/replicatedhq/ship/pkg/version"
 	"github.com/spf13/viper"
 )
@@ -22,42 +23,16 @@ var (
 	errInternal = errors.New("internal_error")
 )
 
-// Daemon is a sort of UI interface. Some implementations start an API to
-// power the on-prem web console. A headless implementation logs progress
-// to stdout.
-//
-// A daemon is manipulated by lifecycle step handlers to present the
-// correct UI to the user and collect necessary information
-type Daemon interface {
-	EnsureStarted(context.Context, *api.Release) chan error
-	PushMessageStep(context.Context, Message, []Action)
-	PushStreamStep(context.Context, <-chan Message)
-	PushRenderStep(context.Context, Render)
-	PushHelmIntroStep(context.Context, HelmIntro, []Action)
-	PushHelmValuesStep(context.Context, HelmValues, []Action)
-	PushKustomizeStep(context.Context, Kustomize)
-	SetStepName(context.Context, string)
-	AllStepsDone(context.Context)
-	CleanPreviousStep()
-	MessageConfirmedChan() chan string
-	ConfigSavedChan() chan interface{}
-	TerraformConfirmedChan() chan bool
-	KustomizeSavedChan() chan interface{}
-
-	GetCurrentConfig() map[string]interface{}
-	SetProgress(Progress)
-	ClearProgress()
-}
-
-var _ Daemon = &ShipDaemon{}
+var _ daemontypes.Daemon = &ShipDaemon{}
 
 // Daemon runs the ship api server.
 type ShipDaemon struct {
 	Logger       log.Logger
 	WebUIFactory WebUIBuilder
 	Viper        *viper.Viper
-	exitChan     chan error
-	startOnce    sync.Once
+	// todo private this
+	ExitChan  chan error
+	StartOnce sync.Once
 
 	*V1Routes
 	*V2Routes
@@ -66,13 +41,13 @@ type ShipDaemon struct {
 // "this is fine"
 func (d *ShipDaemon) EnsureStarted(ctx context.Context, release *api.Release) chan error {
 
-	go d.startOnce.Do(func() {
+	go d.StartOnce.Do(func() {
 		err := d.Serve(ctx, release)
 		level.Info(d.Logger).Log("event", "daemon.startonce.exit", err, "err")
-		d.exitChan <- err
+		d.ExitChan <- err
 	})
 
-	return d.exitChan
+	return d.ExitChan
 }
 
 // Serve starts the server with the given context
@@ -112,7 +87,7 @@ func (d *ShipDaemon) Serve(ctx context.Context, release *api.Release) error {
 
 	select {
 	case err := <-errChan:
-		level.Error(d.Logger).Log("event", "shutdown", "reason", "exitChan", "err", err)
+		level.Error(d.Logger).Log("event", "shutdown", "reason", "ExitChan", "err", err)
 		return err
 	case <-ctx.Done():
 		level.Error(d.Logger).Log("event", "shutdown", "reason", "context", "err", ctx.Err())

--- a/pkg/lifecycle/daemon/daemon_test.go
+++ b/pkg/lifecycle/daemon/daemon_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mitchellh/cli"
 	"github.com/replicatedhq/libyaml"
 	"github.com/replicatedhq/ship/pkg/api"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 	"github.com/replicatedhq/ship/pkg/testing/logger"
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
@@ -132,7 +133,7 @@ func TestDaemonAPI(t *testing.T) {
 		{
 			name: "read message after 1st step",
 			test: func(t *testing.T) {
-				daemon.PushMessageStep(context.Background(), Message{
+				daemon.PushMessageStep(context.Background(), daemontypes.Message{
 					Contents: step1.Message.Contents,
 					Level:    step1.Message.Level,
 				}, MessageActions())
@@ -154,7 +155,7 @@ func TestDaemonAPI(t *testing.T) {
 			name: "confirm message that is not current",
 			test: func(t *testing.T) {
 				log := &logger.TestLogger{T: t}
-				daemon.PushMessageStep(context.Background(), Message{
+				daemon.PushMessageStep(context.Background(), daemontypes.Message{
 					Contents: step2.Message.Contents,
 					Level:    step2.Message.Level,
 				}, MessageActions())

--- a/pkg/lifecycle/daemon/daemontypes/progress.go
+++ b/pkg/lifecycle/daemon/daemontypes/progress.go
@@ -1,4 +1,4 @@
-package daemon
+package daemontypes
 
 import "encoding/json"
 

--- a/pkg/lifecycle/daemon/daemontypes/types.go
+++ b/pkg/lifecycle/daemon/daemontypes/types.go
@@ -1,9 +1,38 @@
-package daemon
+package daemontypes
 
 import (
+	"context"
+
 	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/filetree"
 )
+
+// Daemon is a sort of UI interface. Some implementations start an API to
+// power the on-prem web console. A headless implementation logs progress
+// to stdout.
+//
+// A daemon is manipulated by lifecycle step handlers to present the
+// correct UI to the user and collect necessary information
+type Daemon interface {
+	EnsureStarted(context.Context, *api.Release) chan error
+	PushMessageStep(context.Context, Message, []Action)
+	PushStreamStep(context.Context, <-chan Message)
+	PushRenderStep(context.Context, Render)
+	PushHelmIntroStep(context.Context, HelmIntro, []Action)
+	PushHelmValuesStep(context.Context, HelmValues, []Action)
+	PushKustomizeStep(context.Context, Kustomize)
+	SetStepName(context.Context, string)
+	AllStepsDone(context.Context)
+	CleanPreviousStep()
+	MessageConfirmedChan() chan string
+	ConfigSavedChan() chan interface{}
+	TerraformConfirmedChan() chan bool
+	KustomizeSavedChan() chan interface{}
+
+	GetCurrentConfig() map[string]interface{}
+	SetProgress(Progress)
+	ClearProgress()
+}
 
 const StepNameMessage = "message"
 const StepNameConfig = "render.config"

--- a/pkg/lifecycle/daemon/headless/daemon_test.go
+++ b/pkg/lifecycle/daemon/headless/daemon_test.go
@@ -1,4 +1,4 @@
-package daemon
+package headless
 
 import (
 	"context"

--- a/pkg/lifecycle/daemon/routes_v1.go
+++ b/pkg/lifecycle/daemon/routes_v1.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/filetree"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 	"github.com/replicatedhq/ship/pkg/lifecycle/render/config/resolve"
 	"github.com/replicatedhq/ship/pkg/state"
 	"github.com/spf13/afero"
@@ -30,16 +31,16 @@ type V1Routes struct {
 	OpenWebConsole opener
 
 	sync.Mutex
-	currentStep          *Step
+	currentStep          *daemontypes.Step
 	currentStepName      string
 	currentStepConfirmed bool
-	stepProgress         *Progress
+	stepProgress         *daemontypes.Progress
 	allStepsDone         bool
-	pastSteps            []Step
+	pastSteps            []daemontypes.Step
 
 	// this is kind of kludged in,
 	// it only makes sense for Message steps
-	currentStepActions []Action
+	currentStepActions []daemontypes.Action
 
 	initConfig    sync.Once
 	ConfigSaved   chan interface{}
@@ -126,7 +127,7 @@ func (d *V1Routes) createOrMergePatch(c *gin.Context) {
 	}
 }
 
-func (d *V1Routes) SetProgress(p Progress) {
+func (d *V1Routes) SetProgress(p daemontypes.Progress) {
 	defer d.locker(log.NewNopLogger())()
 	d.stepProgress = &p
 }
@@ -228,7 +229,7 @@ func (d *V1Routes) getCurrentStep(c *gin.Context) {
 		d.currentStep.HelmValues.Values = helmValues
 	}
 
-	result := StepResponse{
+	result := daemontypes.StepResponse{
 		CurrentStep: *d.currentStep,
 		Phase:       d.currentStepName,
 		Actions:     d.currentStepActions,

--- a/pkg/lifecycle/daemon/routes_v1_config.go
+++ b/pkg/lifecycle/daemon/routes_v1_config.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/replicatedhq/libyaml"
 	"github.com/replicatedhq/ship/pkg/api"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 	"github.com/replicatedhq/ship/pkg/lifecycle/render/config/resolve"
 )
 
@@ -21,7 +22,7 @@ func (d *V1Routes) postAppConfigLive(release *api.Release) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		debug := level.Debug(log.With(d.Logger, "handler", "postAppConfigLive"))
 
-		if d.currentStepName != StepNameConfig {
+		if d.currentStepName != daemontypes.StepNameConfig {
 			c.JSON(400, map[string]interface{}{
 				"error": "no config step active",
 			})
@@ -89,7 +90,7 @@ func (d *V1Routes) putAppConfig(release *api.Release) gin.HandlerFunc {
 		debug := level.Debug(log.With(d.Logger, "handler", "putAppConfig"))
 		defer d.locker(debug)()
 
-		if d.currentStepName != StepNameConfig {
+		if d.currentStepName != daemontypes.StepNameConfig {
 			c.JSON(400, map[string]interface{}{
 				"error": "no config step active",
 			})

--- a/pkg/lifecycle/daemon/routes_v1_kustomize.go
+++ b/pkg/lifecycle/daemon/routes_v1_kustomize.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/ship/pkg/filetree"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 	"github.com/replicatedhq/ship/pkg/state"
 )
 
@@ -28,13 +29,13 @@ func (d *V1Routes) KustomizeSavedChan() chan interface{} {
 	return d.KustomizeSaved
 }
 
-func (d *V1Routes) PushKustomizeStep(ctx context.Context, kustomize Kustomize) {
+func (d *V1Routes) PushKustomizeStep(ctx context.Context, kustomize daemontypes.Kustomize) {
 	debug := level.Debug(log.With(d.Logger, "method", "PushKustomizeStep"))
 	defer d.locker(debug)()
 	d.cleanPreviousStep()
 
-	d.currentStepName = StepNameKustomize
-	d.currentStep = &Step{Kustomize: &kustomize}
+	d.currentStepName = daemontypes.StepNameKustomize
+	d.currentStep = &daemontypes.Step{Kustomize: &kustomize}
 	d.KustomizeSaved = make(chan interface{}, 1)
 }
 

--- a/pkg/lifecycle/daemon/routes_v1_state.go
+++ b/pkg/lifecycle/daemon/routes_v1_state.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 )
 
 func (d *V1Routes) locker(debug log.Logger) func() {
@@ -39,31 +40,31 @@ func (d *V1Routes) CleanPreviousStep() {
 
 func (d *V1Routes) PushMessageStep(
 	ctx context.Context,
-	step Message,
-	actions []Action,
+	step daemontypes.Message,
+	actions []daemontypes.Action,
 ) {
 	debug := level.Debug(log.With(d.Logger, "handler", "PushMessageStep"))
 	defer d.locker(debug)()
 	d.cleanPreviousStep()
 
-	d.currentStepName = StepNameMessage
-	d.currentStep = &Step{Message: &step}
+	d.currentStepName = daemontypes.StepNameMessage
+	d.currentStep = &daemontypes.Step{Message: &step}
 	d.currentStepActions = actions
 }
 
 func (d *V1Routes) PushStreamStep(
 	ctx context.Context,
-	msgs <-chan Message,
+	msgs <-chan daemontypes.Message,
 ) {
 	d.Lock()
 	d.cleanPreviousStep()
-	d.currentStepName = StepNameStream
-	d.currentStep = &Step{Message: &Message{}}
+	d.currentStepName = daemontypes.StepNameStream
+	d.currentStep = &daemontypes.Step{Message: &daemontypes.Message{}}
 	d.Unlock()
 
 	for msg := range msgs {
 		d.Lock()
-		d.currentStep = &Step{Message: &msg}
+		d.currentStep = &daemontypes.Step{Message: &msg}
 		d.Unlock()
 	}
 }
@@ -74,41 +75,41 @@ func (d *V1Routes) TerraformConfirmedChan() chan bool {
 
 func (d *V1Routes) PushRenderStep(
 	ctx context.Context,
-	step Render,
+	step daemontypes.Render,
 ) {
 	debug := level.Debug(log.With(d.Logger, "handler", "PushRender"))
 	defer d.locker(debug)()
 	d.cleanPreviousStep()
 
-	d.currentStepName = StepNameConfig
-	d.currentStep = &Step{Render: &step}
+	d.currentStepName = daemontypes.StepNameConfig
+	d.currentStep = &daemontypes.Step{Render: &step}
 }
 
 func (d *V1Routes) PushHelmIntroStep(
 	ctx context.Context,
-	step HelmIntro,
-	actions []Action,
+	step daemontypes.HelmIntro,
+	actions []daemontypes.Action,
 ) {
 	debug := level.Debug(log.With(d.Logger, "handler", "PushHelmIntroStep"))
 	defer d.locker(debug)()
 	d.cleanPreviousStep()
 
-	d.currentStepName = StepNameHelmIntro
-	d.currentStep = &Step{HelmIntro: &step}
+	d.currentStepName = daemontypes.StepNameHelmIntro
+	d.currentStep = &daemontypes.Step{HelmIntro: &step}
 	d.currentStepActions = actions
 }
 
 func (d *V1Routes) PushHelmValuesStep(
 	ctx context.Context,
-	step HelmValues,
-	actions []Action,
+	step daemontypes.HelmValues,
+	actions []daemontypes.Action,
 ) {
 	debug := level.Debug(log.With(d.Logger, "handler", "PushHelmValuesStep"))
 	defer d.locker(debug)()
 	d.cleanPreviousStep()
 
-	d.currentStepName = StepNameHelmValues
-	d.currentStep = &Step{HelmValues: &step}
+	d.currentStepName = daemontypes.StepNameHelmValues
+	d.currentStep = &daemontypes.Step{HelmValues: &step}
 	d.currentStepActions = actions
 }
 

--- a/pkg/lifecycle/daemon/routes_v2.go
+++ b/pkg/lifecycle/daemon/routes_v2.go
@@ -8,6 +8,7 @@ import (
 	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/filetree"
 	"github.com/replicatedhq/ship/pkg/lifecycle"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 	"github.com/replicatedhq/ship/pkg/state"
 )
 
@@ -19,6 +20,7 @@ type V2Routes struct {
 	Release   *api.Release
 	Messenger lifecycle.Messenger
 	HelmIntro lifecycle.HelmIntro
+	Renderer  lifecycle.Renderer
 }
 
 func (d *V2Routes) Register(group *gin.RouterGroup, release *api.Release) {
@@ -68,7 +70,7 @@ func (d *V2Routes) getRequiredButIncompleteStepFor(requires []string) (string, e
 	return "", nil
 }
 
-func (d *V2Routes) hydrateAndSend(step Step, c *gin.Context) {
+func (d *V2Routes) hydrateAndSend(step daemontypes.Step, c *gin.Context) {
 	result, err := d.hydrateStep(step, true)
 	if err != nil {
 		c.AbortWithError(500, err)

--- a/pkg/lifecycle/daemon/routes_v2_completestep.go
+++ b/pkg/lifecycle/daemon/routes_v2_completestep.go
@@ -64,6 +64,11 @@ func (d *V2Routes) execute(step api.Step) error {
 		err := d.HelmIntro.Execute(context.Background(), d.Release, step.HelmIntro)
 		debug.Log("event", "step.complete", "type", "helmIntro", "err", err)
 		return errors.Wrap(err, "execute helmIntro step")
+	} else if step.Render != nil {
+		debug.Log("event", "step.resolve", "type", "helmIntro")
+		err := d.Renderer.Execute(context.Background(), d.Release, step.Render)
+		debug.Log("event", "step.complete", "type", "helmIntro", "err", err)
+		return errors.Wrap(err, "execute helmIntro step")
 	}
 
 	return errors.Errorf("unknown step %s:%s", step.ShortName(), step.Shared().ID)

--- a/pkg/lifecycle/daemon/routes_v2_getstep.go
+++ b/pkg/lifecycle/daemon/routes_v2_getstep.go
@@ -5,6 +5,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 )
 
 func (d *V2Routes) getStep(c *gin.Context) {
@@ -20,7 +21,7 @@ func (d *V2Routes) getStep(c *gin.Context) {
 			if ok := d.maybeAbortDueToMissingRequirement(stepShared.Requires, c, requestedStep); !ok {
 				return
 			}
-			d.hydrateAndSend(NewStep(step), c)
+			d.hydrateAndSend(daemontypes.NewStep(step), c)
 			return
 		}
 	}
@@ -28,7 +29,7 @@ func (d *V2Routes) getStep(c *gin.Context) {
 	d.errNotFond(c)
 }
 
-func (d *V2Routes) hydrateStep(step Step, isCurrent bool) (*StepResponse, error) {
+func (d *V2Routes) hydrateStep(step daemontypes.Step, isCurrent bool) (*daemontypes.StepResponse, error) {
 	if step.Kustomize != nil {
 		tree, err := d.TreeLoader.LoadTree(step.Kustomize.BasePath)
 		if err != nil {
@@ -52,10 +53,10 @@ func (d *V2Routes) hydrateStep(step Step, isCurrent bool) (*StepResponse, error)
 		step.HelmValues.Values = helmValues
 	}
 
-	result := &StepResponse{
+	result := &daemontypes.StepResponse{
 		CurrentStep: step,
 		Phase:       step.Source.ShortName(),
-		Actions:     []Action{}, //todo actions
+		Actions:     []daemontypes.Action{}, //todo actions
 	}
 
 	return result, nil

--- a/pkg/lifecycle/helmIntro/helmIntro.go
+++ b/pkg/lifecycle/helmIntro/helmIntro.go
@@ -13,13 +13,14 @@ import (
 	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/lifecycle"
 	"github.com/replicatedhq/ship/pkg/lifecycle/daemon"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 	"github.com/spf13/viper"
 	"go.uber.org/dig"
 )
 
 type HelmIntro struct {
 	Logger log.Logger
-	Daemon daemon.Daemon
+	Daemon daemontypes.Daemon
 }
 
 type DaemonlessHelmIntro struct {
@@ -36,7 +37,7 @@ func NewHelmIntro(
 	v *viper.Viper,
 	fs afero.Afero,
 	logger log.Logger,
-	daemon daemon.Daemon,
+	daemon daemontypes.Daemon,
 ) lifecycle.HelmIntro {
 
 	return &HelmIntro{
@@ -50,7 +51,7 @@ func (h *HelmIntro) Execute(ctx context.Context, release *api.Release, step *api
 
 	daemonExitedChan := h.Daemon.EnsureStarted(ctx, release)
 
-	h.Daemon.PushHelmIntroStep(ctx, daemon.HelmIntro{}, daemon.HelmIntroActions())
+	h.Daemon.PushHelmIntroStep(ctx, daemontypes.HelmIntro{}, daemon.HelmIntroActions())
 	debug.Log("event", "step.pushed")
 
 	return h.awaitContinue(ctx, daemonExitedChan)

--- a/pkg/lifecycle/helmValues/helmValues.go
+++ b/pkg/lifecycle/helmValues/helmValues.go
@@ -12,6 +12,7 @@ import (
 	"github.com/replicatedhq/ship/pkg/constants"
 	"github.com/replicatedhq/ship/pkg/lifecycle"
 	"github.com/replicatedhq/ship/pkg/lifecycle/daemon"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 	"github.com/replicatedhq/ship/pkg/state"
 	"github.com/spf13/afero"
 )
@@ -19,14 +20,14 @@ import (
 type helmValues struct {
 	Fs           afero.Afero
 	Logger       log.Logger
-	Daemon       daemon.Daemon
+	Daemon       daemontypes.Daemon
 	StateManager state.Manager
 }
 
 func NewHelmValues(
 	fs afero.Afero,
 	logger log.Logger,
-	daemon daemon.Daemon,
+	daemon daemontypes.Daemon,
 	stateManager state.Manager,
 ) lifecycle.HelmValues {
 	return &helmValues{
@@ -48,7 +49,7 @@ func (h *helmValues) Execute(ctx context.Context, release *api.Release, step *ap
 		return errors.Wrap(err, "read file values.yaml")
 	}
 
-	h.Daemon.PushHelmValuesStep(ctx, daemon.HelmValues{
+	h.Daemon.PushHelmValuesStep(ctx, daemontypes.HelmValues{
 		Values: string(bytes),
 	}, daemon.HelmValuesActions())
 	debug.Log("event", "step.pushed")

--- a/pkg/lifecycle/kustomize/kustomizer.go
+++ b/pkg/lifecycle/kustomize/kustomizer.go
@@ -15,7 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/lifecycle"
-	"github.com/replicatedhq/ship/pkg/lifecycle/daemon"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 	"github.com/replicatedhq/ship/pkg/state"
 	"github.com/spf13/afero"
 	"gopkg.in/yaml.v2"
@@ -23,7 +23,7 @@ import (
 
 func NewKustomizer(
 	logger log.Logger,
-	daemon daemon.Daemon,
+	daemon daemontypes.Daemon,
 	fs afero.Afero,
 	stateManager state.Manager,
 ) lifecycle.Kustomizer {
@@ -39,7 +39,7 @@ func NewKustomizer(
 // if not we'll have to fork. for now it just explodes
 type kustomizer struct {
 	Logger log.Logger
-	Daemon daemon.Daemon
+	Daemon daemontypes.Daemon
 	FS     afero.Afero
 	State  state.Manager
 }
@@ -51,7 +51,7 @@ func (l *kustomizer) Execute(ctx context.Context, release api.Release, step api.
 
 	debug.Log("event", "daemon.started")
 
-	l.Daemon.PushKustomizeStep(ctx, daemon.Kustomize{
+	l.Daemon.PushKustomizeStep(ctx, daemontypes.Kustomize{
 		BasePath: step.BasePath,
 	})
 	debug.Log("event", "step.pushed")

--- a/pkg/lifecycle/kustomize/kustomizer_test.go
+++ b/pkg/lifecycle/kustomize/kustomizer_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/replicatedhq/ship/pkg/api"
-	"github.com/replicatedhq/ship/pkg/lifecycle/daemon"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 	"github.com/replicatedhq/ship/pkg/state"
 	daemon2 "github.com/replicatedhq/ship/pkg/test-mocks/daemon"
 	state2 "github.com/replicatedhq/ship/pkg/test-mocks/state"
@@ -80,7 +80,7 @@ spec:
 			release := api.Release{}
 
 			mockDaemon.EXPECT().EnsureStarted(ctx, &release)
-			mockDaemon.EXPECT().PushKustomizeStep(ctx, daemon.Kustomize{
+			mockDaemon.EXPECT().PushKustomizeStep(ctx, daemontypes.Kustomize{
 				BasePath: "someBasePath",
 			})
 			mockDaemon.EXPECT().KustomizeSavedChan().Return(saveChan)

--- a/pkg/lifecycle/message/api.go
+++ b/pkg/lifecycle/message/api.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/lifecycle/daemon"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 	"github.com/replicatedhq/ship/pkg/templates"
 	"github.com/spf13/viper"
 	"go.uber.org/dig"
@@ -21,7 +22,7 @@ type DaemonMessenger struct {
 	Logger         log.Logger
 	UI             cli.Ui
 	Viper          *viper.Viper
-	Daemon         daemon.Daemon
+	Daemon         daemontypes.Daemon
 	BuilderBuilder *templates.BuilderBuilder
 }
 
@@ -33,7 +34,7 @@ func (m *DaemonMessenger) Execute(ctx context.Context, release *api.Release, ste
 	builder := m.getBuilder(release.Metadata)
 	built, _ := builder.String(step.Contents)
 
-	m.Daemon.PushMessageStep(ctx, daemon.Message{
+	m.Daemon.PushMessageStep(ctx, daemontypes.Message{
 		Contents: built,
 		Level:    step.Level,
 	}, daemon.MessageActions())

--- a/pkg/lifecycle/message/cli.go
+++ b/pkg/lifecycle/message/cli.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mitchellh/cli"
 	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/lifecycle"
-	"github.com/replicatedhq/ship/pkg/lifecycle/daemon"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 	"github.com/replicatedhq/ship/pkg/templates"
 	"github.com/spf13/viper"
 	"go.uber.org/dig"
@@ -27,7 +27,7 @@ type CLIMessenger struct {
 	BuilderBuilder *templates.BuilderBuilder
 }
 
-func (m *CLIMessenger) WithDaemon(_ daemon.Daemon) lifecycle.Messenger {
+func (m *CLIMessenger) WithDaemon(_ daemontypes.Daemon) lifecycle.Messenger {
 	return m
 }
 

--- a/pkg/lifecycle/message/templates.go
+++ b/pkg/lifecycle/message/templates.go
@@ -7,13 +7,13 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/spf13/viper"
 
-	"github.com/replicatedhq/ship/pkg/lifecycle/daemon"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 )
 
 type builderContext struct {
 	logger log.Logger
 	viper  *viper.Viper
-	daemon daemon.Daemon
+	daemon daemontypes.Daemon
 }
 
 func (ctx builderContext) FuncMap() template.FuncMap {

--- a/pkg/lifecycle/render/config/daemonresolver.go
+++ b/pkg/lifecycle/render/config/daemonresolver.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/replicatedhq/ship/pkg/lifecycle/daemon"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 )
 
 type DaemonResolver struct {
 	Logger log.Logger
-	Daemon daemon.Daemon
+	Daemon daemontypes.Daemon
 }
 
 func (d *DaemonResolver) ResolveConfig(
@@ -36,7 +36,7 @@ func (d *DaemonResolver) ResolveConfig(
 	for _, step := range release.Spec.Lifecycle.V1 {
 		if step.Render != nil {
 			debug.Log("event", "render.found")
-			d.Daemon.PushRenderStep(ctx, daemon.Render{})
+			d.Daemon.PushRenderStep(ctx, daemontypes.Render{})
 			debug.Log("event", "step.pushed")
 			return d.awaitConfigSaved(ctx, daemonExitedChan)
 		}

--- a/pkg/lifecycle/render/config/resolver.go
+++ b/pkg/lifecycle/render/config/resolver.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/replicatedhq/ship/pkg/api"
-	"github.com/replicatedhq/ship/pkg/lifecycle/daemon"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 )
 
 // Resolver is a thing that can resolve configuration options
@@ -15,7 +15,7 @@ type Resolver interface {
 
 func NewResolver(
 	logger log.Logger,
-	daemon daemon.Daemon,
+	daemon daemontypes.Daemon,
 ) Resolver {
 	return &DaemonResolver{
 		Logger: logger,

--- a/pkg/lifecycle/render/planner/build.go
+++ b/pkg/lifecycle/render/planner/build.go
@@ -14,7 +14,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/ship/pkg/images"
-	"github.com/replicatedhq/ship/pkg/lifecycle/daemon"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 )
 
 type buildProgress struct {
@@ -44,7 +44,7 @@ func (p *CLIPlanner) Build(assets []api.Asset, configGroups []libyaml.ConfigGrou
 			StepNumber: i,
 			TotalSteps: len(assets),
 		}
-		p.Daemon.SetProgress(daemon.JSONProgress("build", progress))
+		p.Daemon.SetProgress(daemontypes.JSONProgress("build", progress))
 
 		if asset.Inline != nil {
 			asset.Inline.Dest = filepath.Join(constants.InstallerPrefixPath, asset.Inline.Dest)
@@ -289,9 +289,9 @@ func (p *CLIPlanner) watchProgress(ch chan interface{}, debug log.Logger) error 
 			// continue reading on error to ensure channel is not blocked
 			saveError = v
 		case images.Progress:
-			p.Daemon.SetProgress(daemon.JSONProgress("docker", v))
+			p.Daemon.SetProgress(daemontypes.JSONProgress("docker", v))
 		case string:
-			p.Daemon.SetProgress(daemon.StringProgress("docker", v))
+			p.Daemon.SetProgress(daemontypes.StringProgress("docker", v))
 		default:
 			debug.Log("event", "progress", "message", fmt.Sprintf("%#v", v))
 		}

--- a/pkg/lifecycle/render/planner/planner.go
+++ b/pkg/lifecycle/render/planner/planner.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
 
-	"github.com/replicatedhq/ship/pkg/lifecycle/daemon"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 	"github.com/replicatedhq/ship/pkg/lifecycle/render/amazonElasticKubernetesService"
 	"github.com/replicatedhq/ship/pkg/lifecycle/render/docker"
 	"github.com/replicatedhq/ship/pkg/lifecycle/render/dockerlayer"
@@ -45,7 +45,7 @@ type Planner interface {
 
 	Confirm(Plan) (bool, error)
 	Execute(context.Context, Plan) error
-	WithDaemon(d daemon.Daemon) Planner
+	WithDaemon(d daemontypes.Daemon) Planner
 }
 
 // CLIPlanner is the default Planner
@@ -54,7 +54,7 @@ type CLIPlanner struct {
 	Fs             afero.Afero
 	UI             cli.Ui
 	Viper          *viper.Viper
-	Daemon         daemon.Daemon
+	Daemon         daemontypes.Daemon
 	BuilderBuilder *templates.BuilderBuilder
 
 	Inline      inline.Renderer
@@ -81,7 +81,7 @@ func NewPlanner(
 	tf terraform.Renderer,
 	webRenderer web.Renderer,
 	awseks amazonElasticKubernetesService.Renderer,
-	daemon daemon.Daemon,
+	daemon daemontypes.Daemon,
 ) Planner {
 	return &CLIPlanner{
 		Logger:         logger,
@@ -102,7 +102,7 @@ func NewPlanner(
 	}
 }
 
-func (p *CLIPlanner) WithDaemon(d daemon.Daemon) Planner {
+func (p *CLIPlanner) WithDaemon(d daemontypes.Daemon) Planner {
 	p.Daemon = d
 	return p
 }

--- a/pkg/lifecycle/render/render.go
+++ b/pkg/lifecycle/render/render.go
@@ -14,7 +14,7 @@ import (
 	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/constants"
 	"github.com/replicatedhq/ship/pkg/lifecycle"
-	"github.com/replicatedhq/ship/pkg/lifecycle/daemon"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 	"github.com/replicatedhq/ship/pkg/lifecycle/render/config"
 	"github.com/replicatedhq/ship/pkg/lifecycle/render/planner"
 	"github.com/replicatedhq/ship/pkg/state"
@@ -22,12 +22,12 @@ import (
 )
 
 var (
-	ProgressLoad    = daemon.StringProgress("render", "load")
-	ProgressResolve = daemon.StringProgress("render", "resolve")
-	ProgressBuild   = daemon.StringProgress("render", "build")
-	ProgressBackup  = daemon.StringProgress("render", "backup")
-	ProgressExecute = daemon.StringProgress("render", "execute")
-	ProgressCommit  = daemon.StringProgress("render", "commit")
+	ProgressLoad    = daemontypes.StringProgress("render", "load")
+	ProgressResolve = daemontypes.StringProgress("render", "resolve")
+	ProgressBuild   = daemontypes.StringProgress("render", "build")
+	ProgressBackup  = daemontypes.StringProgress("render", "backup")
+	ProgressExecute = daemontypes.StringProgress("render", "execute")
+	ProgressCommit  = daemontypes.StringProgress("render", "commit")
 )
 
 // A renderer takes a resolved spec, collects config values, and renders assets
@@ -38,7 +38,7 @@ type renderer struct {
 	StateManager   state.Manager
 	Fs             afero.Afero
 	UI             cli.Ui
-	Daemon         daemon.Daemon
+	Daemon         daemontypes.Daemon
 	Now            func() time.Time
 }
 
@@ -49,7 +49,7 @@ func NewRenderer(
 	stateManager state.Manager,
 	planner planner.Planner,
 	resolver config.Resolver,
-	daemon daemon.Daemon,
+	daemon daemontypes.Daemon,
 ) lifecycle.Renderer {
 	return &renderer{
 		Logger:         logger,
@@ -98,7 +98,7 @@ func (r *renderer) Execute(ctx context.Context, release *api.Release, step *api.
 	}
 
 	r.Daemon.SetProgress(ProgressExecute)
-	r.Daemon.SetStepName(ctx, daemon.StepNameConfirm)
+	r.Daemon.SetStepName(ctx, daemontypes.StepNameConfirm)
 	err = r.Planner.Execute(ctx, pln)
 	if err != nil {
 		return errors.Wrap(err, "execute plan")

--- a/pkg/lifecycle/render/render_test.go
+++ b/pkg/lifecycle/render/render_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/golang/mock/gomock"
 	"github.com/replicatedhq/ship/pkg/api"
-	"github.com/replicatedhq/ship/pkg/lifecycle/daemon"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 	"github.com/replicatedhq/ship/pkg/lifecycle/render/planner"
 	mockconfig "github.com/replicatedhq/ship/pkg/test-mocks/config"
 	mockdaemon "github.com/replicatedhq/ship/pkg/test-mocks/daemon"
@@ -73,7 +73,7 @@ func TestRender(t *testing.T) {
 			prog = mockDaemon.EXPECT().SetProgress(ProgressBuild).After(prog)
 			prog = mockDaemon.EXPECT().SetProgress(ProgressBackup).After(prog)
 			prog = mockDaemon.EXPECT().SetProgress(ProgressExecute).After(prog)
-			prog = mockDaemon.EXPECT().SetStepName(ctx, daemon.StepNameConfirm).After(prog)
+			prog = mockDaemon.EXPECT().SetStepName(ctx, daemontypes.StepNameConfirm).After(prog)
 			prog = mockDaemon.EXPECT().SetProgress(ProgressCommit).After(prog)
 			mockDaemon.EXPECT().ClearProgress().After(prog)
 

--- a/pkg/lifecycle/terraform/terraformer_test.go
+++ b/pkg/lifecycle/terraform/terraformer_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/replicatedhq/ship/pkg/api"
-	uidaemon "github.com/replicatedhq/ship/pkg/lifecycle/daemon"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 	"github.com/replicatedhq/ship/pkg/test-mocks/daemon"
 	mocktf "github.com/replicatedhq/ship/pkg/test-mocks/tfplan"
 	"github.com/replicatedhq/ship/pkg/testing/logger"
@@ -132,7 +132,7 @@ func TestTerraformer(t *testing.T) {
 					EXPECT().
 					PushStreamStep(gomock.Any(), gomock.Any())
 
-				msg := uidaemon.Message{
+				msg := daemontypes.Message{
 					Contents:    test.expectApplyOutput,
 					TrustedHTML: true,
 				}
@@ -234,27 +234,27 @@ func TestForkTerraformerApply(t *testing.T) {
 		},
 	}
 
-	msgs := make(chan uidaemon.Message, 10)
+	msgs := make(chan daemontypes.Message, 10)
 	output, err := ft.apply(msgs)
 	req.NoError(err)
 	req.Equal(output, `<div class="term-container">stdout1stderr1stdout2</div>`)
 
-	req.EqualValues(uidaemon.Message{
+	req.EqualValues(daemontypes.Message{
 		Contents:    `<div class="term-container">terraform apply</div>`,
 		TrustedHTML: true,
 	}, <-msgs)
 
-	req.EqualValues(uidaemon.Message{
+	req.EqualValues(daemontypes.Message{
 		Contents:    `<div class="term-container">stdout1</div>`,
 		TrustedHTML: true,
 	}, <-msgs)
 
-	req.EqualValues(uidaemon.Message{
+	req.EqualValues(daemontypes.Message{
 		Contents:    `<div class="term-container">stdout1stderr1</div>`,
 		TrustedHTML: true,
 	}, <-msgs)
 
-	req.EqualValues(uidaemon.Message{
+	req.EqualValues(daemontypes.Message{
 		Contents:    `<div class="term-container">stdout1stderr1stdout2</div>`,
 		TrustedHTML: true,
 	}, <-msgs)

--- a/pkg/lifecycle/terraform/tfplan/daemon_plan.go
+++ b/pkg/lifecycle/terraform/tfplan/daemon_plan.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/ship/pkg/api"
-	"github.com/replicatedhq/ship/pkg/lifecycle/daemon"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 )
 
 type PlanConfirmer interface {
@@ -22,7 +22,7 @@ type PlanConfirmer interface {
 
 func NewPlanner(
 	logger log.Logger,
-	daemon daemon.Daemon,
+	daemon daemontypes.Daemon,
 ) PlanConfirmer {
 	return &DaemonPlanner{
 		Logger: logger,
@@ -34,7 +34,7 @@ func NewPlanner(
 // to perform interactions with the end user
 type DaemonPlanner struct {
 	Logger log.Logger
-	Daemon daemon.Daemon
+	Daemon daemontypes.Daemon
 }
 
 // ConfirmPlan presents the plan to the user.
@@ -50,7 +50,7 @@ func (d *DaemonPlanner) ConfirmPlan(
 	daemonExitedChan := d.Daemon.EnsureStarted(ctx, &release)
 	d.Daemon.PushMessageStep(
 		ctx,
-		daemon.Message{Contents: formmatedTerraformPlan, TrustedHTML: true},
+		daemontypes.Message{Contents: formmatedTerraformPlan, TrustedHTML: true},
 		planActions(),
 	)
 
@@ -81,13 +81,13 @@ func (d *DaemonPlanner) awaitPlanResult(ctx context.Context, daemonExitedChan ch
 	}
 }
 
-func planActions() []daemon.Action {
-	return []daemon.Action{
+func planActions() []daemontypes.Action {
+	return []daemontypes.Action{
 		{
 			ButtonType:  "primary",
 			Text:        "Apply",
 			LoadingText: "Applying",
-			OnClick: daemon.ActionRequest{
+			OnClick: daemontypes.ActionRequest{
 				URI:    "/terraform/apply",
 				Method: "POST",
 			},
@@ -96,7 +96,7 @@ func planActions() []daemon.Action {
 			ButtonType:  "secondary-gray",
 			Text:        "Skip",
 			LoadingText: "Skipping",
-			OnClick: daemon.ActionRequest{
+			OnClick: daemontypes.ActionRequest{
 				URI:    "/terraform/skip",
 				Method: "POST",
 			},

--- a/pkg/ship/dig.go
+++ b/pkg/ship/dig.go
@@ -16,6 +16,7 @@ import (
 	"github.com/replicatedhq/ship/pkg/images"
 	"github.com/replicatedhq/ship/pkg/lifecycle"
 	"github.com/replicatedhq/ship/pkg/lifecycle/daemon"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/headless"
 	"github.com/replicatedhq/ship/pkg/lifecycle/helmIntro"
 	"github.com/replicatedhq/ship/pkg/lifecycle/kustomize"
 	"github.com/replicatedhq/ship/pkg/lifecycle/message"
@@ -68,7 +69,6 @@ func buildInjector() (*dig.Container, error) {
 
 		state.NewManager,
 		planner.NewPlanner,
-		render.NewRenderer,
 		specs.NewResolver,
 		specs.NewGraphqlClient,
 		specs.NewGithubClient,
@@ -143,35 +143,34 @@ func buildInjector() (*dig.Container, error) {
 // "headedless mode" is the standard execute-the-lifecycle-in-order mode of ship, that runs without UI or api server
 // and is generally intended for CI/automation
 func headlessProviders() []interface{} {
-	headlessProviders := []interface{}{
+	return []interface{}{
 		func(messenger message.CLIMessenger) lifecycle.Messenger { return &messenger },
-		daemon.NewHeadlessDaemon,
+		headless.NewHeadlessDaemon,
 		helmIntro.NewHelmIntro,
+		render.NewRenderer,
 	}
-	return headlessProviders
 }
 
 // "headed mode" is the standard execute-the-lifecycle-in-order mode of ship, where steps manipulate
 // the UI/API via a ShipDaemon implementing the daemon.Daemon interface
 func headedProviders() []interface{} {
-	headedProviders := []interface{}{
+	return []interface{}{
 		func(messenger message.DaemonMessenger) lifecycle.Messenger { return &messenger },
 		daemon.NewHeadedDaemon,
 		helmIntro.NewHelmIntro,
+		render.NewRenderer,
 	}
-	return headedProviders
 }
 
 // "navigable mode" provides a new, v2-ish version of ship that provides browser navigation back
 // and forth through the lifecycle, and uses runbook declarations of lifecycle dependencies to
 // control execution ordering and workflows
 func navigableProviders() []interface{} {
-	navigableProviders := []interface{}{
+	return []interface{}{
 		daemon.NewHeadedDaemon,
 		func(messenger message.DaemonlessMessenger) lifecycle.Messenger { return &messenger },
 		func(intro helmIntro.DaemonlessHelmIntro) lifecycle.HelmIntro { return &intro },
 	}
-	return navigableProviders
 }
 
 func Get() (*Ship, error) {

--- a/pkg/ship/ship.go
+++ b/pkg/ship/ship.go
@@ -17,7 +17,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/lifecycle"
-	"github.com/replicatedhq/ship/pkg/lifecycle/daemon"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 	"github.com/replicatedhq/ship/pkg/specs"
 	"github.com/replicatedhq/ship/pkg/state"
 	"github.com/replicatedhq/ship/pkg/version"
@@ -40,7 +40,7 @@ type Ship struct {
 	InstallationID string
 	PlanOnly       bool
 
-	Daemon   daemon.Daemon
+	Daemon   daemontypes.Daemon
 	Resolver *specs.Resolver
 	Runbook  string
 	Client   *specs.GraphQLClient
@@ -55,7 +55,7 @@ type Ship struct {
 func NewShip(
 	logger log.Logger,
 	v *viper.Viper,
-	daemon daemon.Daemon,
+	daemon daemontypes.Daemon,
 	resolver *specs.Resolver,
 	graphql *specs.GraphQLClient,
 	runner *lifecycle.Runner,

--- a/pkg/test-mocks/daemon/daemon.go
+++ b/pkg/test-mocks/daemon/daemon.go
@@ -5,12 +5,12 @@
 package daemon
 
 import (
-	context "context"
-	reflect "reflect"
+	"context"
+	"reflect"
 
-	gomock "github.com/golang/mock/gomock"
-	api "github.com/replicatedhq/ship/pkg/api"
-	daemon "github.com/replicatedhq/ship/pkg/lifecycle/daemon"
+	"github.com/golang/mock/gomock"
+	"github.com/replicatedhq/ship/pkg/api"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 )
 
 // MockDaemon is a mock of Daemon interface
@@ -127,7 +127,7 @@ func (mr *MockDaemonMockRecorder) MessageConfirmedChan() *gomock.Call {
 }
 
 // PushHelmIntroStep mocks base method
-func (m *MockDaemon) PushHelmIntroStep(arg0 context.Context, arg1 daemon.HelmIntro, arg2 []daemon.Action) {
+func (m *MockDaemon) PushHelmIntroStep(arg0 context.Context, arg1 daemontypes.HelmIntro, arg2 []daemontypes.Action) {
 	m.ctrl.Call(m, "PushHelmIntroStep", arg0, arg1, arg2)
 }
 
@@ -137,7 +137,7 @@ func (mr *MockDaemonMockRecorder) PushHelmIntroStep(arg0, arg1, arg2 interface{}
 }
 
 // PushHelmValuesStep mocks base method
-func (m *MockDaemon) PushHelmValuesStep(arg0 context.Context, arg1 daemon.HelmValues, arg2 []daemon.Action) {
+func (m *MockDaemon) PushHelmValuesStep(arg0 context.Context, arg1 daemontypes.HelmValues, arg2 []daemontypes.Action) {
 	m.ctrl.Call(m, "PushHelmValuesStep", arg0, arg1, arg2)
 }
 
@@ -147,7 +147,7 @@ func (mr *MockDaemonMockRecorder) PushHelmValuesStep(arg0, arg1, arg2 interface{
 }
 
 // PushKustomizeStep mocks base method
-func (m *MockDaemon) PushKustomizeStep(arg0 context.Context, arg1 daemon.Kustomize) {
+func (m *MockDaemon) PushKustomizeStep(arg0 context.Context, arg1 daemontypes.Kustomize) {
 	m.ctrl.Call(m, "PushKustomizeStep", arg0, arg1)
 }
 
@@ -157,7 +157,7 @@ func (mr *MockDaemonMockRecorder) PushKustomizeStep(arg0, arg1 interface{}) *gom
 }
 
 // PushMessageStep mocks base method
-func (m *MockDaemon) PushMessageStep(arg0 context.Context, arg1 daemon.Message, arg2 []daemon.Action) {
+func (m *MockDaemon) PushMessageStep(arg0 context.Context, arg1 daemontypes.Message, arg2 []daemontypes.Action) {
 	m.ctrl.Call(m, "PushMessageStep", arg0, arg1, arg2)
 }
 
@@ -167,7 +167,7 @@ func (mr *MockDaemonMockRecorder) PushMessageStep(arg0, arg1, arg2 interface{}) 
 }
 
 // PushRenderStep mocks base method
-func (m *MockDaemon) PushRenderStep(arg0 context.Context, arg1 daemon.Render) {
+func (m *MockDaemon) PushRenderStep(arg0 context.Context, arg1 daemontypes.Render) {
 	m.ctrl.Call(m, "PushRenderStep", arg0, arg1)
 }
 
@@ -177,7 +177,7 @@ func (mr *MockDaemonMockRecorder) PushRenderStep(arg0, arg1 interface{}) *gomock
 }
 
 // PushStreamStep mocks base method
-func (m *MockDaemon) PushStreamStep(arg0 context.Context, arg1 <-chan daemon.Message) {
+func (m *MockDaemon) PushStreamStep(arg0 context.Context, arg1 <-chan daemontypes.Message) {
 	m.ctrl.Call(m, "PushStreamStep", arg0, arg1)
 }
 
@@ -187,7 +187,7 @@ func (mr *MockDaemonMockRecorder) PushStreamStep(arg0, arg1 interface{}) *gomock
 }
 
 // SetProgress mocks base method
-func (m *MockDaemon) SetProgress(arg0 daemon.Progress) {
+func (m *MockDaemon) SetProgress(arg0 daemontypes.Progress) {
 	m.ctrl.Call(m, "SetProgress", arg0)
 }
 

--- a/pkg/test-mocks/planner/planner_mock.go
+++ b/pkg/test-mocks/planner/planner_mock.go
@@ -5,14 +5,14 @@
 package planner
 
 import (
-	context "context"
-	reflect "reflect"
+	"context"
+	"reflect"
 
-	gomock "github.com/golang/mock/gomock"
-	libyaml "github.com/replicatedhq/libyaml"
-	api "github.com/replicatedhq/ship/pkg/api"
-	daemon "github.com/replicatedhq/ship/pkg/lifecycle/daemon"
-	planner "github.com/replicatedhq/ship/pkg/lifecycle/render/planner"
+	"github.com/golang/mock/gomock"
+	"github.com/replicatedhq/libyaml"
+	"github.com/replicatedhq/ship/pkg/api"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
+	"github.com/replicatedhq/ship/pkg/lifecycle/render/planner"
 )
 
 // MockPlanner is a mock of Planner interface
@@ -77,7 +77,7 @@ func (mr *MockPlannerMockRecorder) Execute(arg0, arg1 interface{}) *gomock.Call 
 }
 
 // WithDaemon mocks base method
-func (m *MockPlanner) WithDaemon(arg0 daemon.Daemon) planner.Planner {
+func (m *MockPlanner) WithDaemon(arg0 daemontypes.Daemon) planner.Planner {
 	ret := m.ctrl.Call(m, "WithDaemon", arg0)
 	ret0, _ := ret[0].(planner.Planner)
 	return ret0


### PR DESCRIPTION
What I Did
------------

Move some types around to help avoid circular deps when building out nav.


How I Did it
------------

- move Daemon interface and and Message types to a new package daemontypes
- move headless daemon into headless package


How to verify it
------------

Make sure it still builds


Description for the Changelog
------------

none

:rowboat:










<!-- (thanks https://github.com/docker/docker for this template) -->