### PR TITLE
fix tree loader test on osx, pipefail during make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build-deps dep-deps docker shell githooks dep e2e run citest ci-upload-coverage goreleaser integration-test build_ship_integration_test build-ui mark-ui-gitignored fmt lint vet test build embed-ui
 
 
-SHELL := /bin/bash
+SHELL := /bin/bash -o pipefail
 SRC = $(shell find . -name "*.go" ! -name "ui.bindatafs.go")
 FULLSRC = $(shell find . -name "*.go")
 UI = $(shell find web/dist -name "*.js")

--- a/pkg/filetree/test-cases/tests.yml
+++ b/pkg/filetree/test-cases/tests.yml
@@ -21,7 +21,7 @@
   touch:
     - foo.txt
   read: foo.txt
-  expectErr: 'read dir "foo.txt": readdirent: not a directory'
+  expectErr: 'read dir "foo.txt": readdirent:'
 
 
 - name: read single file


### PR DESCRIPTION
What I Did
------------

Fix the test that was failing on osx because "readdir on a file" gives different error messages in BSD vs. Linux. 

Ensure a failure in the tests causes `make build` to fail. Previously failing `test` or `vet` still built the binary.

How I Did it
------------

- Make expected error message in `TestAferoLoader` less specific (the test compiles `expectErr` as a regex.
- Use `-o pipefail` for make tasks, since the piping `go test` results to `grep` was causing the tests to fail silently.


How to verify it
------------

- `make test` on macOS, ensure tests pass
- break a test and `make build`, ensure no `bin/ship` gets built


Description for the Changelog
------------

Fix a test that would only fail on macOS/BSD


![](https://upload.wikimedia.org/wikipedia/commons/9/9c/Titanic_wreck_bow.jpg)











<!-- (thanks https://github.com/docker/docker for this template) -->