### PR TITLE
enable init_chart integration tests on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,7 @@ jobs:
           $GOPATH/bin/ginkgo -p -stream integration/base
           $GOPATH/bin/ginkgo -p -stream integration/update
           $GOPATH/bin/ginkgo -p -stream integration/init_app
+          $GOPATH/bin/ginkgo -p -stream integration/init_chart
 
   deploy_unstable:
     docker:

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -31,7 +31,8 @@ ADD . /go/src/github.com/replicatedhq/ship
 RUN cd /go/src/github.com/replicatedhq/ship && \
     go test -c ./integration/base && \
     go test -c ./integration/update && \
-    go test -c ./integration/init_app
+    go test -c ./integration/init_app && \
+    go test -c ./integration/init_chart
 
 # package things up
 FROM alpine
@@ -52,6 +53,7 @@ RUN cd /test && rm *.go
 COPY --from=build-step /go/src/github.com/replicatedhq/ship/base.test /test/base/
 COPY --from=build-step /go/src/github.com/replicatedhq/ship/update.test /test/update/
 COPY --from=build-step /go/src/github.com/replicatedhq/ship/init_app.test /test/init_app/
+COPY --from=build-step /go/src/github.com/replicatedhq/ship/init_chart.test /test/init_chart/
 ENTRYPOINT ./integration_docker_start.sh
 
 

--- a/integration/integration_docker_start.sh
+++ b/integration/integration_docker_start.sh
@@ -17,5 +17,9 @@ echo "END UPDATE TESTS"
 cd ../init_app
 echo "START INIT_APP TESTS"
 ./init_app.test
-echo "END UPDATE TESTS"
+echo "END INIT_APP TESTS"
 
+cd ../init_chart
+echo "START INIT_CHART TESTS"
+./init_chart.test
+echo "END INIT_CHART TESTS"


### PR DESCRIPTION
What I Did
------------
Enabled the init_chart set of integration tests on CircleCI and in the Integration Tests docker image. This suite was added in https://github.com/replicatedhq/ship/pull/392.

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------
![image](https://user-images.githubusercontent.com/2318911/44294747-46e0fa00-a251-11e8-98bd-c1989f26bf19.png)












<!-- (thanks https://github.com/docker/docker for this template) -->

