### PR TITLE
first steps for breaking out config/render

### DIFF
--- a/deploy/e2e.yml
+++ b/deploy/e2e.yml
@@ -10,6 +10,7 @@
            mode: 0777
     lifecycle:
       v1:
+        - config: {}
         - render: {}
   expect:
     ./uninstall.sh: |

--- a/fixtures/app.yml
+++ b/fixtures/app.yml
@@ -45,6 +45,7 @@ lifecycle:
       contents: |
         This tool will prepare assets so you can deploy Cooltool-Enterpise
         to your existing Kubernetes cluster
+  - config: {}
   - render:
       id: render
   - message:

--- a/fixtures/dockerlayer/packages.yml
+++ b/fixtures/dockerlayer/packages.yml
@@ -10,4 +10,5 @@ assets:
 
 lifecycle:
   v1:
+  - config: {}
   - render: {}

--- a/fixtures/helm/github.yml
+++ b/fixtures/helm/github.yml
@@ -26,4 +26,5 @@ config:
 
 lifecycle:
   v1:
+    - config: {}
     - render: {}

--- a/fixtures/helm/nginx.yml
+++ b/fixtures/helm/nginx.yml
@@ -206,4 +206,5 @@ assets:
 
 lifecycle:
   v1:
+  - config: {}
   - render: {}

--- a/fixtures/kustomize/ship.yml
+++ b/fixtures/kustomize/ship.yml
@@ -24,6 +24,7 @@ lifecycle:
   v1:
     - helmIntro: {}
     - helmValues: {}
+    - config: {}
     - render: {}
     - kustomize:
         base_path: charts/templates/

--- a/fixtures/support-bundle/ship.yml
+++ b/fixtures/support-bundle/ship.yml
@@ -41,4 +41,5 @@ assets:
                       - infinity
 lifecycle:
   v1:
+    - config: {}
     - render: {}

--- a/fixtures/terraform/ship.yml
+++ b/fixtures/terraform/ship.yml
@@ -70,6 +70,7 @@ lifecycle:
   v1:
     - message:
        contents: "hi"
+    - config: {}
     - render: {}
 #    - terraform: {}
     - message:

--- a/hack/docs/mutations.json
+++ b/hack/docs/mutations.json
@@ -780,7 +780,7 @@
   {
     "path": "properties.lifecycle.properties.v1.items.properties.terraform.properties.path",
     "merge": {
-      "description": "the directory within `installer` to run terraform within."
+      "description": "the directory within `installer` within which to run terraform."
     }
   },
   {
@@ -829,19 +829,27 @@
     }
   },
 
+  {
+    "path": "properties.lifecycle.properties.v1.items.properties.config",
+    "merge": {
+      "description": "A `config` step will present the user with a screen to customize options as defined in your top-level `config` section",
+      "examples": [
+        {}
+      ]
+    },
+    "replace": {
+      "required": []
+    }
+  },
   { "comment": "last step -- delete internal spec types"},
+
   {
     "path": "properties.lifecycle.properties.v1.items.properties",
     "delete": [
-      "message.properties.StepShared",
-      "render.properties.StepShared",
-      "terraform.properties.StepShared",
-      "kustomize.properties.StepShared",
       "kustomizeIntro",
       "kustomizeDiff",
       "helmIntro",
       "helmValues",
-      "config",
       "kubectl_apply.properties.StepShared"
     ]
   }

--- a/hack/docs/schema.json
+++ b/hack/docs/schema.json
@@ -690,6 +690,34 @@
           "items": {
             "type": "object",
             "properties": {
+              "config": {
+                "description": "A `config` step will present the user with a screen to customize options as defined in your top-level `config` section",
+                "examples": [
+                  {}
+                ],
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "invalidates": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "requires": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": []
+              },
               "kubectl_apply": {
                 "description": "A `kubectl_apply` step will run `kubectl apply` with the provided file path and kubeconfig.",
                 "examples": [
@@ -703,6 +731,18 @@
                 ],
                 "type": "object",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "invalidates": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
                   "kubeconfig": {
                     "description": "the kubeconfig file to use, overriding the system default",
                     "type": "string"
@@ -710,6 +750,12 @@
                   "path": {
                     "description": "the file to apply",
                     "type": "string"
+                  },
+                  "requires": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
                   }
                 },
                 "required": [
@@ -724,8 +770,26 @@
                   "base_path": {
                     "type": "string"
                   },
+                  "description": {
+                    "type": "string"
+                  },
                   "dest": {
                     "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "invalidates": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "requires": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
                   }
                 },
                 "required": []
@@ -747,9 +811,27 @@
                     "description": "the message to display",
                     "type": "string"
                   },
+                  "description": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "invalidates": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
                   "level": {
                     "description": "the severity of the message -- defaults to `info`. Other options are `debug`, `warn`, and `error`",
                     "type": "string"
+                  },
+                  "requires": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
                   }
                 },
                 "required": [
@@ -762,7 +844,26 @@
                   {}
                 ],
                 "type": "object",
-                "properties": {},
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "invalidates": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "requires": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
                 "required": []
               },
               "terraform": {
@@ -775,9 +876,27 @@
                 ],
                 "type": "object",
                 "properties": {
-                  "path": {
-                    "description": "the directory within `installer` to run terraform within.",
+                  "description": {
                     "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "invalidates": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "path": {
+                    "description": "the directory within `installer` within which to run terraform.",
+                    "type": "string"
+                  },
+                  "requires": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
                   }
                 },
                 "required": []

--- a/hack/get_build_deps.sh
+++ b/hack/get_build_deps.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -v
 go get -u github.com/golang/lint/golint
 go get golang.org/x/tools/cmd/goimports
 go get github.com/elazarl/go-bindata-assetfs/...

--- a/pkg/api/lifecycle.go
+++ b/pkg/api/lifecycle.go
@@ -59,9 +59,9 @@ type StepShared struct {
 
 // Message is a lifeycle step to print a message
 type Message struct {
-	StepShared StepShared `json:",inline" yaml:",inline" hcl:",inline"`
-	Contents   string     `json:"contents" yaml:"contents" hcl:"contents"`
-	Level      string     `json:"level,omitempty" yaml:"level,omitempty" hcl:"level,omitempty"`
+	StepShared `json:",inline" yaml:",inline" hcl:",inline"`
+	Contents   string `json:"contents" yaml:"contents" hcl:"contents"`
+	Level      string `json:"level,omitempty" yaml:"level,omitempty" hcl:"level,omitempty"`
 }
 
 func (m *Message) Shared() *StepShared { return &m.StepShared }
@@ -69,7 +69,7 @@ func (m *Message) ShortName() string   { return "message" }
 
 // Render is a lifeycle step to collect config and render assets
 type Render struct {
-	StepShared StepShared `json:",inline" yaml:",inline" hcl:",inline"`
+	StepShared `json:",inline" yaml:",inline" hcl:",inline"`
 }
 
 func (r *Render) Shared() *StepShared { return &r.StepShared }
@@ -78,8 +78,8 @@ func (r *Render) ShortName() string { return "render" }
 
 // Terraform is a lifeycle step to execute `apply` for a runbook's terraform asset
 type Terraform struct {
-	StepShared StepShared `json:",inline" yaml:",inline" hcl:",inline"`
-	Path       string     `json:"path,omitempty" yaml:"path,omitempty" hcl:"path,omitempty"`
+	StepShared `json:",inline" yaml:",inline" hcl:",inline"`
+	Path       string `json:"path,omitempty" yaml:"path,omitempty" hcl:"path,omitempty"`
 }
 
 func (t *Terraform) Shared() *StepShared { return &t.StepShared }
@@ -88,9 +88,9 @@ func (t *Terraform) ShortName() string   { return "terraform" }
 // Kustomize is a lifeycle step to generate overlays for generated assets.
 // It does not take a kustomization.yml, rather it will generate one in the .ship/ folder
 type Kustomize struct {
-	StepShared StepShared `json:",inline" yaml:",inline" hcl:",inline"`
-	BasePath   string     `json:"base_path,omitempty" yaml:"base_path,omitempty" hcl:"base_path,omitempty"`
-	Dest       string     `json:"dest,omitempty" yaml:"dest,omitempty" hcl:"dest,omitempty"`
+	StepShared `json:",inline" yaml:",inline" hcl:",inline"`
+	BasePath   string `json:"base_path,omitempty" yaml:"base_path,omitempty" hcl:"base_path,omitempty"`
+	Dest       string `json:"dest,omitempty" yaml:"dest,omitempty" hcl:"dest,omitempty"`
 }
 
 func (k *Kustomize) Shared() *StepShared { return &k.StepShared }
@@ -98,7 +98,7 @@ func (k *Kustomize) ShortName() string   { return "kustomize" }
 
 // KustomizeIntro is a lifeycle step to display an informative intro page for kustomize
 type KustomizeIntro struct {
-	StepShared StepShared `json:",inline" yaml:",inline" hcl:",inline"`
+	StepShared `json:",inline" yaml:",inline" hcl:",inline"`
 }
 
 func (k *KustomizeIntro) Shared() *StepShared { return &k.StepShared }
@@ -106,9 +106,9 @@ func (k *KustomizeIntro) ShortName() string   { return "kustomize-intro" }
 
 // KustomizeDiff is a lifecycle step to display the diff of kustomized assets
 type KustomizeDiff struct {
-	StepShared StepShared `json:",inline" yaml:",inline" hcl:",inline"`
-	BasePath   string     `json:"base_path,omitempty" yaml:"base_path,omitempty" hcl:"base_path,omitempty"`
-	Dest       string     `json:"dest,omitempty" yaml:"dest,omitempty" hcl:"dest,omitempty"`
+	StepShared `json:",inline" yaml:",inline" hcl:",inline"`
+	BasePath   string `json:"base_path,omitempty" yaml:"base_path,omitempty" hcl:"base_path,omitempty"`
+	Dest       string `json:"dest,omitempty" yaml:"dest,omitempty" hcl:"dest,omitempty"`
 }
 
 func (k *KustomizeDiff) Shared() *StepShared { return &k.StepShared }
@@ -116,7 +116,7 @@ func (k *KustomizeDiff) ShortName() string   { return "kustomize-diff" }
 
 // HelmIntro is a lifecycle step to render persisted README.md in the .ship folder
 type HelmIntro struct {
-	StepShared StepShared `json:",inline" yaml:",inline" hcl:",inline"`
+	StepShared `json:",inline" yaml:",inline" hcl:",inline"`
 }
 
 func (h *HelmIntro) Shared() *StepShared { return &h.StepShared }
@@ -125,14 +125,14 @@ func (h *HelmIntro) ShortName() string   { return "helm-intro" }
 // HelmValues is a lifecycle step to render persisted values.yaml in the .ship folder
 // and save user input changes to values.yaml
 type HelmValues struct {
-	StepShared StepShared `json:",inline" yaml:",inline" hcl:",inline"`
+	StepShared `json:",inline" yaml:",inline" hcl:",inline"`
 }
 
 func (h *HelmValues) Shared() *StepShared { return &h.StepShared }
 func (h *HelmValues) ShortName() string   { return "helm-values" }
 
 type ConfigStep struct {
-	StepShared StepShared `json:",inline" yaml:",inline" hcl:",inline"`
+	StepShared `json:",inline" yaml:",inline" hcl:",inline"`
 }
 
 func (c *ConfigStep) Shared() *StepShared {
@@ -145,9 +145,9 @@ func (c ConfigStep) ShortName() string {
 
 // KubectlApply is a lifeycle step to execute `apply` for a kubeconfig asset
 type KubectlApply struct {
-	StepShared StepShared `json:",inline" yaml:",inline" hcl:",inline"`
-	Path       string     `json:"path,omitempty" yaml:"path,omitempty" hcl:"path,omitempty"`
-	Kubeconfig string     `json:"kubeconfig,omitempty" yaml:"kubeconfig,omitempty" hcl:"kubeconfig,omitempty"`
+	StepShared `json:",inline" yaml:",inline" hcl:",inline"`
+	Path       string `json:"path,omitempty" yaml:"path,omitempty" hcl:"path,omitempty"`
+	Kubeconfig string `json:"kubeconfig,omitempty" yaml:"kubeconfig,omitempty" hcl:"kubeconfig,omitempty"`
 }
 
 func (k *KubectlApply) Shared() *StepShared { return &k.StepShared }

--- a/pkg/filetree/test-cases/tests.yml
+++ b/pkg/filetree/test-cases/tests.yml
@@ -23,7 +23,6 @@
   read: foo.txt
   expectErr: 'read dir "foo.txt": readdirent: not a directory'
 
-
 - name: read single file
   touch:
     - foo.txt

--- a/pkg/lifecycle/daemon/constructors.go
+++ b/pkg/lifecycle/daemon/constructors.go
@@ -18,8 +18,8 @@ import (
 
 type OptionalRoutes struct {
 	dig.In
-	V2Router *V2Routes `optional:"true"`
-	V1Router *V1Routes `optional:"true"`
+	V2Router *NavcycleRoutes `optional:"true"`
+	V1Router *V1Routes       `optional:"true"`
 }
 
 func NewHeadedDaemon(
@@ -29,12 +29,12 @@ func NewHeadedDaemon(
 	routes OptionalRoutes,
 ) daemontypes.Daemon {
 	return &ShipDaemon{
-		Logger:       log.With(logger, "struct", "daemon"),
-		WebUIFactory: webUIFactory,
-		Viper:        v,
-		ExitChan:     make(chan error),
-		V1Routes:     routes.V1Router,
-		V2Routes:     routes.V2Router,
+		Logger:         log.With(logger, "struct", "daemon"),
+		WebUIFactory:   webUIFactory,
+		Viper:          v,
+		ExitChan:       make(chan error),
+		V1Routes:       routes.V1Router,
+		NavcycleRoutes: routes.V2Router,
 	}
 }
 
@@ -45,8 +45,8 @@ func NewV2Router(
 	helmIntro lifecycle.HelmIntro,
 	planners planner.Planner,
 	renderer lifecycle.Renderer,
-) *V2Routes {
-	return &V2Routes{
+) *NavcycleRoutes {
+	return &NavcycleRoutes{
 		Logger:       logger,
 		StateManager: stateManager,
 		Planner:      planners,
@@ -54,7 +54,7 @@ func NewV2Router(
 		Messenger: messenger,
 		HelmIntro: helmIntro,
 		Renderer:  renderer,
-		StepExecutor: func(d *V2Routes, step api.Step) error {
+		StepExecutor: func(d *NavcycleRoutes, step api.Step) error {
 			return d.execute(step)
 		},
 		StepProgress: &daemontypes.ProgressMap{},

--- a/pkg/lifecycle/daemon/daemon.go
+++ b/pkg/lifecycle/daemon/daemon.go
@@ -35,7 +35,7 @@ type ShipDaemon struct {
 	StartOnce sync.Once
 
 	*V1Routes
-	*V2Routes
+	*NavcycleRoutes
 }
 
 func (d *ShipDaemon) AwaitShutdown() error {
@@ -121,8 +121,8 @@ func (d *ShipDaemon) configureRoutes(g *gin.Engine, release *api.Release) {
 		d.V1Routes.Register(root, release)
 	}
 
-	if d.V2Routes != nil {
-		d.V2Routes.Register(root, release)
+	if d.NavcycleRoutes != nil {
+		d.NavcycleRoutes.Register(root, release)
 	}
 }
 

--- a/pkg/lifecycle/daemon/daemon_test.go
+++ b/pkg/lifecycle/daemon/daemon_test.go
@@ -30,7 +30,7 @@ type daemonAPITestCase struct {
 func initTestDaemon(
 	t *testing.T,
 	release *api.Release,
-	v2 *V2Routes,
+	v2 *NavcycleRoutes,
 ) (*ShipDaemon, int, context.CancelFunc, error) {
 	v := viper.New()
 
@@ -49,11 +49,11 @@ func initTestDaemon(
 	}
 
 	daemon := &ShipDaemon{
-		Logger:       log,
-		WebUIFactory: WebUIFactoryFactory(log),
-		Viper:        v,
-		V1Routes:     v1,
-		V2Routes:     v2,
+		Logger:         log,
+		WebUIFactory:   WebUIFactoryFactory(log),
+		Viper:          v,
+		V1Routes:       v1,
+		NavcycleRoutes: v2,
 	}
 
 	daemonCtx, daemonCancelFunc := context.WithCancel(context.Background())

--- a/pkg/lifecycle/daemon/routes_navcycle.go
+++ b/pkg/lifecycle/daemon/routes_navcycle.go
@@ -13,7 +13,8 @@ import (
 	"github.com/replicatedhq/ship/pkg/state"
 )
 
-type V2Routes struct {
+// NavcycleRoutes provide workflow execution with standard browser navigation
+type NavcycleRoutes struct {
 	Logger       log.Logger
 	TreeLoader   filetree.Loader
 	StateManager state.Manager
@@ -29,16 +30,17 @@ type V2Routes struct {
 	Release *api.Release
 }
 
-func (d *V2Routes) Register(group *gin.RouterGroup, release *api.Release) {
+// Register registers routes
+func (d *NavcycleRoutes) Register(group *gin.RouterGroup, release *api.Release) {
 	d.Release = release
-	v2 := group.Group("/api/v1")
-	v2.GET("/navcycle", d.getLifecycle)
-	v2.GET("/navcycle/step/:step", d.getStep)
-	v2.POST("/navcycle/step/:step", d.completeStep)
+	v1 := group.Group("/api/v1")
+	v1.GET("/navcycle", d.getNavcycle)
+	v1.GET("/navcycle/step/:step", d.getStep)
+	v1.POST("/navcycle/step/:step", d.completeStep)
 }
 
 // returns false if aborted
-func (d *V2Routes) maybeAbortDueToMissingRequirement(requires []string, c *gin.Context, requestedStepID string) (ok bool) {
+func (d *NavcycleRoutes) maybeAbortDueToMissingRequirement(requires []string, c *gin.Context, requestedStepID string) (ok bool) {
 	required, err := d.getRequiredButIncompleteStepFor(requires)
 	if err != nil {
 		c.AbortWithError(500, errors.Wrapf(err, "check requirements for step %s", requestedStepID))
@@ -54,7 +56,7 @@ func (d *V2Routes) maybeAbortDueToMissingRequirement(requires []string, c *gin.C
 // this will return an incomplete step that is present in the list of required steps.
 // if there are multiple required but incomplete steps, this will return the first one,
 // although from a UI perspective the order is probably not strictly defined
-func (d *V2Routes) getRequiredButIncompleteStepFor(requires []string) (string, error) {
+func (d *NavcycleRoutes) getRequiredButIncompleteStepFor(requires []string) (string, error) {
 	debug := level.Debug(log.With(d.Logger, "method", "getRequiredButIncompleteStepFor"))
 
 	stepsCompleted := map[string]interface{}{}
@@ -79,7 +81,7 @@ func (d *V2Routes) getRequiredButIncompleteStepFor(requires []string) (string, e
 	return "", nil
 }
 
-func (d *V2Routes) hydrateAndSend(step daemontypes.Step, c *gin.Context) {
+func (d *NavcycleRoutes) hydrateAndSend(step daemontypes.Step, c *gin.Context) {
 	result, err := d.hydrateStep(step, true)
 	if err != nil {
 		c.AbortWithError(500, err)
@@ -88,7 +90,7 @@ func (d *V2Routes) hydrateAndSend(step daemontypes.Step, c *gin.Context) {
 	c.JSON(200, result)
 }
 
-func (d *V2Routes) errRequired(required string, c *gin.Context) {
+func (d *NavcycleRoutes) errRequired(required string, c *gin.Context) {
 	c.JSON(400, map[string]interface{}{
 		"currentStep": map[string]interface{}{
 			"requirementNotMet": map[string]interface{}{
@@ -99,7 +101,7 @@ func (d *V2Routes) errRequired(required string, c *gin.Context) {
 	})
 }
 
-func (d *V2Routes) errNotFond(c *gin.Context) {
+func (d *NavcycleRoutes) errNotFond(c *gin.Context) {
 	c.JSON(404, map[string]interface{}{
 		"currentStep": map[string]interface{}{
 			"notFound": map[string]interface{}{},

--- a/pkg/lifecycle/daemon/routes_navcycle_completestep.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_completestep.go
@@ -17,7 +17,7 @@ import (
 	"github.com/replicatedhq/ship/pkg/state"
 )
 
-func (d *V2Routes) completeStep(c *gin.Context) {
+func (d *NavcycleRoutes) completeStep(c *gin.Context) {
 	requestedStep := c.Param("step")
 	logger := log.With(d.Logger, "handler", "completeStep", "step", requestedStep)
 	debug := level.Debug(logger)
@@ -98,7 +98,7 @@ func (d *V2Routes) completeStep(c *gin.Context) {
 	d.errNotFond(c)
 }
 
-func (d *V2Routes) handleAsync(errChan chan error, debug log.Logger, step api.Step, stepID string, state state.State) {
+func (d *NavcycleRoutes) handleAsync(errChan chan error, debug log.Logger, step api.Step, stepID string, state state.State) {
 	err := d.awaitAsyncStep(errChan, debug, step)
 	if err != nil {
 		debug.Log("event", "execute.fail", "err", err)
@@ -114,7 +114,7 @@ func (d *V2Routes) handleAsync(errChan chan error, debug log.Logger, step api.St
 	}
 }
 
-func (d *V2Routes) awaitAsyncStep(errChan chan error, debug log.Logger, step api.Step) error {
+func (d *NavcycleRoutes) awaitAsyncStep(errChan chan error, debug log.Logger, step api.Step) error {
 	debug.Log("event", "async.await")
 	for {
 		select {
@@ -133,11 +133,11 @@ func (d *V2Routes) awaitAsyncStep(errChan chan error, debug log.Logger, step api
 	}
 }
 
-type V2Exectuor func(d *V2Routes, step api.Step) error
+type V2Exectuor func(d *NavcycleRoutes, step api.Step) error
 
 // temprorary home for a copy of pkg/lifecycle.StepExecutor while
 // we re-implement each lifecycle step to not need a handle on a daemon (or something)
-func (d *V2Routes) execute(step api.Step) error {
+func (d *NavcycleRoutes) execute(step api.Step) error {
 	debug := level.Debug(log.With(d.Logger, "method", "execute"))
 
 	statusReceiver := &statusonly.StatusReceiver{
@@ -169,7 +169,7 @@ func (d *V2Routes) execute(step api.Step) error {
 	return errors.Errorf("unknown step %s:%s", step.ShortName(), step.Shared().ID)
 }
 
-func (d *V2Routes) progress(step api.Step) daemontypes.Progress {
+func (d *NavcycleRoutes) progress(step api.Step) daemontypes.Progress {
 	progress, ok := d.StepProgress.Load(step.Shared().ID)
 	if !ok {
 		progress = daemontypes.StringProgress("v2router", "unknown")

--- a/pkg/lifecycle/daemon/routes_navcycle_completestep_test.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_completestep_test.go
@@ -32,7 +32,7 @@ type completestepTestCase struct {
 	ExpectBody     map[string]interface{}
 	State          *state2.Lifeycle
 	ExpectState    *matchers.Is
-	OnExecute      func(d *V2Routes, step api.Step) error
+	OnExecute      func(d *NavcycleRoutes, step api.Step) error
 	WaitForCleanup func() <-chan time.Time
 
 	// gonna move this to another test
@@ -170,7 +170,7 @@ func TestV2CompleteStep(t *testing.T) {
 					return false
 				},
 			},
-			OnExecute: func(d *V2Routes, step api.Step) error {
+			OnExecute: func(d *NavcycleRoutes, step api.Step) error {
 				time.Sleep(100 * time.Millisecond)
 				return nil
 			},
@@ -194,7 +194,7 @@ func TestV2CompleteStep(t *testing.T) {
 			// need to wait until the async task completes before we check all the expected mock calls,
 			// otherwise the state won't have been saved yet
 			WaitForCleanup: func() <-chan time.Time { return time.After(150 * time.Millisecond) },
-			OnExecute: func(d *V2Routes, step api.Step) error {
+			OnExecute: func(d *NavcycleRoutes, step api.Step) error {
 				time.Sleep(600 * time.Millisecond)
 				return nil
 			},
@@ -233,13 +233,13 @@ func TestV2CompleteStep(t *testing.T) {
 			messenger := lifecycle.NewMockMessenger(mc)
 			renderer := lifecycle.NewMockRenderer(mc)
 			mockPlanner := planner2.NewMockPlanner(mc)
-			v2 := &V2Routes{
+			v2 := &NavcycleRoutes{
 				Logger:       testLogger,
 				StateManager: fakeState,
 				Messenger:    messenger,
 				Renderer:     renderer,
 				Planner:      mockPlanner,
-				StepExecutor: func(d *V2Routes, step api.Step) error {
+				StepExecutor: func(d *NavcycleRoutes, step api.Step) error {
 					return nil
 				},
 				StepProgress: &daemontypes.ProgressMap{},

--- a/pkg/lifecycle/daemon/routes_navcycle_getcycle.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_getcycle.go
@@ -12,7 +12,7 @@ type lifeycleStep struct {
 	Progress    *daemontypes.Progress `json:"progress,omitempty"`
 }
 
-func (d *V2Routes) getLifecycle(c *gin.Context) {
+func (d *NavcycleRoutes) getNavcycle(c *gin.Context) {
 	lifecycleIDs := make([]lifeycleStep, 0)
 	for _, step := range d.Release.Spec.Lifecycle.V1 {
 		stepResponse := lifeycleStep{

--- a/pkg/lifecycle/daemon/routes_navcycle_getcycle_test.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_getcycle_test.go
@@ -23,7 +23,7 @@ type lifecycleTestcase struct {
 	ExpectBody   []lifeycleStep `yaml:"expectBody"`
 }
 
-func TestV2Lifecycle(t *testing.T) {
+func TestNavcycle(t *testing.T) {
 	tests := loadTestCases(t)
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
@@ -36,7 +36,7 @@ func TestV2Lifecycle(t *testing.T) {
 				},
 			}
 			testLogger := &logger.TestLogger{T: t}
-			v2 := &V2Routes{
+			v2 := &NavcycleRoutes{
 				Logger:       testLogger,
 				StepProgress: &daemontypes.ProgressMap{},
 			}

--- a/pkg/lifecycle/daemon/routes_navcycle_getstep.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_getstep.go
@@ -11,7 +11,7 @@ import (
 	"github.com/replicatedhq/ship/pkg/state"
 )
 
-func (d *V2Routes) getStep(c *gin.Context) {
+func (d *NavcycleRoutes) getStep(c *gin.Context) {
 	debug := level.Debug(log.With(d.Logger, "handler", "getStep"))
 	debug.Log()
 
@@ -32,7 +32,7 @@ func (d *V2Routes) getStep(c *gin.Context) {
 	d.errNotFond(c)
 }
 
-func (d *V2Routes) hydrateStep(step daemontypes.Step, isCurrent bool) (*daemontypes.StepResponse, error) {
+func (d *NavcycleRoutes) hydrateStep(step daemontypes.Step, isCurrent bool) (*daemontypes.StepResponse, error) {
 
 	if step.Kustomize != nil {
 		// TODO(Robert): move this into TreeLoader, duplicated in V1 routes
@@ -93,7 +93,7 @@ func (d *V2Routes) hydrateStep(step daemontypes.Step, isCurrent bool) (*daemonty
 	return result, nil
 }
 
-func (d *V2Routes) getActions(step daemontypes.Step) []daemontypes.Action {
+func (d *NavcycleRoutes) getActions(step daemontypes.Step) []daemontypes.Action {
 	progress, ok := d.StepProgress.Load(step.Source.Shared().ID)
 
 	shouldAddActions := ok && progress.Detail != "success"

--- a/pkg/lifecycle/daemon/routes_navcycle_getstep_test.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_getstep_test.go
@@ -47,6 +47,7 @@ func TestV2GetStep(t *testing.T) {
 				{
 					Message: &api.Message{
 						StepShared: api.StepShared{
+
 							ID: "foo",
 						},
 						Contents: "hi",
@@ -214,7 +215,7 @@ func TestV2GetStep(t *testing.T) {
 			for key, val := range test.StepProgress {
 				progressmap.Store(key, val)
 			}
-			v2 := &V2Routes{
+			v2 := &NavcycleRoutes{
 				Logger:       testLogger,
 				StateManager: fakeState,
 				StepProgress: progressmap,
@@ -316,7 +317,7 @@ func TestHydrateActions(t *testing.T) {
 			testLogger := &logger.TestLogger{T: t}
 			progressmap := &daemontypes.ProgressMap{}
 
-			v2 := &V2Routes{
+			v2 := &NavcycleRoutes{
 				Logger:       testLogger,
 				StepProgress: progressmap,
 			}

--- a/pkg/lifecycle/interfaces.go
+++ b/pkg/lifecycle/interfaces.go
@@ -40,3 +40,8 @@ type Kustomizer interface {
 type KubectlApply interface {
 	Execute(ctx context.Context, release api.Release, step api.KubectlApply) error
 }
+
+// Config is a thing that can resolve configuration options
+type Config interface {
+	ResolveConfig(context.Context, *api.Release) (map[string]interface{}, error)
+}

--- a/pkg/lifecycle/message/messenger.go
+++ b/pkg/lifecycle/message/messenger.go
@@ -2,25 +2,8 @@ package message
 
 import (
 	"github.com/replicatedhq/ship/pkg/api"
-	"github.com/replicatedhq/ship/pkg/lifecycle"
-	"github.com/replicatedhq/ship/pkg/templates"
-	"github.com/spf13/viper"
-)
-
-func NewMessenger(
-	v *viper.Viper,
-	cli CLIMessenger,
-	daemon DaemonMessenger,
-	daemonless DaemonlessMessenger,
-) lifecycle.Messenger {
-	if v.GetBool("headless") {
-		return &cli
-	} else if v.GetBool("navigate-lifecycle") { // opt in feature flag for v2 routing/lifecycle rules
-		return &daemonless
-	}
-
-	return &daemon
-}
+		"github.com/replicatedhq/ship/pkg/templates"
+	)
 
 func (m *DaemonMessenger) getBuilder(meta api.ReleaseMetadata) templates.Builder {
 	builder := m.BuilderBuilder.NewBuilder(

--- a/pkg/lifecycle/render/backup.go
+++ b/pkg/lifecycle/render/backup.go
@@ -1,0 +1,38 @@
+package render
+
+import (
+	"fmt"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/spf13/afero"
+	"github.com/pkg/errors"
+)
+
+func (r *noconfigrenderer) backupIfPresent(basePath string) error {
+	return backupIfPresent(r.Fs, basePath, r.Logger)
+}
+
+func (r *renderer) backupIfPresent(basePath string) error {
+	return backupIfPresent(r.Fs, basePath, r.Logger)
+}
+
+func backupIfPresent(fs afero.Afero, basePath string, logger log.Logger) error {
+	exists, err := fs.Exists(basePath)
+	if err != nil {
+		return errors.Wrapf(err, "check file exists")
+	}
+	if !exists {
+		return nil
+	}
+	backupDest := fmt.Sprintf("%s.bak", basePath)
+	level.Info(logger).Log("step.type", "render", "event", "unpackTarget.backup.remove", "src", basePath, "dest", backupDest)
+	if err := fs.RemoveAll(backupDest); err != nil {
+		return errors.Wrapf(err, "backup existing dir %s to %s: remove existing %s", basePath, backupDest, backupDest)
+	}
+	if err := fs.Rename(basePath, backupDest); err != nil {
+		return errors.Wrapf(err, "backup existing dir %s to %s", basePath, backupDest)
+	}
+	return nil
+}
+

--- a/pkg/lifecycle/render/noconfig.go
+++ b/pkg/lifecycle/render/noconfig.go
@@ -1,0 +1,97 @@
+package render
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/mitchellh/cli"
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/ship/pkg/api"
+	"github.com/replicatedhq/ship/pkg/constants"
+	"github.com/replicatedhq/ship/pkg/lifecycle"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
+	"github.com/replicatedhq/ship/pkg/lifecycle/render/planner"
+	"github.com/replicatedhq/ship/pkg/state"
+	"github.com/spf13/afero"
+	"go.uber.org/dig"
+)
+
+func NoConfigRenderer(render noconfigrenderer) lifecycle.Renderer {
+	return &render
+}
+
+// noconfigrenderer is the navcycle version of
+// render, that assumes that config has already happened
+type noconfigrenderer struct {
+	dig.In
+	Logger         log.Logger
+	Planner        planner.Planner
+	StateManager   state.Manager
+	Fs             afero.Afero
+	UI             cli.Ui
+	StatusReceiver daemontypes.StatusReceiver
+	Now            func() time.Time
+}
+
+func (r *noconfigrenderer) Execute(ctx context.Context, release *api.Release, step *api.Render) error {
+	defer r.StatusReceiver.ClearProgress()
+
+	debug := level.Debug(log.With(r.Logger, "step.type", "render"))
+	debug.Log("event", "step.execute")
+
+	r.StatusReceiver.SetProgress(ProgressRead)
+	debug.Log("event", "try.load")
+	previousState, err := r.StateManager.TryLoad()
+	if err != nil {
+		return err
+	}
+
+	templateContext := previousState.CurrentConfig()
+	r.StatusReceiver.SetProgress(ProgressRender)
+
+	debug.Log("event", "render.plan")
+	pln, err := r.Planner.Build(release.Spec.Assets.V1, release.Spec.Config.V1, release.Metadata, templateContext)
+	if err != nil {
+		return errors.Wrap(err, "build plan")
+	}
+
+	debug.Log("event", "backup.start")
+	err = r.backupIfPresent(constants.InstallerPrefixPath)
+	if err != nil {
+		return errors.Wrapf(err, "backup existing install directory %s", constants.InstallerPrefixPath)
+	}
+
+	debug.Log("event", "execute.plan")
+	r.StatusReceiver.SetStepName(ctx, daemontypes.StepNameConfirm)
+	err = r.Planner.Execute(ctx, pln)
+	if err != nil {
+		return errors.Wrap(err, "execute plan")
+	}
+	return nil
+}
+
+func (r *noconfigrenderer) WithStatusReceiver(receiver daemontypes.StatusReceiver) lifecycle.Renderer {
+	return &noconfigrenderer{
+		Logger:         r.Logger,
+		Planner:        r.Planner,
+		StateManager:   r.StateManager,
+		Fs:             r.Fs,
+		UI:             r.UI,
+		StatusReceiver: receiver,
+		Now:            r.Now,
+	}
+}
+
+func (r *noconfigrenderer) WithPlanner(planner planner.Planner) lifecycle.Renderer {
+	return &noconfigrenderer{
+		Logger:         r.Logger,
+		Planner:        planner,
+		StateManager:   r.StateManager,
+		Fs:             r.Fs,
+		UI:             r.UI,
+		StatusReceiver: r.StatusReceiver,
+		Now:            r.Now,
+	}
+}

--- a/pkg/lifecycle/render/noconfig_test.go
+++ b/pkg/lifecycle/render/noconfig_test.go
@@ -1,0 +1,77 @@
+package render
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/replicatedhq/ship/pkg/lifecycle/render/test-cases"
+		"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/golang/mock/gomock"
+	"github.com/replicatedhq/ship/pkg/api"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
+	"github.com/replicatedhq/ship/pkg/lifecycle/render/planner"
+	mockdaemon "github.com/replicatedhq/ship/pkg/test-mocks/daemon"
+	mockplanner "github.com/replicatedhq/ship/pkg/test-mocks/planner"
+	"github.com/replicatedhq/ship/pkg/test-mocks/ui"
+	"github.com/spf13/afero"
+		"github.com/stretchr/testify/assert"
+	state2 "github.com/replicatedhq/ship/pkg/test-mocks/state"
+	"github.com/replicatedhq/ship/pkg/state"
+)
+
+func TestRenderNoConfig(t *testing.T) {
+	ctx := context.Background()
+
+	tests := loadTestCases(t, filepath.Join("test-cases", "render-inline.yaml"))
+
+	for _, test := range tests[:1] {
+		t.Run(test.Name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+
+			mockUI := ui.NewMockUi(mc)
+			p := mockplanner.NewMockPlanner(mc)
+			mockFS := afero.Afero{Fs: afero.NewMemMapFs()}
+			mockState := state2.NewMockManager(mc)
+			mockDaemon := mockdaemon.NewMockDaemon(mc)
+
+			renderer := &noconfigrenderer{
+				Logger: log.NewNopLogger(),
+				Now:    time.Now,
+			}
+			renderer.Fs = mockFS
+			renderer.UI = mockUI
+			renderer.Planner = p
+			renderer.StateManager = mockState
+
+			prog := mockDaemon.EXPECT().SetProgress(ProgressRead)
+			prog = mockDaemon.EXPECT().SetProgress(ProgressRender).After(prog)
+			prog = mockDaemon.EXPECT().SetStepName(ctx, daemontypes.StepNameConfirm).After(prog)
+			mockDaemon.EXPECT().ClearProgress().After(prog)
+
+
+			renderer.StatusReceiver = mockDaemon
+
+			release := &api.Release{Spec: test.Spec}
+
+			func() {
+				defer mc.Finish()
+
+				mockState.EXPECT().TryLoad().Return(state.V0(test.ViperConfig), nil)
+
+				p.EXPECT().
+					Build(test.Spec.Assets.V1, test.Spec.Config.V1, gomock.Any(), test.ViperConfig).
+					Return(planner.Plan{}, nil)
+
+				p.EXPECT().
+					Execute(ctx, planner.Plan{}).
+					Return(nil)
+
+				err := renderer.Execute(ctx, release, &api.Render{})
+				assert.NoError(t, err)
+			}()
+		})
+	}
+}

--- a/pkg/lifecycle/render/render.go
+++ b/pkg/lifecycle/render/render.go
@@ -3,7 +3,6 @@ package render
 import (
 	"context"
 
-	"fmt"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -97,27 +96,6 @@ func (r *renderer) Execute(ctx context.Context, release *api.Release, step *api.
 	debug.Log("event", "commit")
 	if err := r.StateManager.SerializeConfig(release.Spec.Assets.V1, release.Metadata, stateTemplateContext); err != nil {
 		return errors.Wrap(err, "serialize state")
-	}
-
-	return nil
-}
-
-func (r *renderer) backupIfPresent(basePath string) error {
-	exists, err := r.Fs.Exists(basePath)
-	if err != nil {
-		return errors.Wrapf(err, "check file exists")
-	}
-	if !exists {
-		return nil
-	}
-
-	backupDest := fmt.Sprintf("%s.bak", basePath)
-	level.Info(r.Logger).Log("step.type", "render", "event", "unpackTarget.backup.remove", "src", basePath, "dest", backupDest)
-	if err := r.Fs.RemoveAll(backupDest); err != nil {
-		return errors.Wrapf(err, "backup existing dir %s to %s: remove existing %s", basePath, backupDest, backupDest)
-	}
-	if err := r.Fs.Rename(basePath, backupDest); err != nil {
-		return errors.Wrapf(err, "backup existing dir %s to %s", basePath, backupDest)
 	}
 
 	return nil

--- a/pkg/ship/dig.go
+++ b/pkg/ship/dig.go
@@ -44,12 +44,16 @@ import (
 	"github.com/replicatedhq/ship/pkg/ui"
 	"github.com/spf13/viper"
 	"go.uber.org/dig"
+	"time"
 )
+
+
 
 func buildInjector() (*dig.Container, error) {
 
 	providers := []interface{}{
 
+		clock,
 		viper.GetViper,
 		logger.FromViper,
 		ui.FromViper,
@@ -125,8 +129,8 @@ func buildInjector() (*dig.Container, error) {
 	// Hopefully once everything is moved over to v2 this gets a lot simpler again.
 	if viper.GetBool("headless") {
 		providers = append(providers, headlessProviders()...)
-	} else if viper.GetBool("navigate-lifecycle") {
-		providers = append(providers, navigableProviders()...)
+	} else if viper.GetBool("navcycle") {
+		providers = append(providers, navcycleProviders()...)
 	} else {
 		providers = append(providers, headedProviders()...)
 
@@ -173,10 +177,10 @@ func headedProviders() []interface{} {
 // "navigable mode" provides a new, v2-ish version of ship that provides browser navigation back
 // and forth through the lifecycle, and uses runbook declarations of lifecycle dependencies to
 // control execution ordering and workflows
-func navigableProviders() []interface{} {
+func navcycleProviders() []interface{} {
 	return []interface{}{
 		daemon.NewHeadedDaemon,
-		render.NewFactory,
+		render.NoConfigRenderer,
 		config.NewNoOpResolver,
 		func(messenger message.DaemonlessMessenger) lifecycle.Messenger { return &messenger },
 		func(intro helmIntro.DaemonlessHelmIntro) lifecycle.HelmIntro { return &intro },
@@ -221,4 +225,11 @@ func RunE(ctx context.Context) error {
 	}
 	s.ExecuteAndMaybeExit(ctx)
 	return nil
+}
+
+func clock() func() time.Time {
+	clock := func() time.Time {
+		return time.Now()
+	}
+	return clock
 }

--- a/pkg/ship/dig_test.go
+++ b/pkg/ship/dig_test.go
@@ -17,21 +17,21 @@ func TestDI(t *testing.T) {
 			name: "headless",
 			set: map[string]bool{
 				"headless":           true,
-				"navigate-lifecycle": false,
+				"navcycle": false,
 			},
 		},
 		{
-			name: "navigate",
+			name: "navcycle",
 			set: map[string]bool{
 				"headless":           false,
-				"navigate-lifecycle": true,
+				"navcycle": true,
 			},
 		},
 		{
 			name: "headed",
 			set: map[string]bool{
 				"headless":           false,
-				"navigate-lifecycle": false,
+				"navcycle": false,
 			},
 		},
 	}

--- a/pkg/ship/ship.go
+++ b/pkg/ship/ship.go
@@ -166,7 +166,7 @@ func (s *Ship) execute(ctx context.Context, release *api.Release, selector *spec
 		defer close(runResultCh)
 		var err error
 		// *wince* dex do this better
-		if viper.GetBool("navigate-lifecycle") {
+		if viper.GetBool("navcycle") {
 			s.Daemon.EnsureStarted(ctx, release)
 			err = s.Daemon.AwaitShutdown()
 		} else {


### PR DESCRIPTION
What I Did
------------

Start teasing apart config/render steps

How I Did it
------------

- add `Config` to lifeycle/interfaces.go -- this is close to whats implemented by config/resolve/DaemonResolver, and serves the same purpose
- add a new `render.noconfigrenderer` that just loads config from state and renders assets, doesn't interact with daemon at all
- in `navcycle` mode, dig injects the `noconfigrenderer`
- refactor the core logic of `backupIfPresent` off of `render.renderer`. I have a feeling there's going to be a lot of this happening as we migrate implementations over. One `render.renderer` is deprecated and `render.noconfigrender` is the main one, we can move the function back onto `noconfigrenderer.
-

Other stuff

- change `navigate-lifeycle` to `navcycle` -- its shorter and easier to say, and more accurate than "lifecycle v2" or "ship v2"
- fix `json:",inline"` on StepShared, add to  hack/docs and schema
-

How to verify it
------------

navcycle might not work all the way, still need to test

Description for the Changelog
------------

![](https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Shipwreck_Point_Reyes%2C_Inverness.jpg/120px-Shipwreck_Point_Reyes%2C_Inverness.jpg)


