### PR TITLE
application resource type flag

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -38,8 +38,8 @@ func RootCmd() *cobra.Command {
 	cmd.PersistentFlags().IntP("api-port", "p", 8800, "port to start the API server on.")
 	cmd.PersistentFlags().BoolP("headless", "", false, "run ship in headless mode")
 	cmd.PersistentFlags().Bool("no-open", false, "skip opening the ship console in the default browser--does not disable the UI, has no effect if `headless` is set to true.")
-
 	cmd.PersistentFlags().String("state-file", "", "path to the state file to read from, defaults to .ship/state.json")
+	cmd.PersistentFlags().String("resource-type", "", "upstream application resource type")
 
 	cmd.AddCommand(Init())
 	cmd.AddCommand(Watch())


### PR DESCRIPTION
What I Did
------------
Support for the `ship` flag `resource-type`, which allows the user to specify the upstream application resource type (k8s, helm, ...)

Not functional yet (no associated logic)

How I Did it
------------
`root.go`: added a persistent flag to the `ship` root command


How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------
⛵️ 











<!-- (thanks https://github.com/docker/docker for this template) -->

