### PR TITLE
Don't crash if Helm chart has no README file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
   apt-get update || true && \
   apt-get install -y apt-transport-https && \
-  apt-get update && apt-get install -y yarn curl
+  apt-get update && apt-get install -y yarn curl bzip2
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
   apt-get install -y nodejs

--- a/pkg/lifecycle/step.go
+++ b/pkg/lifecycle/step.go
@@ -46,7 +46,7 @@ func (s *StepExecutor) Execute(ctx context.Context, release *api.Release, step *
 		err := s.Kustomizer.Execute(ctx, *release, *step.Kustomize)
 		debug.Log("event", "step.complete", "type", "kustomize", "err", err)
 		return errors.Wrap(err, "execute kustomize step")
-	} else if step.HelmIntro != nil {
+	} else if step.HelmIntro != nil && release.Metadata.HelmChartMetadata.Readme != "" {
 		debug.Log("event", "step.helmIntro", "type", "helmIntro")
 		err := s.HelmIntro.Execute(ctx, release, step.HelmIntro)
 		debug.Log("event", "step.complete", "type", "helmIntro", "err", err)

--- a/pkg/specs/chart.go
+++ b/pkg/specs/chart.go
@@ -254,7 +254,9 @@ func (r *Resolver) ResolveChartMetadata(ctx context.Context, path string) (api.H
 	debug.Log("phase", "read-readme", "from", localReadmePath)
 	readme, err := r.FS.ReadFile(localReadmePath)
 	if err != nil {
-		return api.HelmChartMetadata{}, errors.Wrapf(err, "read file from %s", localReadmePath)
+		if !os.IsNotExist(err) {
+			return api.HelmChartMetadata{}, errors.Wrapf(err, "read file from %s", localReadmePath)
+		}
 	}
 
 	debug.Log("phase", "unmarshal-chart.yaml")
@@ -262,7 +264,9 @@ func (r *Resolver) ResolveChartMetadata(ctx context.Context, path string) (api.H
 		return api.HelmChartMetadata{}, err
 	}
 
-	md.Readme = string(readme)
+	if readme != nil {
+		md.Readme = string(readme)
+	}
 
 	return md, nil
 }


### PR DESCRIPTION
Closes #316 and does some gofmt'ing

What I Did
------------
Add support for Helm chars without README files.

How I Did it
------------
Don't error out when README.md does not exist, but skip the intro step.

How to verify it
------------
Run this command and observe that Ship doesn't crash: ```ship init github.com/divolgin/sample-chart```

Description for the Changelog
------------
Helm chart repos are no longer required to have a README.md file.

Picture of a Boat (not required but encouraged)
------------

![avrora1905](https://user-images.githubusercontent.com/1004892/44057377-e0ed3406-9eff-11e8-9883-33753c725569.jpg)










<!-- (thanks https://github.com/docker/docker for this template) -->

