### PR TITLE
Group all stdlib imports by default in goland

### DIFF
--- a/.idea/go.imports.xml
+++ b/.idea/go.imports.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GoImports">
+    <option name="groupStdlibImports" value="true" />
+    <option name="importSorting" value="GOIMPORTS" />
+    <option name="moveAllImportsInOneDeclaration" value="true" />
+    <option name="moveAllStdlibImportsInOneGroup" value="true" />
+    <option name="optimizeImportsOnTheFly" value="false" />
+  </component>
+</project>


### PR DESCRIPTION
What I Did
------------
Added go imports settings for Goland to the repo.
![settings](https://user-images.githubusercontent.com/2318911/44361091-ae759000-a471-11e8-99c7-28943d09999e.png)


How I Did it
------------
`git add -f .idea/go.imports.xml`


How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------
![image](https://user-images.githubusercontent.com/2318911/44361185-f4caef00-a471-11e8-9466-d929bb5cbf2f.png)












<!-- (thanks https://github.com/docker/docker for this template) -->

