### PR TITLE
band-aid for tmp folder change

### DIFF
--- a/pkg/lifecycle/render/helm/fetch_test.go
+++ b/pkg/lifecycle/render/helm/fetch_test.go
@@ -68,7 +68,7 @@ func TestFetch(t *testing.T) {
 							if !ok {
 								return false
 							}
-							return strings.HasPrefix(githubAsset.Dest, "/tmp/helmchart")
+							return strings.Contains(githubAsset.Dest, "/helmchart")
 
 						},
 					},
@@ -77,7 +77,7 @@ func TestFetch(t *testing.T) {
 					map[string]interface{}{},
 				).Return(func(ctx context.Context) error { return nil })
 			},
-			expect:      "/tmp/helmchart",
+			expect:      "/helmchart",
 			expectError: "",
 		},
 	}
@@ -118,7 +118,7 @@ func TestFetch(t *testing.T) {
 			}
 
 			req.True(
-				strings.HasPrefix(dest, test.expect),
+				strings.Contains(dest, test.expect),
 				"expected %s to have prefix %s",
 				dest,
 				test.expect,


### PR DESCRIPTION
What I Did
------------

Fix test that was failing on OSX due to change in https://github.com/replicatedhq/ship/commit/41a60d2edbae34a1d119b7b0e728d0dfbb240f97#diff-2546fa025dcf3d6357953d01df66dc12R50


How I Did it
------------

Make test less specific about what the generated temp dir looks like.
Instead of checking `strings.HasPrefix`, we just check
`strings.Contains` instead.


How to verify it
------------

```
make test
```

on macOS


Description for the Changelog
------------


Fix unittest that only failed on macOS


:ship: