### PR TITLE
Don't error during build if local repo has no tags.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ UI = $(shell find web/dist -name "*.js")
 DOCKER_REPO ?= replicated
 
 VERSION_PACKAGE = github.com/replicatedhq/ship/pkg/version
-VERSION=`git describe --tags`
+VERSION=`git describe --tags &>/dev/null || echo "v0.0.1"`
 GIT_SHA=`git rev-parse HEAD`
 DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
 
@@ -244,7 +244,7 @@ pkg/lifeycle/daemon/ui.bindatafs.go: .state/build-deps
 	  -prefix web/ \
 	  web/dist/...
 
-mark-ui-gitignored: 
+mark-ui-gitignored:
 	cd pkg/lifecycle/daemon/; git update-index --assume-unchanged ui.bindatafs.go
 
 


### PR DESCRIPTION
Closes #300

What I Did
------------
Fixed error for `make bin/ship` command in local environments

How I Did it
------------
Use version `v0.0.1` if local repo has no tags.

How to verify it
------------
Clone clean repo and run `make build`.  There should be no message saying
> fatal: No names found, cannot describe anything


Description for the Changelog
------------
Making a local build in a clean repo clone no longer errors because repo has no tags.


Picture of a Boat (not required but encouraged)
------------
![64647520-the-word-boat-written-in-tile-letters-isolated-on-a-white-background-](https://user-images.githubusercontent.com/1004892/44062104-e5e1874a-9f0f-11e8-9960-9ce4adc13441.jpg)












<!-- (thanks https://github.com/docker/docker for this template) -->

