### PR TITLE
add helmintro actions to navcycle responses

### DIFF
--- a/pkg/lifecycle/daemon/routes_v2_getstep_test.go
+++ b/pkg/lifecycle/daemon/routes_v2_getstep_test.go
@@ -286,6 +286,28 @@ func TestHydrateActions(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "helmintro",
+			step: daemontypes.NewStep(api.Step{
+				HelmIntro: &api.HelmIntro{
+					StepShared: api.StepShared{
+						ID: "yo",
+					},
+				},
+			}),
+			want: []daemontypes.Action{
+				{
+					ButtonType:  "primary",
+					Text:        "Get started",
+					LoadingText: "Confirming",
+					OnClick: daemontypes.ActionRequest{
+						URI:    "/api/v2/lifecycle/step/yo",
+						Method: "POST",
+						Body:   "",
+					},
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
What I Did
------------

add helmintro actions to navcycle responses

How I Did it
------------

- add check for helmintro, attach appropriate actions
- move check for progress up out of `if` blocks
- write a test

How to verify it
------------

```
NAVIGATE_LIFECYCLE=1 ship init <chart>
```

then curl the helm step

```
curl http://localhost:8800/api/v2/lifecycle/step/intro

```

get back something like

```
{
  "actions": [
    {
      "buttonType": "primary",
      "loadingText": "Confirming",
      "onclick": {
        "body": "",
        "method": "POST",
        "uri": "/api/v2/lifecycle/step/intro"
      },
      "text": "Get started"
    }
  ],
  "currentStep": {
    "helmIntro": {}
  },
  "phase": "helm-intro"
}
```

Note that `intro` will always be the step id for `ship init`, but it may vary in vendor yaml

Description for the Changelog
------------

None, still WIP

:passenger_ship: