### PR TITLE
Fix ship update

### DIFF
--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -34,7 +34,6 @@ func Update() *cobra.Command {
 	}
 
 	cmd.Flags().BoolP("headed", "", false, "run ship update in headed mode")
-	cmd.Flags().Bool("rm-asset-dest", true, "Always remove asset destinations if already present")
 
 	viper.BindPFlags(cmd.Flags())
 	viper.AutomaticEnv()

--- a/pkg/ship/update.go
+++ b/pkg/ship/update.go
@@ -24,6 +24,8 @@ func (s *Ship) Update(ctx context.Context) error {
 	ctx, cancelFunc := context.WithCancel(ctx)
 	defer s.Shutdown(cancelFunc)
 
+	s.Viper.Set("rm-asset-dest", true)
+
 	s.Daemon.SetProgress(daemontypes.StringProgress("kustomize", `loading state`))
 	// does a state already exist
 	existingState, err := s.State.TryLoad()


### PR DESCRIPTION
What I Did
------------
Fixed #491 by adding the same flag to `ship update` as was added to `ship init` by PR #481 (`--rm-asset-dest`) with the default set to true


How I Did it
------------
It's a 1 line change

How to verify it
------------
Run `ship init https://github.com/replicatedhq/test-charts/tree/master/plain-k8s` and then `ship update`
Integration tests for `ship update` will be added (see https://github.com/replicatedhq/ship/pull/503) but there are currently other issues blocking this. (such as #498 and #502, though #498 may be made irrelevant by #500)

Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------

![image](https://user-images.githubusercontent.com/2318911/44694350-c88b1180-aa21-11e8-8288-45fc8c3df6a3.png)











<!-- (thanks https://github.com/docker/docker for this template) -->

