### PR TITLE
Return actions from steps unless in progress

### DIFF
--- a/pkg/lifecycle/daemon/daemontypes/progress.go
+++ b/pkg/lifecycle/daemon/daemontypes/progress.go
@@ -27,9 +27,7 @@ func (p Progress) Status() string {
 	if p.Detail != "" {
 		var statusDetail map[string]string
 		json.Unmarshal([]byte(p.Detail), &statusDetail)
-		if statusDetail["status"] != "" {
-			return statusDetail["status"]
-		}
+		return statusDetail["status"]
 	}
 	return ""
 }

--- a/pkg/lifecycle/daemon/daemontypes/progress.go
+++ b/pkg/lifecycle/daemon/daemontypes/progress.go
@@ -21,6 +21,19 @@ func (p Progress) String() string {
 	return fmt.Sprintf("Progress{%s %s %s %s}", p.Source, p.Type, p.Level, p.Detail)
 }
 
+// Status parses the status code within progress detail that is used by the FE to determine
+// progress phases within a step
+func (p Progress) Status() string {
+	if p.Detail != "" {
+		var statusDetail map[string]string
+		json.Unmarshal([]byte(p.Detail), &statusDetail)
+		if statusDetail["status"] != "" {
+			return statusDetail["status"]
+		}
+	}
+	return ""
+}
+
 func StringProgress(source, detail string) Progress {
 	return JSONProgress(source, map[string]interface{}{
 		"status": detail,

--- a/pkg/lifecycle/daemon/routes_navcycle_getstep.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_getstep.go
@@ -91,8 +91,7 @@ func (d *NavcycleRoutes) hydrateStep(step daemontypes.Step) (*daemontypes.StepRe
 func (d *NavcycleRoutes) getActions(step daemontypes.Step) []daemontypes.Action {
 	progress, hasProgress := d.StepProgress.Load(step.Source.Shared().ID)
 
-	/// JAAAANK
-	shouldSkipActions := hasProgress && progress.Detail != `{"status":"success"}`
+	shouldSkipActions := hasProgress && progress.Status() != "success"
 
 	if shouldSkipActions {
 		return nil

--- a/web/src/components/shared/StepBuildingAssets.jsx
+++ b/web/src/components/shared/StepBuildingAssets.jsx
@@ -37,6 +37,7 @@ export default class StepBuildingAssets extends React.Component {
     if (location.pathname === "/render") {
       initializeStep(routeId);
       startPoll(routeId, () => {
+        // Timeout to wait a little bit before transitioning to the next step
         setTimeout(gotoRoute, 500);
       });
     }

--- a/web/src/components/shared/StepTerraform.jsx
+++ b/web/src/components/shared/StepTerraform.jsx
@@ -41,6 +41,7 @@ export default class StepPreparingTerraform extends React.Component {
     if (location.pathname === "/terraform") {
       initializeStep(routeId);
       startPoll(routeId, () => {
+        // Timeout to wait a little bit before transitioning to the next step
         setTimeout(gotoRoute, 500);
       });
     }

--- a/web/src/components/shared/StepTerraform.jsx
+++ b/web/src/components/shared/StepTerraform.jsx
@@ -40,7 +40,9 @@ export default class StepPreparingTerraform extends React.Component {
 
     if (location.pathname === "/terraform") {
       initializeStep(routeId);
-      startPoll(routeId, gotoRoute);
+      startPoll(routeId, () => {
+        setTimeout(gotoRoute, 500);
+      });
     }
   }
 


### PR DESCRIPTION
What I Did
------------
Fix #490 

How I Did it
------------
- Add a `Status` method to `progress` to return the detail status used by the FE to determine phases within a step (e.g. working, success, error, etc.)

How to verify it
------------
- Tests

Description for the Changelog
------------
Return actions from steps unless in progress


Picture of a Boat (not required but encouraged)
------------
🛶 











<!-- (thanks https://github.com/docker/docker for this template) -->

