### PR TITLE
Inject version variables at build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,19 @@ UI = $(shell find web/dist -name "*.js")
 
 DOCKER_REPO ?= replicated
 
+VERSION_PACKAGE = github.com/replicatedhq/ship/pkg/version
+VERSION=`git describe --tags`
+GIT_SHA=`git rev-parse HEAD`
+DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
+
+define LDFLAGS
+-ldflags "\
+	-X ${VERSION_PACKAGE}.version=${VERSION} \
+	-X ${VERSION_PACKAGE}.gitSHA=${GIT_SHA} \
+	-X ${VERSION_PACKAGE}.buildTime=${DATE} \
+"
+endef
+
 .state/build-deps: hack/get_build_deps.sh
 	./hack/get_build_deps.sh
 	@mkdir -p .state/
@@ -190,6 +203,7 @@ _build: bin/ship
 
 bin/ship: $(SRC)
 	go build \
+		${LDFLAGS} \
 		-i \
 		-o bin/ship \
 		./cmd/ship


### PR DESCRIPTION
What I Did
------------
Inject variables through `ldflags` so `ship version` actually prints out version info.

How I Did it
------------
Update Makefile with necessary build flags to populate variables for `ship version` command

How to verify it
------------
Run `ship version` after building the Ship binary.

Description for the Changelog
------------
- Inject version variables at build time


Picture of a Boat (not required but encouraged)
------------
:boat:











<!-- (thanks https://github.com/docker/docker for this template) -->

