### PR TITLE
change web/.state/build_ship deps to include src files properly

### DIFF
--- a/web/Makefile
+++ b/web/Makefile
@@ -21,7 +21,7 @@ serve_config:
 serve_ship:
 	`yarn bin`/webpack-dev-server --config webpack.config.js --progress -w --debug --env shipDev --mode development
 
-.state/build_ship: .state/package $(SRC)
+.state/build_ship: .state/package webpack* postcss* $(shell find src -type f)
 	rm -rf dist
 	`yarn bin`/webpack --config webpack.config.js --env ship --mode production
 	@mkdir -p .state


### PR DESCRIPTION
What I Did
------------
Fixed the build deps for web's `build_ship` so that it gets rebuilt when source files change

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------


![image](https://user-images.githubusercontent.com/2318911/43916123-8ea00840-9bc1-11e8-932e-c8e0a4f32066.png)










<!-- (thanks https://github.com/docker/docker for this template) -->

