### PR TITLE
Ship should show human readable messages when running in headless

### DIFF
--- a/pkg/lifecycle/daemon/headless/daemon.go
+++ b/pkg/lifecycle/daemon/headless/daemon.go
@@ -47,9 +47,6 @@ func (d *HeadlessDaemon) PushMessageStep(context.Context, daemontypes.Message, [
 func (d *HeadlessDaemon) PushRenderStep(context.Context, daemontypes.Render)                         {}
 
 func (d *HeadlessDaemon) KustomizeSavedChan() chan interface{} {
-	// TODO: Utilize daemon.SetProgress?
-	d.UI.Info("Generating installable application manifests")
-
 	ch := make(chan interface{}, 1)
 	level.Debug(d.Logger).Log("event", "kustomize.skip", "detail", "running in automation, not waiting for kustomize")
 	ch <- nil
@@ -176,7 +173,9 @@ func (d *HeadlessDaemon) HeadlessResolve(ctx context.Context, release *api.Relea
 }
 
 func (d *HeadlessDaemon) SetProgress(progress daemontypes.Progress) {
-	d.UI.Output(progress.Detail)
+	if progress.Type == "string" {
+		d.UI.Output(progress.Detail)
+	}
 }
 
 func (d *HeadlessDaemon) ClearProgress() {}

--- a/pkg/lifecycle/helmValues/helmValues.go
+++ b/pkg/lifecycle/helmValues/helmValues.go
@@ -49,6 +49,8 @@ func (h *helmValues) Execute(ctx context.Context, release *api.Release, step *ap
 		return errors.Wrap(err, "read file values.yaml")
 	}
 
+	h.Daemon.SetProgress(daemontypes.StringProgress("helmValues", "generating installable application manifests"))
+
 	h.Daemon.PushHelmValuesStep(ctx, daemontypes.HelmValues{
 		Values: string(bytes),
 	}, daemon.HelmValuesActions())

--- a/pkg/lifecycle/render/render_test.go
+++ b/pkg/lifecycle/render/render_test.go
@@ -68,13 +68,9 @@ func TestRender(t *testing.T) {
 				V:      viper.New(),
 			}
 
-			prog := mockDaemon.EXPECT().SetProgress(ProgressLoad)
-			prog = mockDaemon.EXPECT().SetProgress(ProgressResolve).After(prog)
-			prog = mockDaemon.EXPECT().SetProgress(ProgressBuild).After(prog)
-			prog = mockDaemon.EXPECT().SetProgress(ProgressBackup).After(prog)
-			prog = mockDaemon.EXPECT().SetProgress(ProgressExecute).After(prog)
+			prog := mockDaemon.EXPECT().SetProgress(ProgressRead)
+			prog = mockDaemon.EXPECT().SetProgress(ProgressRender).After(prog)
 			prog = mockDaemon.EXPECT().SetStepName(ctx, daemontypes.StepNameConfirm).After(prog)
-			prog = mockDaemon.EXPECT().SetProgress(ProgressCommit).After(prog)
 			mockDaemon.EXPECT().ClearProgress().After(prog)
 
 			renderer.StatusReceiver = mockDaemon

--- a/pkg/ship/kustomize.go
+++ b/pkg/ship/kustomize.go
@@ -13,6 +13,7 @@ import (
 	"github.com/replicatedhq/libyaml"
 	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/constants"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 	"github.com/replicatedhq/ship/pkg/state"
 )
 
@@ -56,8 +57,7 @@ func (s *Ship) Update(ctx context.Context) error {
 	// does a state file exist on disk?
 	existingState, err := s.State.TryLoad()
 
-	// TODO: Utilize daemon.SetProgress?
-	s.UI.Info("Loading state from " + constants.StatePath)
+	s.Daemon.SetProgress(daemontypes.StringProgress("kustomize", `loading state from `+constants.StatePath))
 
 	if _, noExistingState := existingState.(state.Empty); noExistingState {
 		debug.Log("event", "state.missing")
@@ -71,8 +71,7 @@ func (s *Ship) Update(ctx context.Context) error {
 	}
 
 	debug.Log("event", "fetch latest chart")
-	// TODO: Utilize daemon.SetProgress?
-	s.UI.Info("Downloading latest from upstream " + helmChartPath)
+	s.Daemon.SetProgress(daemontypes.StringProgress("kustomize", `downloading latest from upstream `+helmChartPath))
 	helmChartMetadata, err := s.Resolver.ResolveChartMetadata(context.Background(), string(helmChartPath))
 	if err != nil {
 		return errors.Wrapf(err, "resolve helm chart metadata for %s", helmChartPath)


### PR DESCRIPTION
What I Did
------------
Ship headless now prints human-readable progress messages!

Changed the behavior from this
```
$ ship update
load
resolve
build
{"step_number":0,"total_steps":1}
backup
execute
commit
```

to this
```
$ ship update
loading state from .ship/state.json
downloading latest from upstream (<chart url>)
generating installable application manifests
reading application release
rendering assets and configuration values
```

How I Did it
------------
- `kustomize.go`: added relevant `ship update` `kustomize` progress messages

- `render.go`: cleaned up `render` progress messages. concatenated critical messages into human readable format and created debug logs for the remaining messages


How to verify it
------------
run `ship update` to see the progress messages printed

Related to Issue #266

Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------
🛥 











<!-- (thanks https://github.com/docker/docker for this template) -->

