### PR TITLE
add helm values actions, move routes all back to v1/

### DIFF
--- a/pkg/lifecycle/daemon/routes_v2.go
+++ b/pkg/lifecycle/daemon/routes_v2.go
@@ -31,10 +31,10 @@ type V2Routes struct {
 
 func (d *V2Routes) Register(group *gin.RouterGroup, release *api.Release) {
 	d.Release = release
-	v2 := group.Group("/api/v2")
-	v2.GET("/lifecycle", d.getLifecycle)
-	v2.GET("/lifecycle/step/:step", d.getStep)
-	v2.POST("/lifecycle/step/:step", d.completeStep)
+	v2 := group.Group("/api/v1")
+	v2.GET("/navcycle", d.getLifecycle)
+	v2.GET("/navcycle/step/:step", d.getStep)
+	v2.POST("/navcycle/step/:step", d.completeStep)
 }
 
 // returns false if aborted

--- a/pkg/lifecycle/daemon/routes_v2_getstep.go
+++ b/pkg/lifecycle/daemon/routes_v2_getstep.go
@@ -109,7 +109,7 @@ func (d *V2Routes) getActions(step daemontypes.Step) []daemontypes.Action {
 				Text:        "Confirm",
 				LoadingText: "Confirming",
 				OnClick: daemontypes.ActionRequest{
-					URI:    fmt.Sprintf("/api/v2/lifecycle/step/%s", step.Source.Shared().ID),
+					URI:    fmt.Sprintf("/navcycle/step/%s", step.Source.Shared().ID),
 					Method: "POST",
 					Body:   "",
 				},
@@ -122,7 +122,30 @@ func (d *V2Routes) getActions(step daemontypes.Step) []daemontypes.Action {
 				Text:        "Get started",
 				LoadingText: "Confirming",
 				OnClick: daemontypes.ActionRequest{
-					URI:    fmt.Sprintf("/api/v2/lifecycle/step/%s", step.Source.Shared().ID),
+					URI:    fmt.Sprintf("/navcycle/step/%s", step.Source.Shared().ID),
+					Method: "POST",
+					Body:   "",
+				},
+			},
+		}
+	} else if step.HelmValues != nil {
+		return []daemontypes.Action{
+			{
+				ButtonType:  "primary",
+				Text:        "Saving",
+				LoadingText: "Save",
+				OnClick: daemontypes.ActionRequest{
+					URI:    fmt.Sprintf("/helm-values"),
+					Method: "POST",
+					Body:   "",
+				},
+			},
+			{
+				ButtonType:  "popover",
+				Text:        "Save & Continue",
+				LoadingText: "Saving",
+				OnClick: daemontypes.ActionRequest{
+					URI:    fmt.Sprintf("/navcycle/step/%s", step.Source.Shared().ID),
 					Method: "POST",
 					Body:   "",
 				},


### PR DESCRIPTION
What I Did
------------

Add some helm values actions, move routes around

How I Did it
------------

see above

How to verify it
------------

```
curl -sSL localhost:8800/api/v1/navcycle/step/values | jq .
```

```json
{
  "actions": [
    {
      "buttonType": "primary",
      "loadingText": "Save",
      "onclick": {
        "body": "",
        "method": "POST",
        "uri": "/helm-values"
      },
      "text": "saving"
    },
    {
      "buttonType": "popover",
      "loadingText": "sorry grayson",
      "onclick": {
        "body": "",
        "method": "POST",
        "uri": "/navcycle/step/values"
      },
      "text": "Save & Continue"
    }
  ],
  "currentStep": {
    "helmValues": {
      "values": ""
    }
  },
  "phase": "helm-values"
}
```

Description for the Changelog
------------

None

:canoe: