### PR TITLE
Improvements and fixes to `ship watch`

### DIFF
--- a/integration/base/integration_test.go
+++ b/integration/base/integration_test.go
@@ -60,6 +60,7 @@ var _ = Describe("ship app", func() {
 				var testMetadata TestMetadata
 
 				BeforeEach(func() {
+					os.Setenv("NO_OS_EXIT", "1")
 					// create a temporary directory within this directory to compare files with
 					testOutputPath, err = ioutil.TempDir(testPath, "_test_")
 					Expect(err).NotTo(HaveOccurred())

--- a/integration/init/integration_test.go
+++ b/integration/init/integration_test.go
@@ -55,6 +55,7 @@ var _ = Describe("ship init with arbitrary upstream", func() {
 				var testMetadata TestMetadata
 
 				BeforeEach(func() {
+					os.Setenv("NO_OS_EXIT", "1")
 					// create a temporary directory within this directory to compare files with
 					testOutputPath, err = ioutil.TempDir(testPath, "_test_")
 					Expect(err).NotTo(HaveOccurred())

--- a/integration/init_app/integration_test.go
+++ b/integration/init_app/integration_test.go
@@ -78,6 +78,7 @@ var _ = Describe("ship init replicated.app/...", func() {
 				}
 
 				BeforeEach(func(done chan<- interface{}) {
+					os.Setenv("NO_OS_EXIT", "1")
 					// create a temporary directory within this directory to compare files with
 					testOutputPath, err = ioutil.TempDir(testPath, "_test_")
 					Expect(err).NotTo(HaveOccurred())

--- a/integration/update/integration_test.go
+++ b/integration/update/integration_test.go
@@ -56,6 +56,7 @@ var _ = Describe("ship update", func() {
 				var testMetadata TestMetadata
 
 				BeforeEach(func() {
+					os.Setenv("NO_OS_EXIT", "1")
 					// create a temporary directory within this directory to compare files with
 					testOutputPath, err = ioutil.TempDir(testPath, "_test_")
 					Expect(err).NotTo(HaveOccurred())

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -34,7 +34,11 @@ func RootCmd() *cobra.Command {
 		// I think its okay to use real OS filesystem commands instead of afero here,
 		// since I think cobra lives outside the scope of dig injection/unit testing.
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return os.MkdirAll(constants.ShipPathInternalTmp, 0755)
+			var multiErr *multierror.Error
+			multiErr = multierror.Append(os.RemoveAll(constants.ShipPathInternalTmp))
+			multiErr = multierror.Append(os.MkdirAll(constants.ShipPathInternalTmp, 0755))
+			return multiErr.ErrorOrNil()
+
 		},
 		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
 			var multiErr *multierror.Error

--- a/pkg/cli/watch.go
+++ b/pkg/cli/watch.go
@@ -14,6 +14,7 @@ import (
 )
 
 func Watch() *cobra.Command {
+	v := viper.GetViper()
 	cmd := &cobra.Command{
 		Use:   "watch",
 		Short: "Watch an upstream for updates",
@@ -21,7 +22,7 @@ func Watch() *cobra.Command {
 change has been published. The watch command will return with an exit code
 of 0 when there's an update available.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			s, err := ship.Get(viper.GetViper())
+			s, err := ship.Get(v)
 			if err != nil {
 				return err
 			}
@@ -32,6 +33,9 @@ of 0 when there's an update available.`,
 	}
 
 	cmd.Flags().DurationP("interval", "", time.Duration(time.Minute*15), "interval to wait between cycles polling for updates")
+
+	v.BindPFlags(cmd.PersistentFlags())
+	v.BindPFlags(cmd.Flags())
 
 	return cmd
 }

--- a/pkg/ship/kustomize.go
+++ b/pkg/ship/kustomize.go
@@ -2,18 +2,15 @@ package ship
 
 import (
 	"context"
-	"time"
+	"os"
 
 	"strings"
-
-	"fmt"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/constants"
-	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 	"github.com/replicatedhq/ship/pkg/specs"
 	"github.com/replicatedhq/ship/pkg/state"
 )
@@ -23,18 +20,6 @@ func (s *Ship) InitAndMaybeExit(ctx context.Context) {
 		if err.Error() == constants.ShouldUseUpdate {
 			s.ExitWithWarn(err)
 		}
-		s.ExitWithError(err)
-	}
-}
-
-func (s *Ship) WatchAndExit(ctx context.Context) {
-	if err := s.Watch(ctx); err != nil {
-		s.ExitWithError(err)
-	}
-}
-
-func (s *Ship) UpdateAndMaybeExit(ctx context.Context) {
-	if err := s.Update(ctx); err != nil {
 		s.ExitWithError(err)
 	}
 }
@@ -52,86 +37,6 @@ func (s *Ship) stateFileExists(ctx context.Context) bool {
 	return !noExistingState
 }
 
-func (s *Ship) Update(ctx context.Context) error {
-	debug := level.Debug(log.With(s.Logger, "method", "update"))
-	ctx, cancelFunc := context.WithCancel(ctx)
-	defer s.Shutdown(cancelFunc)
-
-	s.Daemon.SetProgress(daemontypes.StringProgress("kustomize", `loading state`))
-	// does a state already exist
-	existingState, err := s.State.TryLoad()
-	if err != nil {
-		return errors.Wrap(err, "load state")
-	}
-
-	if _, noExistingState := existingState.(state.Empty); noExistingState {
-		debug.Log("event", "state.missing")
-		return errors.New(`No state file found at ` + s.Viper.GetString("state-file") + `, please run "ship init"`)
-	}
-
-	debug.Log("event", "read.upstream")
-	upstreamURL := existingState.Upstream()
-	if upstreamURL == "" {
-		return errors.New(fmt.Sprintf(`No upstream URL found at %s, please run "ship init"`, s.Viper.GetString("state-file")))
-	}
-
-	debug.Log("event", "fetch latest chart")
-	s.Daemon.SetProgress(daemontypes.StringProgress("kustomize", `Downloading latest from upstream `+upstreamURL))
-
-	release, err := s.Resolver.ResolveRelease(ctx, upstreamURL)
-	if err != nil {
-		return errors.Wrapf(err, "resolve helm chart metadata for %s", upstreamURL)
-	}
-
-	release.Spec.Lifecycle = s.IDPatcher.EnsureAllStepsHaveUniqueIDs(release.Spec.Lifecycle)
-
-	return s.execute(ctx, release, nil, true)
-}
-
-func (s *Ship) Watch(ctx context.Context) error {
-	debug := level.Debug(log.With(s.Logger, "method", "watch"))
-	ctx, cancelFunc := context.WithCancel(ctx)
-	defer s.Shutdown(cancelFunc)
-
-	for {
-		existingState, err := s.State.TryLoad()
-		if err != nil {
-			return errors.Wrap(err, "load state")
-		}
-
-		if _, noExistingState := existingState.(state.Empty); noExistingState {
-			debug.Log("event", "state.missing")
-			return errors.New(`No state found, please run "ship init"`)
-		}
-
-		debug.Log("event", "read.upstream")
-
-		helmChartPath := existingState.Upstream()
-		if helmChartPath == "" {
-			return errors.New(`No current chart url found at ` + s.Viper.GetString("state-file") + `, please run "ship init"`)
-		}
-
-		debug.Log("event", "read.lastSHA")
-		lastSHA := existingState.Versioned().V1.ContentSHA
-		if lastSHA == "" {
-			return errors.New(`No current SHA found at ` + s.Viper.GetString("state-file") + `, please run "ship init"`)
-		}
-
-		debug.Log("event", "fetch latest chart")
-		release, err := s.Resolver.ResolveRelease(context.Background(), string(helmChartPath))
-		if err != nil {
-			return errors.Wrapf(err, "resolve helm chart metadata for %s", helmChartPath)
-		}
-
-		if release.Metadata.ShipAppMetadata.ContentSHA != existingState.Versioned().V1.ContentSHA {
-			debug.Log("event", "new sha")
-			return nil
-		}
-
-		time.Sleep(s.Viper.GetDuration("interval"))
-	}
-}
-
 func (s *Ship) Init(ctx context.Context) error {
 	debug := level.Debug(log.With(s.Logger, "method", "init"))
 	ctx, cancelFunc := context.WithCancel(ctx)
@@ -145,14 +50,35 @@ func (s *Ship) Init(ctx context.Context) error {
 
 	// does a state file exist on disk?
 	if s.stateFileExists(ctx) {
-		debug.Log("event", "state.exists")
+		if err := s.promptToRemoveState(); err != nil {
+			debug.Log("event", "state.remove.prompt.fail")
+			return errors.Wrap(err, "prompt to remove state")
+		}
+	}
 
+	release, err := s.Resolver.ResolveRelease(ctx, s.Viper.GetString("target"))
+	if err != nil {
+		return errors.Wrap(err, "resolve release")
+	}
+
+	release.Spec.Lifecycle = s.IDPatcher.EnsureAllStepsHaveUniqueIDs(release.Spec.Lifecycle)
+	return s.execute(ctx, release, nil, true)
+}
+
+func (s *Ship) promptToRemoveState() error {
+	debug := level.Debug(log.With(s.Logger, "event", "promptToRemoveState"))
+	debug.Log("event", "state.exists")
+	if os.Getenv("RM_STATE") == "1" {
+		if err := s.State.RemoveStateFile(); err != nil {
+			return errors.Wrap(err, "remove existing state")
+		}
+	} else {
 		s.UI.Warn(`
-An existing .ship directory was found. If you are trying to update this application, run "ship update".
-Continuing will delete this state, would you like to continue? There is no undo.`)
+		An existing .ship directory was found. If you are trying to update this application, run "ship update".
+		Continuing will delete this state, would you like to continue? There is no undo.`)
 
 		useUpdate, err := s.UI.Ask(`
-	Start from scratch? (y/N): `)
+			Start from scratch? (y/N): `)
 		if err != nil {
 			return err
 		}
@@ -168,14 +94,7 @@ Continuing will delete this state, would you like to continue? There is no undo.
 			return errors.New(constants.ShouldUseUpdate)
 		}
 	}
-
-	release, err := s.Resolver.ResolveRelease(ctx, s.Viper.GetString("target"))
-	if err != nil {
-		return errors.Wrap(err, "resolve release")
-	}
-
-	release.Spec.Lifecycle = s.IDPatcher.EnsureAllStepsHaveUniqueIDs(release.Spec.Lifecycle)
-	return s.execute(ctx, release, nil, true)
+	return nil
 }
 
 func (s *Ship) fakeKustomizeRawRelease() *api.Release {

--- a/pkg/ship/ship.go
+++ b/pkg/ship/ship.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/replicatedhq/ship/pkg/helpers/flags"
+	"github.com/replicatedhq/ship/pkg/specs/apptype"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -40,14 +41,15 @@ type Ship struct {
 	InstallationID string
 	PlanOnly       bool
 
-	Daemon      daemontypes.Daemon
-	Resolver    *specs.Resolver
-	AppResolver replicatedapp.Resolver
-	Runbook     string
-	UI          cli.Ui
-	State       state.Manager
-	IDPatcher   *specs.IDPatcher
-	FS          afero.Afero
+	Daemon           daemontypes.Daemon
+	Resolver         *specs.Resolver
+	AppTypeInspector apptype.Inspector
+	AppResolver      replicatedapp.Resolver
+	Runbook          string
+	UI               cli.Ui
+	State            state.Manager
+	IDPatcher        *specs.IDPatcher
+	FS               afero.Afero
 
 	KustomizeRaw string
 	Runner       *lifecycle.Runner
@@ -65,6 +67,7 @@ func NewShip(
 	stateManager state.Manager,
 	patcher *specs.IDPatcher,
 	fs afero.Afero,
+	inspector apptype.Inspector,
 ) (*Ship, error) {
 
 	return &Ship{
@@ -77,16 +80,17 @@ func NewShip(
 
 		KustomizeRaw: v.GetString("raw"),
 
-		Viper:       v,
-		Logger:      logger,
-		Resolver:    resolver,
-		AppResolver: appresolver,
-		Daemon:      daemon,
-		UI:          ui,
-		Runner:      runner,
-		State:       stateManager,
-		IDPatcher:   patcher,
-		FS:          fs,
+		Viper:            v,
+		Logger:           logger,
+		Resolver:         resolver,
+		AppResolver:      appresolver,
+		AppTypeInspector: inspector,
+		Daemon:           daemon,
+		UI:               ui,
+		Runner:           runner,
+		State:            stateManager,
+		IDPatcher:        patcher,
+		FS:               fs,
 	}, nil
 }
 

--- a/pkg/ship/update.go
+++ b/pkg/ship/update.go
@@ -1,0 +1,54 @@
+package ship
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
+	"github.com/replicatedhq/ship/pkg/state"
+)
+
+func (s *Ship) UpdateAndMaybeExit(ctx context.Context) {
+	if err := s.Update(ctx); err != nil {
+		s.ExitWithError(err)
+	}
+}
+
+func (s *Ship) Update(ctx context.Context) error {
+	debug := level.Debug(log.With(s.Logger, "method", "update"))
+	ctx, cancelFunc := context.WithCancel(ctx)
+	defer s.Shutdown(cancelFunc)
+
+	s.Daemon.SetProgress(daemontypes.StringProgress("kustomize", `loading state`))
+	// does a state already exist
+	existingState, err := s.State.TryLoad()
+	if err != nil {
+		return errors.Wrap(err, "load state")
+	}
+
+	if _, noExistingState := existingState.(state.Empty); noExistingState {
+		debug.Log("event", "state.missing")
+		return errors.New(`No state file found at ` + s.Viper.GetString("state-file") + `, please run "ship init"`)
+	}
+
+	debug.Log("event", "read.upstream")
+	upstreamURL := existingState.Upstream()
+	if upstreamURL == "" {
+		return errors.New(fmt.Sprintf(`No upstream URL found at %s, please run "ship init"`, s.Viper.GetString("state-file")))
+	}
+
+	debug.Log("event", "fetch latest chart")
+	s.Daemon.SetProgress(daemontypes.StringProgress("kustomize", `Downloading latest from upstream `+upstreamURL))
+
+	release, err := s.Resolver.ResolveRelease(ctx, upstreamURL)
+	if err != nil {
+		return errors.Wrapf(err, "resolve helm chart metadata for %s", upstreamURL)
+	}
+
+	release.Spec.Lifecycle = s.IDPatcher.EnsureAllStepsHaveUniqueIDs(release.Spec.Lifecycle)
+
+	return s.execute(ctx, release, nil, true)
+}

--- a/pkg/ship/watch.go
+++ b/pkg/ship/watch.go
@@ -1,0 +1,81 @@
+package ship
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/ship/pkg/state"
+)
+
+func (s *Ship) WatchAndExit(ctx context.Context) {
+	if err := s.Watch(ctx); err != nil {
+		s.ExitWithError(err)
+	}
+}
+
+func (s *Ship) Watch(ctx context.Context) error {
+	debug := level.Debug(log.With(s.Logger, "method", "watch"))
+	ctx, cancelFunc := context.WithCancel(ctx)
+	defer s.Shutdown(cancelFunc)
+
+	for {
+		existingState, err := s.State.TryLoad()
+		if err != nil {
+			return errors.Wrap(err, "load state")
+		}
+
+		if _, noExistingState := existingState.(state.Empty); noExistingState {
+			debug.Log("event", "state.missing")
+			return errors.New(`No state found, please run "ship init"`)
+		}
+
+		debug.Log("event", "read.upstream")
+
+		upstream := existingState.Upstream()
+		if upstream == "" {
+			return errors.New(`No current chart url found at ` + s.Viper.GetString("state-file") + `, please run "ship init"`)
+		}
+
+		debug.Log("event", "read.lastSHA")
+		lastSHA := existingState.Versioned().V1.ContentSHA
+		if lastSHA == "" {
+			return errors.New(`No current SHA found at ` + s.Viper.GetString("state-file") + `, please run "ship init"`)
+		}
+
+		debug.Log("event", "fetch latest chart")
+		appType, localPath, err := s.AppTypeInspector.DetermineApplicationType(ctx, upstream)
+		if err != nil {
+			return errors.Wrapf(err, "resolve app type for %s", upstream)
+		}
+		debug.Log("event", "apptype.inspect", "type", appType, "localPath", localPath)
+
+		metadata, err := s.Resolver.ResolveBaseMetadata(upstream, localPath)
+		if err != nil {
+			return errors.Wrapf(err, "resolve metadata and content sha for %s", upstream)
+		}
+		debug.Log("event", "metadata.resolve", "sha", metadata.ContentSHA)
+
+		if metadata.ContentSHA != existingState.Versioned().V1.ContentSHA {
+			debug.Log(
+				"event", "new sha",
+				"previous", existingState.Versioned().V1.ContentSHA,
+				"new", metadata.ContentSHA,
+			)
+			s.UI.Info(fmt.Sprintf("%s has an update available", upstream))
+			return nil
+		}
+
+		debug.Log(
+			"event", "sha.unchanged",
+			"previous", existingState.Versioned().V1.ContentSHA,
+			"new", metadata.ContentSHA,
+			"sleeping", s.Viper.GetDuration("interval"),
+		)
+
+		time.Sleep(s.Viper.GetDuration("interval"))
+	}
+}

--- a/pkg/specs/chart.go
+++ b/pkg/specs/chart.go
@@ -148,7 +148,7 @@ to deploy the overlaid assets to your cluster.
 func (r *Resolver) resolveMetadata(ctx context.Context, upstream, localPath string) (*api.ShipAppMetadata, error) {
 	debug := level.Debug(log.With(r.Logger, "method", "ResolveHelmMetadata"))
 
-	baseMetadata, err := r.resolveBaseMetadata(upstream, localPath)
+	baseMetadata, err := r.ResolveBaseMetadata(upstream, localPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "resolve base metadata")
 	}
@@ -177,8 +177,8 @@ func (r *Resolver) resolveMetadata(ctx context.Context, upstream, localPath stri
 	return baseMetadata, nil
 }
 
-// resolveBaseMetadata resolves URL, ContentSHA, and Readme for the resource
-func (r *Resolver) resolveBaseMetadata(upstream string, localPath string) (*api.ShipAppMetadata, error) {
+// ResolveBaseMetadata resolves URL, ContentSHA, and Readme for the resource
+func (r *Resolver) ResolveBaseMetadata(upstream string, localPath string) (*api.ShipAppMetadata, error) {
 	debug := level.Debug(log.With(r.Logger, "method", "resolveBaseMetaData"))
 	var md api.ShipAppMetadata
 	md.URL = upstream

--- a/pkg/util/filesystem.go
+++ b/pkg/util/filesystem.go
@@ -55,7 +55,7 @@ func BackupIfPresent(fs afero.Afero, basePath string, logger log.Logger, ui cli.
 	}
 
 	backupDest := fmt.Sprintf("%s.bak", basePath)
-	ui.Warn(fmt.Sprintf("WARNING found directory %s, backing up to %s", basePath, backupDest))
+	ui.Warn(fmt.Sprintf("WARNING found directory %q, backing up to %q", basePath, backupDest))
 
 	level.Info(logger).Log("step.type", "render", "event", "unpackTarget.backup.remove", "src", basePath, "dest", backupDest)
 	if err := fs.RemoveAll(backupDest); err != nil {


### PR DESCRIPTION
What I Did
------------

Improve and fix some things with `ship watch`, Resolve #428

```
$ bin/ship watch --interval 30s
github.com/dexhorthy/sysdigcloud-kubernetes/sysdigcloud has an update available
```

How I Did it
------------

- apptype.Inspector no longer moves the cloned assets up from .ship/tmp into "base" or "chart"
- resolver.ResolveRelease handles moving chart up from .ship/tmp into "base" or "chart"
- remove defer os.RemoveAll in apptype.Inspector, is in `.ship/tmp` now, so it will get cleaned up eventually
- more/better debug logging in `ship watch`
- bind viper flags in `cli/watch.go` so `viper.GetDuration("interval")` works in watch command
- added some UI output for ship watch

Other stuff:

- move watch and update into their own files
- clean .ship/tmp on startup  in case its hanging around

How to verify it
------------

`ship init ...; ship watch --interval 30s`

Description for the Changelog
------------

Add configurable interval for `ship watch` via `--interval` flag

![](https://upload.wikimedia.org/wikipedia/commons/thumb/c/cf/Shipwreck_%289558712326%29.jpg/120px-Shipwreck_%289558712326%29.jpg)


What I Did
------------


How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->