### PR TITLE
Use system default TempDir

### DIFF
--- a/pkg/lifecycle/render/dockerlayer/layer.go
+++ b/pkg/lifecycle/render/dockerlayer/layer.go
@@ -87,14 +87,14 @@ func (u *Unpacker) Execute(
 func (u *Unpacker) getPaths(asset api.DockerLayerAsset, rootFs root.Fs) (string, string, string, string, error) {
 	fail := func(err error) (string, string, string, string, error) { return "", "", "", "", err }
 
-	saveDir, err := rootFs.TempDir("/tmp", "dockerlayer")
+	saveDir, err := rootFs.TempDir("", "dockerlayer")
 	if err != nil {
 		return fail(errors.Wrap(err, "get image save tmpdir"))
 	}
 
 	savePath := path.Join(saveDir, "image.tar")
 
-	firstPassUnpackPath, err := rootFs.TempDir("/tmp", "dockerlayer")
+	firstPassUnpackPath, err := rootFs.TempDir("", "dockerlayer")
 	if err != nil {
 		return fail(errors.Wrap(err, "get unpack tmpdir"))
 	}

--- a/pkg/testing/tmpfs/tmp.go
+++ b/pkg/testing/tmpfs/tmp.go
@@ -12,7 +12,7 @@ import (
 
 func Tmpdir(t *testing.T) (string, func()) {
 	req := require.New(t)
-	d, err := ioutil.TempDir("/tmp", "gotest")
+	d, err := ioutil.TempDir("", "gotest")
 	req.NoError(err)
 
 	return d, func() {


### PR DESCRIPTION
What I Did
------------
Fixes #365

How I Did it
------------
Replaced instances of the string `"/tmp"` with `""`


How to verify it
------------
Run ship on a system that doesn't use `/tmp` as the default temp folder.


Description for the Changelog
------------
Closes #365 


Picture of a Boat (not required but encouraged)
------------
This does not deserve a picture of a beautiful boat.











<!-- (thanks https://github.com/docker/docker for this template) -->

