### PR TITLE
rename kubectl lifecycle step to kubectl_apply

### DIFF
--- a/hack/docs/mutations.json
+++ b/hack/docs/mutations.json
@@ -788,9 +788,9 @@
     "delete": ["github"]
   },
   {
-    "path": "properties.lifecycle.properties.v1.items.properties.kubectl",
+    "path": "properties.lifecycle.properties.v1.items.properties.kubectl_apply",
     "merge": {
-      "description": "A `kubectl` step will run `kubectl apply` with the provided file path and kubeconfig.",
+      "description": "A `kubectl_apply` step will run `kubectl apply` with the provided file path and kubeconfig.",
       "examples": [
         { "path": "config.yml" },
         {
@@ -806,13 +806,13 @@
     }
   },
   {
-    "path": "properties.lifecycle.properties.v1.items.properties.kubectl.properties.path",
+    "path": "properties.lifecycle.properties.v1.items.properties.kubectl_apply.properties.path",
     "merge": {
       "description": "the file to apply"
     }
   },
   {
-    "path": "properties.lifecycle.properties.v1.items.properties.kubectl.properties.kubeconfig",
+    "path": "properties.lifecycle.properties.v1.items.properties.kubectl_apply.properties.kubeconfig",
     "merge": {
       "description": "the kubeconfig file to use, overriding the system default"
     }
@@ -842,7 +842,7 @@
       "helmIntro",
       "helmValues",
       "config",
-      "kubectl.properties.StepShared"
+      "kubectl_apply.properties.StepShared"
     ]
   }
 ]

--- a/hack/docs/schema.json
+++ b/hack/docs/schema.json
@@ -690,8 +690,8 @@
           "items": {
             "type": "object",
             "properties": {
-              "kubectl": {
-                "description": "A `kubectl` step will run `kubectl apply` with the provided file path and kubeconfig.",
+              "kubectl_apply": {
+                "description": "A `kubectl_apply` step will run `kubectl apply` with the provided file path and kubeconfig.",
                 "examples": [
                   {
                     "path": "config.yml"

--- a/pkg/api/lifecycle.go
+++ b/pkg/api/lifecycle.go
@@ -16,7 +16,7 @@ type Step struct {
 	KustomizeDiff  *KustomizeDiff  `json:"kustomizeDiff,omitempty" yaml:"kustomizeDiff,omitempty" hcl:"kustomizeDiff,omitempty"`
 	HelmIntro      *HelmIntro      `json:"helmIntro,omitempty" yaml:"helmIntro,omitempty" hcl:"helmIntro,omitempty"`
 	HelmValues     *HelmValues     `json:"helmValues,omitempty" yaml:"helmValues,omitempty" hcl:"helmValues,omitempty"`
-	Kubectl        *Kubectl        `json:"kubectl,omitempty" yaml:"kubectl,omitempty" hcl:"kubectl,omitempty"`
+	KubectlApply   *KubectlApply   `json:"kubectl_apply,omitempty" yaml:"kubectl_apply,omitempty" hcl:"kubectl_apply,omitempty"`
 }
 
 type StepDetails interface {
@@ -143,12 +143,12 @@ func (c ConfigStep) ShortName() string {
 	return "config"
 }
 
-// Kubectl is a lifeycle step to execute `apply` for a kubeconfig asset
-type Kubectl struct {
+// KubectlApply is a lifeycle step to execute `apply` for a kubeconfig asset
+type KubectlApply struct {
 	StepShared StepShared `json:",inline" yaml:",inline" hcl:",inline"`
 	Path       string     `json:"path,omitempty" yaml:"path,omitempty" hcl:"path,omitempty"`
 	Kubeconfig string     `json:"kubeconfig,omitempty" yaml:"kubeconfig,omitempty" hcl:"kubeconfig,omitempty"`
 }
 
-func (k *Kubectl) Shared() *StepShared { return &k.StepShared }
-func (k *Kubectl) ShortName() string   { return "kubectl" }
+func (k *KubectlApply) Shared() *StepShared { return &k.StepShared }
+func (k *KubectlApply) ShortName() string   { return "kubectl" }

--- a/pkg/lifecycle/interfaces.go
+++ b/pkg/lifecycle/interfaces.go
@@ -37,6 +37,6 @@ type Kustomizer interface {
 	Execute(ctx context.Context, release api.Release, step api.Kustomize) error
 }
 
-type Kubectl interface {
-	Execute(ctx context.Context, release api.Release, step api.Kubectl) error
+type KubectlApply interface {
+	Execute(ctx context.Context, release api.Release, step api.KubectlApply) error
 }

--- a/pkg/lifecycle/kubectl/kubectl.go
+++ b/pkg/lifecycle/kubectl/kubectl.go
@@ -31,7 +31,7 @@ func NewKubectl(
 	logger log.Logger,
 	daemon daemontypes.Daemon,
 	viper *viper.Viper,
-) lifecycle.Kubectl {
+) lifecycle.KubectlApply {
 	return &ForkKubectl{
 		Logger: logger,
 		Daemon: daemon,
@@ -39,7 +39,7 @@ func NewKubectl(
 	}
 }
 
-func (k *ForkKubectl) Execute(ctx context.Context, release api.Release, step api.Kubectl) error {
+func (k *ForkKubectl) Execute(ctx context.Context, release api.Release, step api.KubectlApply) error {
 	builder := k.getBuilder(release.Metadata)
 	builtPath, _ := builder.String(step.Path)
 	builtKubePath, _ := builder.String(step.Kubeconfig)

--- a/pkg/lifecycle/step.go
+++ b/pkg/lifecycle/step.go
@@ -13,14 +13,14 @@ import (
 type StepExecutor struct {
 	dig.In
 
-	Logger      log.Logger
-	Messenger   Messenger
-	Renderer    Renderer
-	Terraformer Terraformer
-	HelmIntro   HelmIntro
-	HelmValues  HelmValues
-	Kubectl     Kubectl
-	Kustomizer  Kustomizer
+	Logger       log.Logger
+	Messenger    Messenger
+	Renderer     Renderer
+	Terraformer  Terraformer
+	HelmIntro    HelmIntro
+	HelmValues   HelmValues
+	KubectlApply KubectlApply
+	Kustomizer   Kustomizer
 }
 
 func (s *StepExecutor) Execute(ctx context.Context, release *api.Release, step *api.Step) error {
@@ -54,9 +54,9 @@ func (s *StepExecutor) Execute(ctx context.Context, release *api.Release, step *
 		debug.Log("event", "step.helmValues", "type", "helmValues")
 		err := s.HelmValues.Execute(ctx, release, step.HelmValues)
 		debug.Log("event", "step.complete", "type", "helmValues", "err", err)
-	} else if step.Kubectl != nil {
+	} else if step.KubectlApply != nil {
 		debug.Log("event", "step.resolve", "type", "kubectl")
-		err := s.Kubectl.Execute(ctx, *release, *step.Kubectl)
+		err := s.KubectlApply.Execute(ctx, *release, *step.KubectlApply)
 		debug.Log("event", "step.complete", "type", "kubectl", "err", err)
 	}
 


### PR DESCRIPTION
What I Did
------------
Renamed the `kubectl` lifecycle step to `kubectl_apply`

How I Did it
------------
`sed`
(not really)
Context aware refactor is nice

How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------
![image](https://user-images.githubusercontent.com/2318911/43854228-235b2e86-9af7-11e8-8105-fcf851ee441d.png)












<!-- (thanks https://github.com/docker/docker for this template) -->

