### PR TITLE
Update config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,8 +115,10 @@ jobs:
           sudo $GOPATH/bin/registry serve config.yml > /dev/null 2>&1 &
           $GOPATH/bin/ginkgo -p -stream integration/base
           $GOPATH/bin/ginkgo -p -stream integration/update
-          $GOPATH/bin/ginkgo -p -stream integration/init_app
           $GOPATH/bin/ginkgo -p -stream integration/init
+          if [ -n "$SHIP_INTEGRATION_VENDOR_TOKEN" ]; then
+            $GOPATH/bin/ginkgo -p -stream integration/init_app
+          fi
 
   deploy_unstable:
     docker:


### PR DESCRIPTION
What I Did
------------

Make tests that integrate with pg.replicated.com opt-in

How I Did it
------------

Check if the required token is set, else skip

How to verify it
------------

Build from a fork that does not have the variable set

Description for the Changelog
------------

Ship integration testing in CI no longer requires a token to access pg.replicated.com. These tests will still be run if the token is set in the build environment.


![](https://upload.wikimedia.org/wikipedia/commons/2/2b/Shipwreck_%288321698639%29.jpg)
