### PR TITLE
dont build dev UI in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
       - setup_remote_docker
       - attach_workspace:
           at: /go/src/github.com/replicatedhq/ship/web
-      - run: make build-deps embed-ui
+      - run: make build-deps ci-embed-ui
       - run: git diff pkg/lifecycle/daemon/ui.bindatafs.go | cat
       - run: docker pull alpine:latest # make sure it's fresh
       - deploy:
@@ -146,7 +146,7 @@ jobs:
       - setup_remote_docker
       - attach_workspace:
           at: /go/src/github.com/replicatedhq/ship/web
-      - run: make build-deps embed-ui
+      - run: make build-deps ci-embed-ui
       - run: git diff pkg/lifecycle/daemon/ui.bindatafs.go | cat
       - run: docker pull alpine:latest # make sure it's fresh
       - run: docker login -u="$DOCKERHUB_DOCKER_USER" -p="$DOCKERHUB_DOCKER_PASS"

--- a/Makefile
+++ b/Makefile
@@ -251,6 +251,7 @@ mark-ui-gitignored:
 embed-ui: mark-ui-gitignored build-ui-dev pkg/lifeycle/daemon/ui.bindatafs.go
 
 
+ci-embed-ui: mark-ui-gitignored pkg/lifeycle/daemon/ui.bindatafs.go
 build-ui:
 	$(MAKE) -C web build_ship
 


### PR DESCRIPTION
What I Did
------------

fix circle build

How I Did it
------------

use new `ci-embed-ui` task that doesn't depend on `build-ui-dev`

How to verify it
------------

ensure circle `deploy_unstable` job passes


:passenger_ship: 










<!-- (thanks https://github.com/docker/docker for this template) -->

