### PR TITLE
Modify delete overlay logic

### DIFF
--- a/web/src/components/kustomize/kustomize_overlay/KustomizeOverlay.jsx
+++ b/web/src/components/kustomize/kustomize_overlay/KustomizeOverlay.jsx
@@ -129,7 +129,7 @@ export default class KustomizeOverlay extends React.Component {
       routeId,
       pollCallback
     } = this.props;
-    
+
     if (isNavcycle) {
       await finalizeStep({ action: actions[0] });
       startPoll(routeId, pollCallback);
@@ -143,10 +143,8 @@ export default class KustomizeOverlay extends React.Component {
   }
 
   async discardOverlay() {
-    const file = find(this.props.fileContents, ["key", this.state.selectedFile]);
-    if (file.overlayContent && file.overlayContent.length) {
-      await this.deleteOverlay(this.state.selectedFile);
-    }
+    const { overlayToDelete } = this.state;
+    await this.deleteOverlay(overlayToDelete);
     this.setState({
       patch: "",
       displayConfirmModal: false
@@ -239,7 +237,7 @@ export default class KustomizeOverlay extends React.Component {
                         files={tree.children}
                         basePath={tree.name}
                         handleFileSelect={(path) => this.setSelectedFile(path)}
-                        handleDeleteOverlay={(path) => this.toggleModal(path)}
+                        handleDeleteOverlay={this.toggleModal}
                         selectedFile={this.state.selectedFile}
                         isOverlayTree={tree.name === "overlays"}
                       />
@@ -344,7 +342,7 @@ export default class KustomizeOverlay extends React.Component {
                   <p className="u-margin--none u-fontSize--small u-color--dustyGray u-fontWeight--normal">Contributed by <a target="_blank" rel="noopener noreferrer" href="https://replicated.com" className="u-fontWeight--medium u-color--astral u-textDecoration--underlineOnHover">Replicated</a></p>
                 </div>
                 <div className="flex1 flex alignItems--center justifyContent--flexEnd">
-                  {selectedFile === "" ? 
+                  {selectedFile === "" ?
                     <button type="button" onClick={this.props.skipKustomize} className="btn primary">Continue</button>
                     :
                     <div className="flex">
@@ -376,7 +374,7 @@ export default class KustomizeOverlay extends React.Component {
               <button type="button" className="btn primary" onClick={this.discardOverlay}>Discard overlay</button>
             </div>
           </div>
-            
+
         </Modal>
       </div>
     );


### PR DESCRIPTION
What I Did
------------
- Modify delete overlay logic

How I Did it
------------
- Previous logic used `this.props.fileContents` to look up the file for deletion
-`this.props.fileContents` is only hydrated with the file when the file has been selected
- Modified logic uses the directly provided path for deletion 

How to verify it
------------
- Navigate through `init` workflow and delete a created overlay with any file selected and no file selected

Description for the Changelog
------------
Modify delete overlay logic


Picture of a Boat (not required but encouraged)
------------
🛶 











<!-- (thanks https://github.com/docker/docker for this template) -->

