### PR TITLE
suppress cobra output

### DIFF
--- a/pkg/helm/dependency.go
+++ b/pkg/helm/dependency.go
@@ -13,7 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*This file was edited by Replicated in 2018 to expose `helm dependency` as a function.*/
+/*This file was edited by Replicated in 2018 to
+  - expose `helm dependency` as a function
+  - silence the error output from the cobra command.
+*/
 
 package helm
 
@@ -115,10 +118,12 @@ func newDependencyListCmd(out io.Writer) *cobra.Command {
 	dlc := &dependencyListCmd{out: out}
 
 	cmd := &cobra.Command{
-		Use:     "list [flags] CHART",
-		Aliases: []string{"ls"},
-		Short:   "list the dependencies for the given chart",
-		Long:    dependencyListDesc,
+		Use:           "list [flags] CHART",
+		Aliases:       []string{"ls"},
+		Short:         "list the dependencies for the given chart",
+		Long:          dependencyListDesc,
+		SilenceErrors: true,
+		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cp := "."
 			if len(args) > 0 {

--- a/pkg/helm/dependency_build.go
+++ b/pkg/helm/dependency_build.go
@@ -13,7 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*This file was edited by Replicated in 2018 to expose `helm dependency build` as a function.*/
+/*This file was edited by Replicated in 2018 to
+  - expose `helm dependency build` as a function
+  - silence the error output from the cobra command.
+*/
 
 package helm
 

--- a/pkg/helm/dependency_update.go
+++ b/pkg/helm/dependency_update.go
@@ -13,7 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*This file was edited by Replicated in 2018 to expose `helm dependency update` as a function.*/
+/*This file was edited by Replicated in 2018 to
+  - expose `helm dependency update` as a function
+  - silence the error output from the cobra command.
+*/
 
 package helm
 
@@ -57,10 +60,12 @@ func newDependencyUpdateCmd(out io.Writer) *cobra.Command {
 	duc := &dependencyUpdateCmd{out: out}
 
 	cmd := &cobra.Command{
-		Use:     "update [flags] CHART",
-		Aliases: []string{"up"},
-		Short:   "update charts/ based on the contents of requirements.yaml",
-		Long:    dependencyUpDesc,
+		Use:           "update [flags] CHART",
+		Aliases:       []string{"up"},
+		Short:         "update charts/ based on the contents of requirements.yaml",
+		Long:          dependencyUpDesc,
+		SilenceErrors: true,
+		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cp := "."
 			if len(args) > 0 {

--- a/pkg/helm/fetch.go
+++ b/pkg/helm/fetch.go
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*This file was edited by Replicated in 2018 to remove some functionality and to expose `helm fetch` as a function.*/
+/*This file was edited by Replicated in 2018 to
+  - expose `helm fetch` as a function
+  - silence the error output from the cobra command.
+  - remove some functionality (todo document this)
+*/
 
 package helm
 

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -14,7 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*This file was edited by Replicated in 2018 to expose `helm template` as a function.*/
+/*This file was edited by Replicated in 2018 to
+  - expose `helm template` as a function
+  - silence the error output from the cobra command.
+*/
 
 package helm
 
@@ -88,10 +91,12 @@ func newTemplateCmd(out io.Writer) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "template [flags] CHART",
-		Short: fmt.Sprintf("locally render templates"),
-		Long:  templateDesc,
-		RunE:  t.run,
+		Use:           "template [flags] CHART",
+		Short:         fmt.Sprintf("locally render templates"),
+		Long:          templateDesc,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE:          t.run,
 	}
 
 	f := cmd.Flags()


### PR DESCRIPTION
What I Did
------------

Suppress printing usage/errors from helm commands

How I Did it
------------

Add `SupressOutput` and `SupressErrors` to cobra flags.

Long term we ought to refactor this to not use cobra, but this is an
improvement.

How to verify it
------------

Run ship against a chart with invalid values or dependencies.

Description for the Changelog
------------

Bugfix -- Suppress printing output from failed helm commands.


Picture of a Boat (not required but encouraged)
------------

:ship: