### PR TITLE
Default fileToView

### DIFF
--- a/web/src/components/kustomize/kustomize_overlay/KustomizeOverlay.jsx
+++ b/web/src/components/kustomize/kustomize_overlay/KustomizeOverlay.jsx
@@ -9,6 +9,7 @@ import sortBy from "lodash/sortBy";
 import pick from "lodash/pick";
 import keyBy from "lodash/keyBy";
 import find from "lodash/find";
+import defaultTo from "lodash/defaultTo";
 
 import FileTree from "./FileTree";
 import Loader from "../../shared/Loader";
@@ -217,9 +218,10 @@ export default class KustomizeOverlay extends React.Component {
       fileLoadErr,
       fileLoadErrMessage,
       patch,
-      savingFinalize
+      savingFinalize,
+      fileContents,
     } = this.state;
-    const fileToView = find(this.state.fileContents, ["key", selectedFile]);
+    const fileToView = defaultTo(find(fileContents, ["key", selectedFile]), {});
     const showOverlay = patch.length;
 
     return (


### PR DESCRIPTION
What I Did
------------
- This is to address the following workflow within the UI
- Navigate through the default `init` workflow to the `kustomize` page
- Click to create an overlay
- Save the overlay
- Open the diff editor and switch to inline mode
- Click on a different file

- Following the above workflow would cause an error within the page due to `fileToView` not being populated
- `fileContents` which is supplying the file for `fileToView` is hydrated asynchronously while the UI is re-rendering from state changes
- During the re-render the `fileToView` is assigned as undefined from `find` and errors when `baseContent` is accessed at line 334


How I Did it
------------
- Default fileToView

How to verify it
------------
- Follow the above workflow

Description for the Changelog
------------
N/A


Picture of a Boat (not required but encouraged)
------------
🛶 











<!-- (thanks https://github.com/docker/docker for this template) -->

