### PR TITLE
hack hack hack

### DIFF
--- a/pkg/lifecycle/daemon/constructors.go
+++ b/pkg/lifecycle/daemon/constructors.go
@@ -43,6 +43,7 @@ func NewV2Router(
 	stateManager state.Manager,
 	messenger lifecycle.Messenger,
 	helmIntro lifecycle.HelmIntro,
+	helmValues lifecycle.HelmValues,
 	planners planner.Planner,
 	renderer lifecycle.Renderer,
 	fs afero.Afero,
@@ -52,9 +53,10 @@ func NewV2Router(
 		StateManager: stateManager,
 		Planner:      planners,
 
-		Messenger: messenger,
-		HelmIntro: helmIntro,
-		Renderer:  renderer,
+		Messenger:  messenger,
+		HelmIntro:  helmIntro,
+		HelmValues: helmValues,
+		Renderer:   renderer,
 		StepExecutor: func(d *NavcycleRoutes, step api.Step) error {
 			return d.execute(step)
 		},

--- a/pkg/lifecycle/daemon/routes_navcycle.go
+++ b/pkg/lifecycle/daemon/routes_navcycle.go
@@ -21,14 +21,16 @@ type NavcycleRoutes struct {
 	Logger       log.Logger
 	TreeLoader   filetree.Loader
 	StateManager state.Manager
-	Messenger    lifecycle.Messenger
-	HelmIntro    lifecycle.HelmIntro
-	Renderer     lifecycle.Renderer
-	Planner      planner.Planner
 	StepExecutor V2Exectuor
 	Fs           afero.Afero
 
 	StepProgress *daemontypes.ProgressMap
+
+	Messenger  lifecycle.Messenger
+	HelmIntro  lifecycle.HelmIntro
+	HelmValues lifecycle.HelmValues
+	Renderer   lifecycle.Renderer
+	Planner    planner.Planner
 
 	// This isn't known at injection time, so we have to set in Register
 	Release *api.Release

--- a/pkg/lifecycle/daemon/routes_navcycle_completestep.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_completestep.go
@@ -156,6 +156,11 @@ func (d *NavcycleRoutes) execute(step api.Step) error {
 		err := d.HelmIntro.Execute(context.Background(), d.Release, step.HelmIntro)
 		debug.Log("event", "step.complete", "type", "helmIntro", "err", err)
 		return errors.Wrap(err, "execute helmIntro step")
+	} else if step.HelmValues != nil {
+		debug.Log("event", "step.resolve", "type", "helmIntro")
+		err := d.HelmValues.Execute(context.Background(), d.Release, step.HelmValues)
+		debug.Log("event", "step.complete", "type", "helmIntro", "err", err)
+		return errors.Wrap(err, "execute helmIntro step")
 	} else if step.Render != nil {
 		debug.Log("event", "step.resolve", "type", "helmIntro")
 		planner := d.Planner.WithStatusReceiver(statusReceiver)

--- a/pkg/lifecycle/daemon/routes_navcycle_getstep.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_getstep.go
@@ -27,8 +27,28 @@ func (d *NavcycleRoutes) getStep(c *gin.Context) {
 			if ok := d.maybeAbortDueToMissingRequirement(stepShared.Requires, c, requestedStep); !ok {
 				return
 			}
-			d.hydrateAndSend(daemontypes.NewStep(step), c)
-			return
+
+			if step.Render == nil {
+				d.hydrateAndSend(daemontypes.NewStep(step), c)
+				return
+			} else {
+				debug.Log("event", "renderStep.get", "msg", "(hack) starting render on GET request")
+				// HACK HACK HACK because dex can't redux
+				//
+				// on get render, automatically treat it like a POST to the render step,
+				// that is, start rendering, let the UI poll for status.
+				//
+				// ideally (maybe?) this can happen on the FE, as soon as render page loads, FE does a POST
+				//
+				// we check if its in the map, for now only run render if its never been run, or if its already done
+				progress, ok := d.StepProgress.Load(step.Shared().ID)
+				if !ok || progress.Detail == "success" {
+					d.completeStep(c)
+				} else {
+					d.hydrateAndSend(daemontypes.NewStep(step), c)
+				}
+				return
+			}
 		}
 	}
 
@@ -115,15 +135,11 @@ func (d *NavcycleRoutes) getActions(step daemontypes.Step) []daemontypes.Action 
 
 	if step.Message != nil {
 		return []daemontypes.Action{
-			{
-				ButtonType:  "primary",
-				Text:        "Confirm",
-				LoadingText: "Confirming",
-				OnClick: daemontypes.ActionRequest{
-					URI:    fmt.Sprintf("/navcycle/step/%s", step.Source.Shared().ID),
-					Method: "POST",
-					Body:   "",
-				},
+			{ButtonType: "primary", Text: "Confirm", LoadingText: "Confirming", OnClick: daemontypes.ActionRequest{
+				URI:    fmt.Sprintf("/navcycle/step/%s", step.Source.Shared().ID),
+				Method: "POST",
+				Body:   "",
+			},
 			},
 		}
 	} else if step.HelmIntro != nil {

--- a/pkg/lifecycle/helmValues/daemonless.go
+++ b/pkg/lifecycle/helmValues/daemonless.go
@@ -1,0 +1,24 @@
+package helmValues
+
+import (
+	"github.com/go-kit/kit/log"
+	"github.com/replicatedhq/ship/pkg/lifecycle"
+	"github.com/replicatedhq/ship/pkg/state"
+	"github.com/spf13/afero"
+)
+
+func NewDaemonlessHelmValues(
+	fs afero.Afero,
+	logger log.Logger,
+	stateManager state.Manager,
+) lifecycle.HelmValues {
+	return &daemonlessHelmValues{
+		Fs:           fs,
+		Logger:       logger,
+		StateManager: stateManager,
+	}
+}
+
+func (h *daemonlessHelmValues) resolveStateHelmValues() error {
+	return resolveStateHelmValues(h.Logger, h.StateManager, h.Fs)
+}

--- a/pkg/lifecycle/render/helm/template.go
+++ b/pkg/lifecycle/render/helm/template.go
@@ -11,11 +11,14 @@ import (
 
 	"regexp"
 
+	"path/filepath"
+
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/libyaml"
 	"github.com/replicatedhq/ship/pkg/api"
+	"github.com/replicatedhq/ship/pkg/state"
 	"github.com/replicatedhq/ship/pkg/templates"
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
@@ -43,6 +46,7 @@ type ForkTemplater struct {
 	FS             afero.Afero
 	BuilderBuilder *templates.BuilderBuilder
 	Viper          *viper.Viper
+	StateManager   state.Manager
 	process        process.Process
 }
 
@@ -102,6 +106,15 @@ func (f *ForkTemplater) Template(
 	err = f.helmDependencyUpdate(chartRoot)
 	if err != nil {
 		return errors.Wrap(err, "update helm dependencies")
+	}
+
+	if !viper.GetBool("is-app") {
+		// HACKKK for ship init
+
+		// todo move this, or refactor to share duped code from helmValues package
+		if err := writeStateHelmValuesToChartTmpdir(f.Logger, f.StateManager, f.FS); err != nil {
+			return errors.Wrapf(err, "copy state value to tmp directory", constants.RenderedHelmTempPath)
+		}
 	}
 
 	stdout, stderr, err := f.process.Fork(cmd)
@@ -280,6 +293,7 @@ func NewTemplater(
 	fs afero.Afero,
 	builderBuilder *templates.BuilderBuilder,
 	viper *viper.Viper,
+	stateManager state.Manager,
 ) Templater {
 	return &ForkTemplater{
 		Helm: func() *exec.Cmd {
@@ -289,6 +303,37 @@ func NewTemplater(
 		FS:             fs,
 		BuilderBuilder: builderBuilder,
 		Viper:          viper,
+		StateManager:   stateManager,
 		process:        process.Process{Logger: logger},
 	}
+}
+
+// TODO duped from lifecycle/helmValues
+func writeStateHelmValuesToChartTmpdir(logger log.Logger, manager state.Manager, fs afero.Afero) error {
+	debug := level.Debug(log.With(logger, "step.type", "helmValues", "resolveHelmValues"))
+	debug.Log("event", "tryLoadState")
+	editState, err := manager.TryLoad()
+	if err != nil {
+		return errors.Wrap(err, "try load state")
+	}
+	helmValues := editState.CurrentHelmValues()
+	if helmValues == "" {
+		defaultValuesShippedWithChart := filepath.Join(constants.KustomizeHelmPath, "values.yaml")
+		bytes, err := fs.ReadFile(defaultValuesShippedWithChart)
+		if err != nil {
+			return errors.Wrapf(err, "read helm values from %s", defaultValuesShippedWithChart)
+		}
+		helmValues = string(bytes)
+	}
+	debug.Log("event", "tryLoadState")
+	err = fs.MkdirAll(constants.TempHelmValuesPath, 0700)
+	if err != nil {
+		return errors.Wrapf(err, "make dir %s", constants.TempHelmValuesPath)
+	}
+	debug.Log("event", "writeTempValuesYaml")
+	err = fs.WriteFile(path.Join(constants.TempHelmValuesPath, "values.yaml"), []byte(helmValues), 0644)
+	if err != nil {
+		return errors.Wrapf(err, "write values.yaml to %s", constants.TempHelmValuesPath)
+	}
+	return nil
 }

--- a/pkg/lifecycle/render/helm/template_test.go
+++ b/pkg/lifecycle/render/helm/template_test.go
@@ -13,11 +13,14 @@ import (
 
 	"path"
 
+	"github.com/golang/mock/gomock"
 	"github.com/replicatedhq/libyaml"
 	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/constants"
 	"github.com/replicatedhq/ship/pkg/process"
+	state2 "github.com/replicatedhq/ship/pkg/state"
 	"github.com/replicatedhq/ship/pkg/templates"
+	"github.com/replicatedhq/ship/pkg/test-mocks/state"
 	"github.com/replicatedhq/ship/pkg/testing/logger"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
@@ -144,7 +147,9 @@ func TestForkTemplater(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			req := require.New(t)
 
+			mc := gomock.NewController(t)
 			testLogger := &logger.TestLogger{T: t}
+			mockState := state.NewMockManager(mc)
 			tpl := &ForkTemplater{
 				Helm: func() *exec.Cmd {
 					cmd := exec.Command(os.Args[0], "-test.run=TestMockHelm")
@@ -155,8 +160,15 @@ func TestForkTemplater(t *testing.T) {
 				FS:             afero.Afero{Fs: afero.NewMemMapFs()},
 				BuilderBuilder: templates.NewBuilderBuilder(testLogger),
 				Viper:          viper.New(),
+				StateManager:   mockState,
 				process:        process.Process{Logger: testLogger},
 			}
+
+			mockState.EXPECT().TryLoad().Return(state2.VersionedState{
+				V1: &state2.V1{
+					HelmValues: "we fake",
+				},
+			}, nil)
 
 			channelName := "Frobnitz"
 			if test.channelName != "" {

--- a/pkg/lifecycle/render/noconfig.go
+++ b/pkg/lifecycle/render/noconfig.go
@@ -64,7 +64,7 @@ func (r *noconfigrenderer) Execute(ctx context.Context, release *api.Release, st
 	}
 
 	debug.Log("event", "execute.plan")
-	r.StatusReceiver.SetStepName(ctx, daemontypes.StepNameConfirm)
+	//r.StatusReceiver.SetStepName(ctx, daemontypes.StepNameConfirm)
 	err = r.Planner.Execute(ctx, pln)
 	if err != nil {
 		return errors.Wrap(err, "execute plan")

--- a/pkg/lifecycle/render/noconfig_test.go
+++ b/pkg/lifecycle/render/noconfig_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"time"
 
@@ -13,7 +12,6 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/golang/mock/gomock"
 	"github.com/replicatedhq/ship/pkg/api"
-	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 	"github.com/replicatedhq/ship/pkg/lifecycle/render/planner"
 	"github.com/replicatedhq/ship/pkg/state"
 	mockdaemon "github.com/replicatedhq/ship/pkg/test-mocks/daemon"
@@ -50,7 +48,6 @@ func TestRenderNoConfig(t *testing.T) {
 
 			prog := mockDaemon.EXPECT().SetProgress(ProgressRead)
 			prog = mockDaemon.EXPECT().SetProgress(ProgressRender).After(prog)
-			prog = mockDaemon.EXPECT().SetStepName(ctx, daemontypes.StepNameConfirm).After(prog)
 			mockDaemon.EXPECT().ClearProgress().After(prog)
 
 			renderer.StatusReceiver = mockDaemon

--- a/pkg/ship/dig.go
+++ b/pkg/ship/dig.go
@@ -2,7 +2,8 @@ package ship
 
 import (
 	"context"
-	"time"
+
+	"github.com/replicatedhq/ship/pkg/patch"
 
 	"time"
 
@@ -38,7 +39,6 @@ import (
 	terraform2 "github.com/replicatedhq/ship/pkg/lifecycle/terraform"
 	"github.com/replicatedhq/ship/pkg/lifecycle/terraform/tfplan"
 	"github.com/replicatedhq/ship/pkg/logger"
-	"github.com/replicatedhq/ship/pkg/patch"
 	"github.com/replicatedhq/ship/pkg/specs"
 	"github.com/replicatedhq/ship/pkg/state"
 	"github.com/replicatedhq/ship/pkg/templates"
@@ -69,7 +69,6 @@ func buildInjector() (*dig.Container, error) {
 		terraform2.NewTerraformer,
 		kustomize.NewKustomizer,
 		tfplan.NewPlanner,
-		helmValues.NewHelmValues,
 
 		state.NewManager,
 		planner.NewFactory,
@@ -154,6 +153,7 @@ func headlessProviders() []interface{} {
 		helmIntro.NewHelmIntro,
 		config.NewResolver,
 		render.NewFactory,
+		helmValues.NewHelmValues,
 		func(messenger message.CLIMessenger) lifecycle.Messenger { return &messenger },
 		func(d daemontypes.Daemon) daemontypes.StatusReceiver { return d },
 	}
@@ -167,6 +167,7 @@ func headedProviders() []interface{} {
 		helmIntro.NewHelmIntro,
 		config.NewResolver,
 		render.NewFactory,
+		helmValues.NewHelmValues,
 		func(messenger message.DaemonMessenger) lifecycle.Messenger { return &messenger },
 		func(d daemontypes.Daemon) daemontypes.StatusReceiver { return d },
 	}
@@ -180,6 +181,7 @@ func navcycleProviders() []interface{} {
 		daemon.NewHeadedDaemon,
 		render.NoConfigRenderer,
 		config.NewNoOpResolver,
+		helmValues.NewDaemonlessHelmValues,
 		func(messenger message.DaemonlessMessenger) lifecycle.Messenger { return &messenger },
 		func(intro helmIntro.DaemonlessHelmIntro) lifecycle.HelmIntro { return &intro },
 		// fake, we override it, this is janky, use a factory dex


### PR DESCRIPTION
Some fixes and hacks to get render working on re-run

How I Did it
------------

- HelmValues has a dameonless implementation that just writes the values
from state into the chart/tmp/values.yaml -- this should probably be
parameterized
- if `is-app` is false, re-write the helm values during the render step,
somehow `chart/tmp/values.yaml` gets randomly deleted sometimes
- on GET /navcycle/step/:stepID, if the step is a render step, pretend the
GET was a POST. Turning the hacks up to 11 here folks.

How to verify it
------------

``` 
NAVCYCLE=1 ship init ...
```

Description for the Changelog
------------

none

:boat: