### PR TITLE
Adding a missing err check from conflict resolutions

### DIFF
--- a/pkg/ship/kustomize.go
+++ b/pkg/ship/kustomize.go
@@ -81,6 +81,9 @@ func (s *Ship) Update(ctx context.Context) error {
 	s.Daemon.SetProgress(daemontypes.StringProgress("kustomize", `Downloading latest from upstream `+upstreamURL))
 
 	release, err := s.Resolver.ResolveRelease(ctx, upstreamURL)
+	if err != nil {
+		return errors.Wrapf(err, "resolve helm chart metadata for %s", upstreamURL)
+	}
 
 	release.Spec.Lifecycle = s.IDPatcher.EnsureAllStepsHaveUniqueIDs(release.Spec.Lifecycle)
 
@@ -169,7 +172,6 @@ Continuing will delete this state, would you like to continue? There is no undo.
 	release, err := s.Resolver.ResolveRelease(ctx, s.Viper.GetString("target"))
 	if err != nil {
 		return errors.Wrap(err, "resolve release")
-
 	}
 
 	release.Spec.Lifecycle = s.IDPatcher.EnsureAllStepsHaveUniqueIDs(release.Spec.Lifecycle)


### PR DESCRIPTION
What I Did
------------
Made things a bit safer.


How I Did it
------------
By adding a missing `err != nil` check

How to verify it
------------
Run ship init with bogus helm location.

Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------
![titanic_sinking_tw](https://user-images.githubusercontent.com/1004892/44363681-b5a09c00-a479-11e8-8ce7-24a509c9fd29.jpg)












<!-- (thanks https://github.com/docker/docker for this template) -->

