### PR TITLE
set test parallelism to 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,8 @@ test: lint .state/test
 
 .state/coverage.out: $(SRC)
 	@mkdir -p .state/
-	go test -coverprofile=.state/coverage.out ./pkg/...
+	#the reduced parallelism here is to avoid hitting the memory limits - we consistently did so with two threads on a 4gb instance
+	go test -parallel 1 -p 1 -coverprofile=.state/coverage.out ./pkg/...
 
 citest: .state/vet .state/lint .state/coverage.out
 


### PR DESCRIPTION
What I Did
------------
Reduced the parallelism of the CI test step. This does not increase build times despite doubling the time for the `test` step to run since the `integration` step is still significantly longer. Fixes https://github.com/replicatedhq/ship/issues/334.

How I Did it
------------
Added `-parallel 1 -p 1` to the test coverage step.

How to verify it
------------
Tests don't fail for OOM issues

Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------


![image](https://user-images.githubusercontent.com/2318911/44106837-8ba1f968-9faa-11e8-8981-9705b6700f89.png)










<!-- (thanks https://github.com/docker/docker for this template) -->

