### PR TITLE
Configurable duration on watch

### DIFF
--- a/pkg/cli/watch.go
+++ b/pkg/cli/watch.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"time"
 
 	_ "github.com/kubernetes-sigs/kustomize/pkg/app"
 	_ "github.com/kubernetes-sigs/kustomize/pkg/fs"
@@ -28,6 +29,8 @@ of 0 when there's an update available.`,
 			return nil
 		},
 	}
+
+	cmd.Flags().DurationP("interval", "", time.Duration(time.Minute*15), "interval to wait between cycles polling for updates")
 
 	return cmd
 }

--- a/pkg/ship/kustomize.go
+++ b/pkg/ship/kustomize.go
@@ -143,7 +143,7 @@ func (s *Ship) Watch(ctx context.Context) error {
 			return nil
 		}
 
-		time.Sleep(time.Minute * 5) // todo flag
+		time.Sleep(s.Viper.GetDuration("interval"))
 	}
 }
 


### PR DESCRIPTION
What I Did
------------
Add support for a configurable sleep interval on watch.

How I Did it
------------
Add a `--interval` flag to watch. Defaults to 15.

How to verify it
------------
Run tests to validate everything is ok. Run `ship watch --interval 10s` to get a quick poll.

Description for the Changelog
------------
Add `--interval` to watch command.


Picture of a Boat (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

