### PR TITLE
less verbose citest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ test: lint .state/test
 
 .state/coverage.out: $(SRC)
 	@mkdir -p .state/
-	go test -coverprofile=.state/coverage.out -v ./pkg/...
+	go test -coverprofile=.state/coverage.out ./pkg/...
 
 citest: .state/vet .state/lint .state/coverage.out
 


### PR DESCRIPTION
What I Did
------------

Make the ci tests not run with `-v` flag, it made it hard to find
failures in all the output

How I Did it
------------

remove `-v` flag

How to verify it
------------


`make citest`

Description for the Changelog
------------

Improve test output in CI builds


:ship:











<!-- (thanks https://github.com/docker/docker for this template) -->