### PR TITLE
update codeclimate badges to refer to open source repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Ship
 =======
 
-[![Test Coverage](https://api.codeclimate.com/v1/badges/7e19355b20109fd50ada/test_coverage)](https://codeclimate.com/repos/5b217b8b536ddc029d005c48/test_coverage)
-[![Maintainability](https://api.codeclimate.com/v1/badges/7e19355b20109fd50ada/maintainability)](https://codeclimate.com/repos/5b217b8b536ddc029d005c48/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/a00869c41469d016a3c8/test_coverage)](https://codeclimate.com/github/replicatedhq/ship/test_coverage)
+[![Maintainability](https://api.codeclimate.com/v1/badges/a00869c41469d016a3c8/maintainability)](https://codeclimate.com/github/replicatedhq/ship/maintainability)
 [![CircleCI](https://circleci.com/gh/replicatedhq/ship.svg?style=svg&circle-token=471765bf5ec85ede48fcf02ea6a886dc6c5a73f1)](https://circleci.com/gh/replicatedhq/ship)
 [![Docker Image](https://images.microbadger.com/badges/image/replicated/ship.svg)](https://microbadger.com/images/replicated/ship)
 


### PR DESCRIPTION
What I Did
------------
Updated the codeclimate badges in the readme to refer to the open source codeclimate project.

How I Did it
------------
I changed the badge urls.

How to verify it
------------
Look at the readme for this fork and see new values reflected in the badges.

Description for the Changelog
------------
Codeclimate badges work


Picture of a Boat (not required but encouraged)
------------

![](https://meritbadge.org/wiki/images/6/68/Small-Boat_Sailing.jpg "from https://meritbadge.org/wiki/index.php/Image:Small-Boat_Sailing.jpg")










<!-- (thanks https://github.com/docker/docker for this template) -->

