### PR TITLE
Ignore potential gitignore'd directories with Go files for Dep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ e2e-retraced/retraced-post.sh
 /installer/
 /installer.bak/
 /.ship/
-/base/
 integration/*/test*
 
 /.state/

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,6 +20,11 @@
 #  name = "github.com/x/y"
 #  version = "2.4.0"
 
+ignored = [
+  "github.com/replicatedcom/*",
+  "github.com/replicatedhq/ship/installer*"
+]
+
 [prune]
   go-tests = true
   unused-packages = true


### PR DESCRIPTION
What I Did
------------
Ignore potential gitignore'd directories with Go files for Dep

How I Did it
------------
Ignore `replicatedcom` repos and files in the gitignored `installer` directory.

How to verify it
------------
Run `dep ensure` with Go files in `installer` and no diff should be produced.

Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------
⛵️ 











<!-- (thanks https://github.com/docker/docker for this template) -->

