### PR TITLE
reduce production web bundle size from 44M to 27M

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build-deps dep-deps docker shell githooks dep e2e run citest ci-upload-coverage goreleaser integration-test build_ship_integration_test build-ui mark-ui-gitignored fmt lint vet test build embed-ui
+.PHONY: build-deps dep-deps docker shell githooks dep e2e run citest ci-upload-coverage goreleaser integration-test build_ship_integration_test build-ui mark-ui-gitignored fmt lint vet test build embed-ui clean
 
 
 SHELL := /bin/bash -o pipefail
@@ -277,3 +277,7 @@ dev-embed-ui:
 	  -prefix .state/tmp/ \
 	  -debug \
 	  .state/tmp/dist/...
+
+clean:
+	rm -rf .state
+	$(MAKE) -C web clean

--- a/web/Makefile
+++ b/web/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean deps serve_config serve_ship build_ship test test_CI build_ship_dev
+.PHONY: clean deps serve_config serve_ship build_ship test test_CI build_ship_dev build_ship_dev_v1 build_ship_v1
 
 PROGRESS := --progress
 SHELL := /bin/bash

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -116,7 +116,19 @@ module.exports = function (env) {
           ]
         },
       }),
-      new MonacoWebpackPlugin()
+      new MonacoWebpackPlugin({
+        languages: [
+          "yaml",
+          "json",
+        ],
+        features: [
+          "coreCommands",
+          "folding",
+          "bracketMatching",
+          "clipboard",
+          "find",
+        ],
+      })
     ],
   };
 


### PR DESCRIPTION
What I Did
------------

reduce production web bundle size from 44M to 27M (kind of Resolves #310)

How I Did it
------------

- disable a bunch of features/languages in MonacoEditorWebpackPlugin, we
  can probably stand to remove even more, but this is a start

How to verify it
------------

```
make clean
make -C web build_ship
make pkg/lifeycle/daemon/ui.bindatafs.go
du -sh pkg/lifecycle/daemon/ui*
```

Description for the Changelog
------------

Reduce size of Ship artifacts by removing unneeded frontend features.

![](https://cdn.bulbagarden.net/upload/thumb/b/b2/Unnamed_island_EP090.png/250px-Unnamed_island_EP090.png)