### PR TITLE
roll back rm state changes, the logic is a little wrong

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,11 +237,7 @@ bin/ship: $(FULLSRC)
 
 # tests base "ship" cli
 integration-test:
-	ginkgo -p -stream integration/base
-
-# tests "ship kustomize"
-integration-test-update:
-	ginkgo -p -stream integration/update
+	ginkgo -p -stream -r integration
 
 goreleaser: .state/goreleaser
 

--- a/integration/init_app/integration_test.go
+++ b/integration/init_app/integration_test.go
@@ -87,13 +87,13 @@ var _ = Describe("ship init replicated.app/...", func() {
 					testMetadata = readMetadata(testPath)
 
 					// if a token is provided, try to ensure the release matches what we have here in the repo
-
-					if vendorToken != "" {
-						channelName := fmt.Sprintf("integration replicated.app %s", filepath.Base(testPath))
-						installationID = createRelease(vendorEndpoint, vendorToken, testInputPath, testMetadata, channelName)
+					if vendorToken == "" {
+						Fail("Please set SHIP_INTEGRATION_VENDOR_TOKEN to run the init_app test suite")
 					}
-					close(done)
 
+					channelName := fmt.Sprintf("integration replicated.app %s", filepath.Base(testPath))
+					installationID = createRelease(vendorEndpoint, vendorToken, testInputPath, testMetadata, channelName)
+					close(done)
 				}, 20)
 
 				AfterEach(func() {

--- a/pkg/ship/kustomize.go
+++ b/pkg/ship/kustomize.go
@@ -6,8 +6,6 @@ import (
 
 	"strings"
 
-	"os"
-
 	"fmt"
 
 	"github.com/go-kit/kit/log"
@@ -146,13 +144,15 @@ func (s *Ship) Init(ctx context.Context) error {
 	}
 
 	// does a state file exist on disk?
-	if s.stateFileExists(ctx) && os.Getenv("RM_STATE") != "" {
+	if s.stateFileExists(ctx) {
 		debug.Log("event", "state.exists")
 
-		useUpdate, err := s.UI.Ask(`
+		s.UI.Warn(`
 An existing .ship directory was found. If you are trying to update this application, run "ship update".
-Continuing will delete this state, would you like to continue? There is no undo. (y/N)
-`)
+Continuing will delete this state, would you like to continue? There is no undo.`)
+
+		useUpdate, err := s.UI.Ask(`
+	Start from scratch? (y/N): `)
 		if err != nil {
 			return err
 		}

--- a/pkg/ship/ship.go
+++ b/pkg/ship/ship.go
@@ -207,4 +207,3 @@ func (s *Ship) execute(ctx context.Context, release *api.Release, selector *repl
 		return result
 	}
 }
-


### PR DESCRIPTION
What I Did
------------
roll back rm state changes, the logic is a little wrong

How I Did it
------------

- remove an if os.Getenv check
- clean up ExitWithWarn, no messaging about error logs or antyhing
- Improve prompt for "start from scratch" so it doesn't put the cursor on the next line

How to verify it
------------

`ship init ...; ship init ...;`, see state warning

Description for the Changelog
------------

Improve prompt when running `ship init` a second time.