### PR TITLE
make GetChartAndReadmeContents verify that the url was a github url

### DIFF
--- a/pkg/specs/chart.go
+++ b/pkg/specs/chart.go
@@ -10,19 +10,17 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/google/go-github/github"
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/constants"
 	"github.com/spf13/afero"
-
-	"path"
-
-	"github.com/google/go-github/github"
-	"github.com/replicatedhq/ship/pkg/api"
 	"gopkg.in/yaml.v2"
 )
 
@@ -137,6 +135,10 @@ func (g *GithubClient) GetChartAndReadmeContents(ctx context.Context, chartURLSt
 	chartURL, err := url.Parse(chartURLString)
 	if err != nil {
 		return err
+	}
+
+	if !strings.Contains(chartURL.Host, "github.com") {
+		return errors.New(fmt.Sprintf("%s is not a Github URL", chartURLString))
 	}
 
 	owner, repo, branch, path, err := decodeGitHubURL(chartURL.Path)


### PR DESCRIPTION
What I Did
------------
Added a check to make sure we only try to download github repos from github.

How I Did it
------------


How to verify it
------------
Look at the `With a non-github url` unit test. Or just look at the code, it's 3 lines.

Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------
![image](https://user-images.githubusercontent.com/2318911/44237418-39e6dc80-a165-11e8-934e-e3b97445003a.png "from http://berlinwateradventuresandjetskirentals.com/paddleboat/")









<!-- (thanks https://github.com/docker/docker for this template) -->

