### PR TITLE
Cannot create an overlay patch to an empty spec

### DIFF
--- a/web/src/components/kustomize/kustomize_overlay/AceEditorHOC.jsx
+++ b/web/src/components/kustomize/kustomize_overlay/AceEditorHOC.jsx
@@ -59,12 +59,10 @@ export class AceEditorHOC extends React.Component {
 
     if (activeMarker.length > 0) {
       const matchingMarker = activeMarker[0];
-      if (matchingMarker.mapping.value) {
-        let tree = yaml.safeLoad(fileToView.baseContent);
-        const modifiedTree = set(tree, matchingMarker.path, PATCH_TOKEN);
-        const dirtybaseContent = yaml.safeDump(modifiedTree);
-        this.props.handleGeneratePatch(dirtybaseContent);
-      }
+      let tree = yaml.safeLoad(fileToView.baseContent);
+      const modifiedTree = set(tree, matchingMarker.path, PATCH_TOKEN);
+      const dirtybaseContent = yaml.safeDump(modifiedTree);
+      this.props.handleGeneratePatch(dirtybaseContent);
     }
   }
 
@@ -122,7 +120,7 @@ export class AceEditorHOC extends React.Component {
             endRow: endRow + 1,
             className: "marker-highlight-null",
             mapping,
-            path,
+            path: [...path, key.value],
           }
           return markers.push(nullMarker);
         }


### PR DESCRIPTION
What I Did
------------
Closes #364


How I Did it
------------
- Allow map items with null values (empty maps) to be rendered in the generated patch spec in the editor
- Added the leaf item to the path in the spec of the above items.


How to verify it
------------
Follow steps in #364

Description for the Changelog
------------
Fix #364


Picture of a Boat (not required but encouraged)
------------
![e1dc9f9dc11f1504647429-goat-transparent](https://user-images.githubusercontent.com/1004892/44238260-c050ed80-a168-11e8-90f5-49db2c480bcd.png)












<!-- (thanks https://github.com/docker/docker for this template) -->

