### PR TITLE
json MarshalIndent when saving as a secret to match the file marshal

### DIFF
--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -334,7 +334,7 @@ func (m *MManager) serializeAndWriteStateFile(state VersionedState) error {
 }
 
 func (m *MManager) serializeAndWriteStateSecret(state VersionedState) error {
-	serialized, err := json.Marshal(state)
+	serialized, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
 		return errors.Wrap(err, "serialize state")
 	}


### PR DESCRIPTION
What I Did
------------
Changed the json marshaller when creating state to create it with indents and pretty printed. It was previously doing this when saving to a state file, but was not when saving to a secret. The operator defaults to using a secret, and this creates a harder-to-read diff on update.

How I Did it
------------
Used the same param from saveStateFile when calling it in saveStateSecret.

How to verify it
------------
Run ship update saving a state to a secret, or run operator.

Description for the Changelog
------------
State will be pretty printed when saving to an in-cluster secret.


Picture of a Boat (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

