### PR TITLE
Properly set $HELM_HOME on Helm commands

### DIFF
--- a/pkg/helm/dependency.go
+++ b/pkg/helm/dependency.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/helm/pkg/chartutil"
+	"k8s.io/helm/pkg/helm/helmpath"
 )
 
 const dependencyDesc = `
@@ -279,8 +280,13 @@ func (l *dependencyListCmd) printMissing(reqs *chartutil.Requirements) {
 }
 
 // NewDependencyCmd returns `helm dependency` as a cobra command
-func NewDependencyCmd(args []string) *cobra.Command {
+func NewDependencyCmd(args []string) (*cobra.Command, error) {
 	command := newDependencyCmd(new(bytes.Buffer))
+	helmHome, err := helmHome()
+	if err != nil {
+		return nil, err
+	}
+	settings.Home = helmpath.Home(helmHome)
 	command.SetArgs(args)
-	return command
+	return command, nil
 }

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -35,6 +35,7 @@ import (
 
 	"k8s.io/helm/pkg/chartutil"
 	"k8s.io/helm/pkg/engine"
+	"k8s.io/helm/pkg/helm/helmpath"
 	"k8s.io/helm/pkg/proto/hapi/chart"
 	"k8s.io/helm/pkg/proto/hapi/release"
 	util "k8s.io/helm/pkg/releaseutil"
@@ -328,8 +329,13 @@ func ensureDirectoryForFile(file string) error {
 }
 
 // NewTemplateCmd returns `helm template` as a cobra command
-func NewTemplateCmd(args []string) *cobra.Command {
+func NewTemplateCmd(args []string) (*cobra.Command, error) {
 	command := newTemplateCmd(new(bytes.Buffer))
+	helmHome, err := helmHome()
+	if err != nil {
+		return nil, err
+	}
+	settings.Home = helmpath.Home(helmHome)
 	command.SetArgs(args)
-	return command
+	return command, nil
 }

--- a/pkg/lifecycle/render/helm/commands.go
+++ b/pkg/lifecycle/render/helm/commands.go
@@ -23,12 +23,18 @@ func (h *helmCommands) DependencyUpdate(chartRoot string) error {
 		"update",
 		chartRoot,
 	}
-	dependencyCommand := helm.NewDependencyCmd(dependencyArgs)
+	dependencyCommand, err := helm.NewDependencyCmd(dependencyArgs)
+	if err != nil {
+		return err
+	}
 	return dependencyCommand.Execute()
 }
 
 func (h *helmCommands) Template(chartName string, args []string) error {
-	templateCommand := helm.NewTemplateCmd(append([]string{chartName}, args...))
+	templateCommand, err := helm.NewTemplateCmd(append([]string{chartName}, args...))
+	if err != nil {
+		return err
+	}
 	return templateCommand.Execute()
 }
 


### PR DESCRIPTION
What I Did
------------
The `ship init` command was broken because `$HELM_HOME` was not set properly on the `helm dependency update` command. This PR fixes that issue.

How I Did it
------------
- Initialize default HELM_HOME in all commands except init
- Return errors from command constructors

How to verify it
------------
Running `ship init github.com/helm/charts/stable/datadog` and making it past the rendering stage.

Description for the Changelog
------------
- Properly set HELM_HOME on Helm commands


Picture of a Boat (not required but encouraged)
------------
![](http://cdn.earthporm.com/wp-content/uploads/2014/06/sinking-boat-92.jpg)











<!-- (thanks https://github.com/docker/docker for this template) -->

