### PR TITLE
navcycle kustomize routes

### DIFF
--- a/pkg/lifecycle/daemon/daemon_test.go
+++ b/pkg/lifecycle/daemon/daemon_test.go
@@ -48,6 +48,9 @@ func initTestDaemon(
 		OpenWebConsole:   func(ui cli.Ui, s string) error { return nil },
 	}
 
+	if v2 != nil {
+		v.Set("navcycle", true)
+	}
 	daemon := &ShipDaemon{
 		Logger:         log,
 		WebUIFactory:   WebUIFactoryFactory(log),

--- a/pkg/lifecycle/daemon/routes_navcycle.go
+++ b/pkg/lifecycle/daemon/routes_navcycle.go
@@ -12,6 +12,7 @@ import (
 	"github.com/replicatedhq/ship/pkg/lifecycle"
 	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 	"github.com/replicatedhq/ship/pkg/lifecycle/render/planner"
+	"github.com/replicatedhq/ship/pkg/patch"
 	"github.com/replicatedhq/ship/pkg/state"
 	"github.com/spf13/afero"
 )
@@ -33,6 +34,7 @@ type NavcycleRoutes struct {
 	KustomizeIntro lifecycle.KustomizeIntro
 	Renderer       lifecycle.Renderer
 	Planner        planner.Planner
+	Patcher        patch.Patcher
 
 	// This isn't known at injection time, so we have to set in Register
 	Release *api.Release
@@ -45,6 +47,13 @@ func (d *NavcycleRoutes) Register(group *gin.RouterGroup, release *api.Release) 
 	v1.GET("/navcycle", d.getNavcycle)
 	v1.GET("/navcycle/step/:step", d.getStep)
 	v1.POST("/navcycle/step/:step", d.completeStep)
+
+	v1.POST("/kustomize/file", d.kustomizeGetFile)
+	v1.POST("/kustomize/save", d.kustomizeSaveOverlay)
+	v1.POST("/kustomize/finalize", d.kustomizeFinalize)
+	v1.POST("/kustomize/patch", d.createOrMergePatch)
+	v1.DELETE("/kustomize/patch", d.deletePatch)
+	v1.POST("/kustomize/apply", d.applyPatch)
 }
 
 // returns false if aborted

--- a/pkg/lifecycle/daemon/routes_navcycle_getstep.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_getstep.go
@@ -69,7 +69,7 @@ func (d *NavcycleRoutes) hackMaybeRunRenderOnGET(debug log.Logger, c *gin.Contex
 	}
 	_, renderAlreadyComplete := state.Versioned().V1.Lifecycle.StepsCompleted[step.Shared().ID]
 	progress, ok := d.StepProgress.Load(step.Shared().ID)
-	shouldRender := !ok || progress.Detail == "success" && !renderAlreadyComplete
+	shouldRender := !ok || progress.Detail == `{"status":"success"}` && !renderAlreadyComplete
 	if shouldRender {
 		d.completeStep(c)
 	} else {

--- a/pkg/lifecycle/daemon/routes_navcycle_kustomize.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_kustomize.go
@@ -1,0 +1,263 @@
+package daemon
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/ship/pkg/api"
+	patch2 "github.com/replicatedhq/ship/pkg/patch"
+	"github.com/replicatedhq/ship/pkg/state"
+)
+
+func (d *NavcycleRoutes) kustomizeSaveOverlay(c *gin.Context) {
+	debug := level.Debug(log.With(d.Logger, "handler", "kustomizeSaveOverlay"))
+	type Request struct {
+		Path     string `json:"path"`
+		Contents string `json:"contents"`
+	}
+
+	var request Request
+	if err := c.BindJSON(&request); err != nil {
+		level.Error(d.Logger).Log("event", "unmarshal request failed", "err", err)
+		c.AbortWithError(http.StatusInternalServerError, err)
+		return
+	}
+
+	if request.Path == "" || request.Contents == "" {
+		c.JSON(
+			http.StatusBadRequest,
+			map[string]string{
+				"error":  "bad_request",
+				"detail": "path and contents cannot be empty",
+			},
+		)
+		return
+	}
+
+	debug.Log("event", "request.bind")
+	currentState, err := d.StateManager.TryLoad()
+	if err != nil {
+		level.Error(d.Logger).Log("event", "unmarshal request failed", "err", err)
+		c.AbortWithError(http.StatusInternalServerError, err)
+		return
+	}
+
+	debug.Log("event", "current.load")
+	kustomize := currentState.CurrentKustomize()
+	if kustomize == nil {
+		kustomize = &state.Kustomize{}
+	}
+
+	if kustomize.Overlays == nil {
+		kustomize.Overlays = make(map[string]state.Overlay)
+	}
+
+	if _, ok := kustomize.Overlays["ship"]; !ok {
+		kustomize.Overlays["ship"] = state.Overlay{
+			Patches: make(map[string]string),
+		}
+	}
+
+	kustomize.Overlays["ship"].Patches[request.Path] = request.Contents
+
+	debug.Log("event", "newstate.save")
+	err = d.StateManager.SaveKustomize(kustomize)
+	if err != nil {
+		level.Error(d.Logger).Log("event", "unmarshal request failed", "err", err)
+		c.AbortWithError(500, err)
+		return
+	}
+
+	c.JSON(200, map[string]string{"status": "success"})
+}
+
+func (d *NavcycleRoutes) kustomizeGetFile(c *gin.Context) {
+	debug := level.Debug(log.With(d.Logger, "method", "kustomizeGetFile"))
+	debug.Log()
+
+	type Request struct {
+		Path string `json:"path"`
+	}
+
+	var request Request
+	if err := c.BindJSON(&request); err != nil {
+		level.Error(d.Logger).Log("event", "unmarshal request failed", "err", err)
+		c.AbortWithError(500, err)
+		return
+	}
+
+	type Response struct {
+		Base    string `json:"base"`
+		Overlay string `json:"overlay"`
+	}
+
+	step, ok := d.getKustomizeStepOrAbort(c) // todo this should fetch by step ID
+	if !ok {
+		return
+	}
+
+	base, err := d.TreeLoader.LoadFile(step.Kustomize.BasePath, request.Path)
+	if err != nil {
+		level.Warn(d.Logger).Log("event", "load file failed", "err", err)
+		c.AbortWithError(500, err)
+		return
+	}
+
+	savedState, err := d.StateManager.TryLoad()
+	if err != nil {
+		level.Error(d.Logger).Log("event", "load state failed", "err", err)
+		c.AbortWithError(500, err)
+		return
+	}
+
+	c.JSON(200, Response{
+		Base:    base,
+		Overlay: savedState.CurrentKustomizeOverlay(request.Path),
+	})
+}
+
+func (d *NavcycleRoutes) getKustomizeStepOrAbort(c *gin.Context) (api.Step, bool) {
+	var step api.Step
+	for _, step = range d.Release.Spec.Lifecycle.V1 {
+		if step.Kustomize != nil {
+			ok := d.maybeAbortDueToMissingRequirement(step.Shared().Requires, c, step.Shared().ID)
+			return step, ok
+		}
+	}
+	return step, false
+}
+
+func (d *NavcycleRoutes) kustomizeFinalize(c *gin.Context) {
+	level.Debug(d.Logger).Log("event", "kustomize.finalize", "detail", "not implemented")
+	c.JSON(200, map[string]interface{}{"status": "success"})
+}
+
+func (d *NavcycleRoutes) applyPatch(c *gin.Context) {
+	debug := level.Debug(log.With(d.Logger, "struct", "daemon", "handler", "applyPatch"))
+	type Request struct {
+		Patch string `json:"patch"`
+	}
+	var request Request
+
+	debug.Log("event", "request.bind")
+	if err := c.BindJSON(&request); err != nil {
+		level.Error(d.Logger).Log("event", "unmarshal request body failed", "err", err)
+		c.AbortWithError(500, errors.New("internal_server_error"))
+	}
+
+	modified, err := d.Patcher.ApplyPatch(request.Patch)
+	if err != nil {
+		level.Error(d.Logger).Log("event", "failed to merge patch with base", "err", err)
+		c.AbortWithError(500, errors.New("internal_server_error"))
+	}
+
+	c.JSON(200, map[string]interface{}{
+		"modified": string(modified),
+	})
+}
+
+func (d *NavcycleRoutes) createOrMergePatch(c *gin.Context) {
+	debug := level.Debug(log.With(d.Logger, "struct", "daemon", "handler", "createOrMergePatch"))
+	type Request struct {
+		Original string `json:"original"`
+		Modified string `json:"modified"`
+		Current  string `json:"current"`
+	}
+	var request Request
+
+	debug.Log("event", "request.bind")
+	if err := c.BindJSON(&request); err != nil {
+		level.Error(d.Logger).Log("event", "unmarshal request body failed", "err", err)
+		c.AbortWithError(500, errors.New("internal_server_error"))
+	}
+
+	step, ok := d.getKustomizeStepOrAbort(c)
+	if !ok {
+		return
+	}
+
+	debug.Log("event", "load.originalFile")
+	original, err := d.TreeLoader.LoadFile(step.Kustomize.BasePath, request.Original)
+	if err != nil {
+		level.Error(d.Logger).Log("event", "failed to read original file", "err", err)
+		c.AbortWithError(500, errors.New("internal_server_error"))
+	}
+
+	debug.Log("event", "patcher.CreatePatch")
+	// I have no idea why d.Patcher is hanging forever here
+	patcher := &patch2.ShipPatcher{
+		Logger: d.Logger,
+		FS:     d.Fs,
+	}
+	patch, err := patcher.CreateTwoWayMergePatch(original, request.Modified)
+	if err != nil {
+		level.Error(d.Logger).Log("event", "create two way merge patch", "err", err)
+		c.AbortWithError(500, errors.New("internal_server_error"))
+	}
+
+	if request.Current != "" {
+		out, err := d.Patcher.MergePatches([]byte(request.Current), patch)
+		if err != nil {
+			level.Error(d.Logger).Log("event", "merge current and new patch", "err", err)
+			c.AbortWithError(500, errors.New("internal_server_error"))
+		}
+		c.JSON(200, map[string]interface{}{
+			"patch": string(out),
+		})
+	} else {
+		c.JSON(200, map[string]interface{}{
+			"patch": string(patch),
+		})
+	}
+}
+
+func (d *NavcycleRoutes) deletePatch(c *gin.Context) {
+	debug := level.Debug(log.With(d.Logger, "struct", "daemon", "handler", "deletePatch"))
+	pathQueryParam := c.Query("path")
+	if pathQueryParam == "" {
+		c.AbortWithError(http.StatusBadRequest, errors.New("bad delete request"))
+	}
+
+	debug.Log("event")
+	currentState, err := d.StateManager.TryLoad()
+	if err != nil {
+		level.Error(d.Logger).Log("event", "try load state failed", "err", err)
+		c.AbortWithError(http.StatusInternalServerError, err)
+		return
+	}
+
+	kustomize := currentState.CurrentKustomize()
+	if kustomize == nil {
+		level.Error(d.Logger).Log("event", "empty kustomize")
+		c.AbortWithError(http.StatusBadRequest, errors.New("bad delete request"))
+		return
+	}
+
+	shipOverlay := kustomize.Ship()
+	if len(shipOverlay.Patches) == 0 {
+		level.Error(d.Logger).Log("event", "empty ship overlay")
+		c.AbortWithError(http.StatusBadRequest, errors.New("bad delete request"))
+		return
+	}
+
+	_, ok := shipOverlay.Patches[pathQueryParam]
+	if !ok {
+		level.Error(d.Logger).Log("event", "patch does not exist")
+		c.AbortWithError(http.StatusBadRequest, errors.New("bad delete request"))
+		return
+	}
+
+	debug.Log("event", "deletePatch", "path", pathQueryParam)
+	delete(shipOverlay.Patches, pathQueryParam)
+
+	if err := d.StateManager.SaveKustomize(kustomize); err != nil {
+		level.Error(d.Logger).Log("event", "patch does not exist")
+		c.AbortWithError(http.StatusBadRequest, errors.New("bad delete request"))
+		return
+	}
+
+	c.JSON(200, map[string]string{"status": "success"})
+}

--- a/pkg/lifecycle/daemon/routes_v1.go
+++ b/pkg/lifecycle/daemon/routes_v1.go
@@ -83,12 +83,15 @@ func (d *V1Routes) Register(g *gin.RouterGroup, release *api.Release) {
 	v1.GET("/helm-metadata", d.getHelmMetadata(release))
 	v1.POST("/helm-values", d.saveHelmValues)
 
-	v1.POST("/kustomize/file", d.requireKustomize(), d.kustomizeGetFile)
-	v1.POST("/kustomize/save", d.requireKustomize(), d.kustomizeSaveOverlay)
-	v1.POST("/kustomize/finalize", d.requireKustomize(), d.kustomizeFinalize)
-	v1.POST("/kustomize/patch", d.requireKustomize(), d.createOrMergePatch)
-	v1.DELETE("/kustomize/patch", d.requireKustomize(), d.deletePatch)
-	v1.POST("/kustomize/apply", d.requireKustomize(), d.applyPatch)
+	/// haaack -- refactor this out into a sub routing component
+	if !d.Viper.GetBool("navcycle") {
+		v1.POST("/kustomize/file", d.requireKustomize(), d.kustomizeGetFile)
+		v1.POST("/kustomize/save", d.requireKustomize(), d.kustomizeSaveOverlay)
+		v1.POST("/kustomize/finalize", d.requireKustomize(), d.kustomizeFinalize)
+		v1.POST("/kustomize/patch", d.requireKustomize(), d.createOrMergePatch)
+		v1.DELETE("/kustomize/patch", d.requireKustomize(), d.deletePatch)
+		v1.POST("/kustomize/apply", d.requireKustomize(), d.applyPatch)
+	}
 }
 
 func (d *V1Routes) applyPatch(c *gin.Context) {


### PR DESCRIPTION
What I Did
------------

Copy over v1 kustomize routes into navcycle. Need to either remove from
V1Router or just delete that thing entirely.

How I Did it
------------

- copy over routes, make with some changes for navcycle state management
- e.g. `d.requireKustomize` is no longer a thing since navcycle has no
"current step", but instead we have `getKustomizeStepOrAbort`, which
enforces step requirements/dependencies
- add a hack to create a `patcher.ShipPatcher` inline instead of using
dig, no idea why the injected one hangs forever

How to verify it
------------

Run ship init and mess around with page 5 (kustomize)

Description for the Changelog
------------

Internal improvements for navigation

Picture of a Boat (not required but encouraged)
------------

![](https://upload.wikimedia.org/wikipedia/commons/thumb/5/53/Fraser_Island_shipwreck_of_Maheno_%28ship_1905%29_IGP4364.jpg/120px-Fraser_Island_shipwreck_of_Maheno_%28ship_1905%29_IGP4364.jpg)









<!-- (thanks https://github.com/docker/docker for this template) -->