### PR TITLE
Remove `helm template` file writing log

### DIFF
--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -313,7 +313,7 @@ func writeToFile(outputDir string, name string, data string) error {
 		return err
 	}
 
-	fmt.Printf("wrote %s\n", outfileName)
+	//fmt.Printf("wrote %s\n", outfileName)
 	return nil
 }
 


### PR DESCRIPTION
What I Did
------------
Removes an internal `helm template` log when rendering Helm templates.

How I Did it
------------
Commented out a log in `pkg/helm/template.go`

How to verify it
------------
Run `ship init` and you should see no more `wrote ...` logs in output

Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------
⛵️ 











<!-- (thanks https://github.com/docker/docker for this template) -->

