### PR TITLE
changed destination of autogenerated ship api docs

### DIFF
--- a/hack/docs/Makefile
+++ b/hack/docs/Makefile
@@ -48,9 +48,14 @@ copy-to-help-center:
 	: To Copy to Help center, run the following command:
 	:
 	:    make pipeline
-	:    cp assets/* [path/to/help/center]/content/api/ship-assets/
-	:    cp lifecycle/* [path/to/help/center]/content/api/ship-lifecycle/
-	:    cp config/* [path/to/help/center]/content/api/ship-config/
+	:    cp assets/* [path/to/ship-www]/content/api/ship-assets/
+	:    cp lifecycle/* [path/to/ship-www]/content/api/ship-lifecycle/
+	:    cp config/* [path/to/ship-www]/content/api/ship-config/
+
+copy-to-help-center-gopath:
+	cp assets/* $$GOPATH/src/github.com/replicatedhq/ship-www/content/api/ship-assets/
+	cp lifecycle/* $$GOPATH/src/github.com/replicatedhq/ship-www/content/api/ship-lifecycle/
+	cp config/* $$GOPATH/src/github.com/replicatedhq/ship-www/content/api/ship-config/
 
 copy-replicated-lint:
 	: To Copy to replicated lint, run the following command:

--- a/hack/docs/mutations.json
+++ b/hack/docs/mutations.json
@@ -866,7 +866,7 @@
   {
     "path": "properties.lifecycle.properties.v1.items.properties.config",
     "merge": {
-      "description": "A `config` step will present the user with a screen to customize options as defined in your top-level `config` section",
+      "description": "A `config` step will present the user with a screen to customize options as defined in your top-level `config` section.",
       "examples": [
         {}
       ]

--- a/hack/docs/schema.json
+++ b/hack/docs/schema.json
@@ -713,7 +713,7 @@
             "type": "object",
             "properties": {
               "config": {
-                "description": "A `config` step will present the user with a screen to customize options as defined in your top-level `config` section",
+                "description": "A `config` step will present the user with a screen to customize options as defined in your top-level `config` section.",
                 "examples": [
                   {}
                 ],

--- a/hack/docs/src/markdown.ts
+++ b/hack/docs/src/markdown.ts
@@ -146,7 +146,7 @@ ${yaml.safeDump({[subgroup]: {v1: [{[specType]: example}]}})}${"```"}
 function writeHeader(specTypes: any, specType, subgroup: string) {
   return `---
 categories:
-- ship-${subgroup}
+- ship-api-${subgroup}
 date: 2018-01-17T23:51:55Z
 description: ${specTypes[specType].description || ""}
 index: docs

--- a/hack/docs/src/static.ts
+++ b/hack/docs/src/static.ts
@@ -1,6 +1,6 @@
 export const ASSETS_INDEX_DOC = `---
 categories:
-- ship-assets
+- ship-api-assets
 date: 2018-01-17T23:51:55Z
 description: Reference Documentation for defining your Ship application assets 
 index: docs
@@ -13,13 +13,12 @@ gradient: "purpleToPink"
 
 ## Ship Assets
 
-This is the reference documenation for Ship assets. To get started with Ship, head on over to [Shipping a Helm Application](/guides/helm-application/)
-
+Ship Assets are files rendered during the [render](/api/ship-lifecycle/render) lifecycle step.
 `;
 
 export const LIFECYCLE_INDEX_DOC = `---
 categories:
-- ship-lifecycle
+- ship-api-lifecycle
 date: 2018-01-17T23:51:55Z
 description: Reference Documentation for defining your Ship application lifecycle 
 index: docs
@@ -32,13 +31,13 @@ gradient: "purpleToPink"
 
 ## Ship Lifecycle
 
-This is the reference documenation for Ship lifecycle. To get started with Ship, head on over to [Shipping a Helm Application](/guides/helm-application/)
+Ship lifecycle steps define the steps that a Ship application will proceed through.
 
 `;
 
 export const CONFIG_INDEX_DOC = `---
 categories:
-- ship-config
+- ship-api-config
 date: 2018-01-17T23:51:55Z
 description: Reference Documentation for defining your Ship application configuration options 
 index: docs
@@ -51,7 +50,5 @@ gradient: "purpleToPink"
 
 ## Ship Config
 
-This is the reference documenation for Ship config. To get started with Ship, head on over to [Shipping a Helm Application](/guides/helm-application/).  The configuration options API is identical to that used for applications managed by
-Replicated's scheduler suite, and the documentation can be found at [Config Screen YAML
-](/docs/config-screen/config-yaml/).
+This is the reference documentation for Ship config. It has unfortunately not yet been created. It is largely shared with the Replicated config described [here](https://help.replicated.com/docs/config-screen/config-yaml/).
 `;


### PR DESCRIPTION
What I Did
------------
Updated the api docs autogeneration code for inclusion in https://ship.replicated.com/ instead of https://help.replicated.com/

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------
![USNS Mercy](https://user-images.githubusercontent.com/2318911/44421214-bf3b0a00-a534-11e8-924e-9c142bc2fd57.png "USNS Mercy")












<!-- (thanks https://github.com/docker/docker for this template) -->

