### PR TITLE
put tmp back for dockerlayer

### DIFF
--- a/pkg/lifecycle/render/dockerlayer/layer.go
+++ b/pkg/lifecycle/render/dockerlayer/layer.go
@@ -87,14 +87,14 @@ func (u *Unpacker) Execute(
 func (u *Unpacker) getPaths(asset api.DockerLayerAsset, rootFs root.Fs) (string, string, string, string, error) {
 	fail := func(err error) (string, string, string, string, error) { return "", "", "", "", err }
 
-	saveDir, err := rootFs.TempDir("", "dockerlayer")
+	saveDir, err := rootFs.TempDir("/tmp", "dockerlayer")
 	if err != nil {
 		return fail(errors.Wrap(err, "get image save tmpdir"))
 	}
 
 	savePath := path.Join(saveDir, "image.tar")
 
-	firstPassUnpackPath, err := rootFs.TempDir("", "dockerlayer")
+	firstPassUnpackPath, err := rootFs.TempDir("/tmp", "dockerlayer")
 	if err != nil {
 		return fail(errors.Wrap(err, "get unpack tmpdir"))
 	}

--- a/pkg/lifecycle/render/root/fs.go
+++ b/pkg/lifecycle/render/root/fs.go
@@ -1,6 +1,7 @@
 package root
 
 import (
+	"github.com/pkg/errors"
 	"github.com/replicatedhq/ship/pkg/constants"
 	"github.com/spf13/afero"
 )
@@ -9,6 +10,13 @@ import (
 type Fs struct {
 	afero.Afero
 	RootPath string
+}
+
+func (f *Fs) TempDir(prefix, name string) (string, error) {
+	if prefix == "" {
+		return "", errors.New("rootfs does not support using system default temp dirs")
+	}
+	return f.Afero.TempDir(prefix, name)
 }
 
 // NewRootFS initializes a Fs struct with a base path of root


### PR DESCRIPTION
What I Did
------------

Fix unit test on osx.


How I Did it
------------

- don't use system tmpdir with a chrooted afero.BasepathFs
- Chrooted `root.Fs` now refuses to create temp dirs with system default
prefix

How to verify it
------------

run

```
ginkgo -r -p integration
```

Description for the Changelog
------------

None

:fire:










<!-- (thanks https://github.com/docker/docker for this template) -->