### PR TITLE
Don't write kustomization yaml to base

### DIFF
--- a/pkg/lifecycle/kustomize/kustomizer.go
+++ b/pkg/lifecycle/kustomize/kustomizer.go
@@ -3,6 +3,7 @@ package kustomize
 import (
 	"context"
 	"os"
+	"strings"
 
 	"time"
 
@@ -197,7 +198,7 @@ func (l *Kustomizer) WriteBase(step api.Kustomize) error {
 				debug.Log("event", "walk.fail", "path", targetPath)
 				return errors.Wrap(err, "failed to walk path")
 			}
-			if filepath.Ext(targetPath) == ".yaml" {
+			if filepath.Ext(targetPath) == ".yaml" && !strings.HasSuffix(targetPath, "kustomization.yaml") {
 				relativePath, err := filepath.Rel(step.BasePath, targetPath)
 				if err != nil {
 					debug.Log("event", "relativepath.fail", "base", step.BasePath, "target", targetPath)


### PR DESCRIPTION
What I Did
------------
Removed `kustomization.yaml` from base resource list in `kustomization.yaml`.

How I Did it
------------
Check filename, skip if name match.

How to verify it
------------
Run ship and be sure to run the final command (kustomize build)

Description for the Changelog
------------
- Fixed bug that was including kustomization.yaml in the kustomization.yaml


Picture of a Boat (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

