### PR TITLE
fix entrypoint for navigate-lifecycle, add clean shutdown to other ship tasks

### DIFF
--- a/pkg/lifecycle/daemon/daemon.go
+++ b/pkg/lifecycle/daemon/daemon.go
@@ -38,6 +38,10 @@ type ShipDaemon struct {
 	*V2Routes
 }
 
+func (d *ShipDaemon) AwaitShutdown() error {
+	return <-d.ExitChan
+}
+
 // "this is fine"
 func (d *ShipDaemon) EnsureStarted(ctx context.Context, release *api.Release) chan error {
 

--- a/pkg/lifecycle/daemon/daemontypes/types.go
+++ b/pkg/lifecycle/daemon/daemontypes/types.go
@@ -36,6 +36,7 @@ type Daemon interface {
 	TerraformConfirmedChan() chan bool
 	KustomizeSavedChan() chan interface{}
 	GetCurrentConfig() map[string]interface{}
+	AwaitShutdown() error
 }
 
 const StepNameMessage = "message"

--- a/pkg/lifecycle/daemon/headless/daemon.go
+++ b/pkg/lifecycle/daemon/headless/daemon.go
@@ -24,6 +24,10 @@ type HeadlessDaemon struct {
 	ResolvedConfig map[string]interface{}
 }
 
+func (d *HeadlessDaemon) AwaitShutdown() error {
+	return nil
+}
+
 func NewHeadlessDaemon(
 	ui cli.Ui,
 	logger log.Logger,

--- a/pkg/ship/kustomize.go
+++ b/pkg/ship/kustomize.go
@@ -80,6 +80,8 @@ func (s *Ship) Update(ctx context.Context) error {
 
 func (s *Ship) Watch(ctx context.Context) error {
 	debug := level.Debug(log.With(s.Logger, "method", "watch"))
+	ctx, cancelFunc := context.WithCancel(ctx)
+	defer s.Shutdown(cancelFunc)
 
 	for {
 		existingState, err := s.State.TryLoad()
@@ -118,6 +120,8 @@ func (s *Ship) Watch(ctx context.Context) error {
 
 func (s *Ship) Init(ctx context.Context) error {
 	debug := level.Debug(log.With(s.Logger, "method", "init"))
+	ctx, cancelFunc := context.WithCancel(ctx)
+	defer s.Shutdown(cancelFunc)
 
 	if s.Viper.GetString("raw") != "" {
 		release := s.fakeKustomizeRawRelease()

--- a/pkg/test-mocks/daemon/daemon.go
+++ b/pkg/test-mocks/daemon/daemon.go
@@ -46,6 +46,18 @@ func (mr *MockDaemonMockRecorder) AllStepsDone(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllStepsDone", reflect.TypeOf((*MockDaemon)(nil).AllStepsDone), arg0)
 }
 
+// AwaitShutdown mocks base method
+func (m *MockDaemon) AwaitShutdown() error {
+	ret := m.ctrl.Call(m, "AwaitShutdown")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AwaitShutdown indicates an expected call of AwaitShutdown
+func (mr *MockDaemonMockRecorder) AwaitShutdown() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AwaitShutdown", reflect.TypeOf((*MockDaemon)(nil).AwaitShutdown))
+}
+
 // CleanPreviousStep mocks base method
 func (m *MockDaemon) CleanPreviousStep() {
 	m.ctrl.Call(m, "CleanPreviousStep")


### PR DESCRIPTION
What I Did
------------

Add new entrypoint logic if we're in `navigate-lifecycle` mode, just start the daemon
and wait for it to shut down (nothing explicitly triggers this yet). Improve shutdown behavior.

How I Did it
------------

- add `AwaitShutdown` to `daemontypes.Daemon`
- add check for `navigate-lifecycle` feature flag, and if set then do that flow
- add `defer s.Shutdown` to the ship init entrypoints

How to verify it
------------

navigate-lifecycle works now


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->