### PR TITLE
add templating for the amazon_eks asset

### DIFF
--- a/hack/docs/mutations.json
+++ b/hack/docs/mutations.json
@@ -513,12 +513,12 @@
           "autoscaling_groups": [
             {
               "name": "group1",
-              "group_size": 2,
+              "group_size": "2",
               "machine_type": "m5.large"
             },
             {
               "name": "group2",
-              "group_size": 1,
+              "group_size": "1",
               "machine_type": "t2.large"
             }
           ]
@@ -544,7 +544,7 @@
           "autoscaling_groups": [
             {
               "name": "firstgroup",
-              "group_size": 3,
+              "group_size": "3",
               "machine_type": "m5.large"
             }
           ]
@@ -979,7 +979,8 @@
       "kustomizeIntro",
       "helmIntro",
       "helmValues",
-      "kubectl_apply.properties.StepShared"
+      "kubectl_apply.properties.StepShared",
+      "helm.properties.values_from"
     ]
   }
 ]

--- a/hack/docs/schema.json
+++ b/hack/docs/schema.json
@@ -32,12 +32,12 @@
                     "autoscaling_groups": [
                       {
                         "name": "group1",
-                        "group_size": 2,
+                        "group_size": "2",
                         "machine_type": "m5.large"
                       },
                       {
                         "name": "group2",
-                        "group_size": 1,
+                        "group_size": "1",
                         "machine_type": "t2.large"
                       }
                     ]
@@ -63,7 +63,7 @@
                     "autoscaling_groups": [
                       {
                         "name": "firstgroup",
-                        "group_size": 3,
+                        "group_size": "3",
                         "machine_type": "m5.large"
                       }
                     ]
@@ -79,7 +79,7 @@
                       "properties": {
                         "group_size": {
                           "description": "The number of instances to be included in the group",
-                          "type": "integer"
+                          "type": "string"
                         },
                         "machine_type": {
                           "description": "The AWS instance type to use within the group",

--- a/integration/init_app/amazon-eks-template/expected/.ship/release.yml
+++ b/integration/init_app/amazon-eks-template/expected/.ship/release.yml
@@ -2,12 +2,12 @@ assets:
   v1:
     - amazon_eks:
         dest: new/new_vpc.tf
-        cluster_name: new-vpc-cluster
+        cluster_name: '{{repl ConfigOption "name_source" }}'
         region: "us-west-2"
         created_vpc:
-          vpc_cidr: "10.0.0.0/16"
+          vpc_cidr: '{{repl ConfigOption "cidr_source" }}'
           zones:
-            - us-west-2a
+            - '{{repl ConfigOption "zone_source" }}'
             - us-west-2b
           public_subnets:
             - "10.0.1.0/24"
@@ -18,7 +18,7 @@ assets:
         autoscaling_groups:
           - name: alpha
             group_size: 3
-            machine_type: m5.2xlarge
+            machine_type: '{{repl ConfigOption "machine_source" }}'
           - name: bravo
             group_size: 1
             machine_type: m5.4xlarge
@@ -28,7 +28,7 @@ assets:
                   #!/bin/bash
                   echo "run:"
                   echo "terraform apply -f new/new_vpc.tf"
-                  echo "kubectl apply -f kube.yaml --kubeconfig {{repl AmazonEKS "new-vpc-cluster" }}"
+                  echo "kubectl apply -f kube.yaml --kubeconfig {{repl AmazonEKS (ConfigOption "name_source") }}"
         mode: 0777
     - inline:
         dest: kube.yaml
@@ -36,7 +36,28 @@ assets:
                   this is not a valid kubernetes yaml
         mode: 0777
 
-config: {}
+config:
+  v1:
+  - name: template_sources
+    title: Template Function Sources
+    description: testing testing 123
+    items:
+    - name: name_source
+      title: Name Source
+      default: cluster-name-template
+      type: text
+    - name: cidr_source
+      title: CIDR Source
+      default: "10.0.0.0/16"
+      type: text
+    - name: zone_source
+      title: Zone Source
+      default: "us-west-2a"
+      type: text
+    - name: machine_source
+      title: Machine Source
+      default: m5.2xlarge
+      type: text
 
 lifecycle:
   v1:

--- a/integration/init_app/amazon-eks-template/expected/installer/install.sh
+++ b/integration/init_app/amazon-eks-template/expected/installer/install.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 echo "run:"
 echo "terraform apply -f new/new_vpc.tf"
-echo "kubectl apply -f kube.yaml --kubeconfig new/kubeconfig_new-vpc-cluster"
+echo "kubectl apply -f kube.yaml --kubeconfig new/kubeconfig_cluster-name-template"

--- a/integration/init_app/amazon-eks-template/expected/installer/new/new_vpc.tf
+++ b/integration/init_app/amazon-eks-template/expected/installer/new/new_vpc.tf
@@ -81,7 +81,7 @@ provider "aws" {
 }
 
 variable "eks-cluster-name" {
-  default = "new-vpc-cluster"
+  default = "cluster-name-template"
   type    = "string"
 }
 

--- a/integration/init_app/amazon-eks-template/input/.ship/release.yml
+++ b/integration/init_app/amazon-eks-template/input/.ship/release.yml
@@ -2,12 +2,12 @@ assets:
   v1:
     - amazon_eks:
         dest: new/new_vpc.tf
-        cluster_name: new-vpc-cluster
+        cluster_name: '{{repl ConfigOption "name_source" }}'
         region: "us-west-2"
         created_vpc:
-          vpc_cidr: "10.0.0.0/16"
+          vpc_cidr: '{{repl ConfigOption "cidr_source" }}'
           zones:
-            - us-west-2a
+            - '{{repl ConfigOption "zone_source" }}'
             - us-west-2b
           public_subnets:
             - "10.0.1.0/24"
@@ -18,7 +18,7 @@ assets:
         autoscaling_groups:
           - name: alpha
             group_size: 3
-            machine_type: m5.2xlarge
+            machine_type: '{{repl ConfigOption "machine_source" }}'
           - name: bravo
             group_size: 1
             machine_type: m5.4xlarge
@@ -28,7 +28,7 @@ assets:
                   #!/bin/bash
                   echo "run:"
                   echo "terraform apply -f new/new_vpc.tf"
-                  echo "kubectl apply -f kube.yaml --kubeconfig {{repl AmazonEKS "new-vpc-cluster" }}"
+                  echo "kubectl apply -f kube.yaml --kubeconfig {{repl AmazonEKS (ConfigOption "name_source") }}"
         mode: 0777
     - inline:
         dest: kube.yaml
@@ -36,7 +36,28 @@ assets:
                   this is not a valid kubernetes yaml
         mode: 0777
 
-config: {}
+config:
+  v1:
+  - name: template_sources
+    title: Template Function Sources
+    description: testing testing 123
+    items:
+    - name: name_source
+      title: Name Source
+      default: cluster-name-template
+      type: text
+    - name: cidr_source
+      title: CIDR Source
+      default: "10.0.0.0/16"
+      type: text
+    - name: zone_source
+      title: Zone Source
+      default: "us-west-2a"
+      type: text
+    - name: machine_source
+      title: Machine Source
+      default: m5.2xlarge
+      type: text
 
 lifecycle:
   v1:

--- a/pkg/api/amazoneks/types.go
+++ b/pkg/api/amazoneks/types.go
@@ -15,6 +15,6 @@ type EKSExistingVPC struct {
 
 type EKSAutoscalingGroup struct {
 	Name        string `json:"name,omitempty" yaml:"name,omitempty" hcl:"name,omitempty"`
-	GroupSize   int    `json:"group_size,omitempty" yaml:"group_size,omitempty" hcl:"group_size,omitempty"`
+	GroupSize   string `json:"group_size,omitempty" yaml:"group_size,omitempty" hcl:"group_size,omitempty"`
 	MachineType string `json:"machine_type,omitempty" yaml:"machine_type,omitempty" hcl:"machine_type,omitempty"`
 }

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -33,16 +33,16 @@ func RootCmd() *cobra.Command {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			version.Init()
 			var multiErr *multierror.Error
-			multiErr = multierror.Append(os.RemoveAll(constants.ShipPathInternalTmp))
-			multiErr = multierror.Append(os.MkdirAll(constants.ShipPathInternalTmp, 0755))
+			multiErr = multierror.Append(multiErr, os.RemoveAll(constants.ShipPathInternalTmp))
+			multiErr = multierror.Append(multiErr, os.MkdirAll(constants.ShipPathInternalTmp, 0755))
 			return multiErr.ErrorOrNil()
 
 		},
 		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
 			var multiErr *multierror.Error
-			multiErr = multierror.Append(os.RemoveAll(constants.ShipPathInternalTmp))
+			multiErr = multierror.Append(multiErr, os.RemoveAll(constants.ShipPathInternalTmp))
 			// if we got here, it means we finished successfully, so remove the internal debug log file
-			multiErr = multierror.Append(os.RemoveAll(constants.ShipPathInternalLog))
+			multiErr = multierror.Append(multiErr, os.RemoveAll(constants.ShipPathInternalLog))
 			return multiErr.ErrorOrNil()
 		},
 	}

--- a/pkg/lifecycle/render/amazoneks/render.go
+++ b/pkg/lifecycle/render/amazoneks/render.go
@@ -3,6 +3,7 @@ package amazoneks
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"path"
 	"text/template"
 
@@ -29,22 +30,25 @@ type Renderer interface {
 
 // LocalRenderer renders a terraform asset by writing generated terraform source code
 type LocalRenderer struct {
-	Logger log.Logger
-	Inline inline.Renderer
-	Fs     afero.Afero
+	BuilderBuilder *templates.BuilderBuilder
+	Fs             afero.Afero
+	Inline         inline.Renderer
+	Logger         log.Logger
 }
 
 var _ Renderer = &LocalRenderer{}
 
 func NewRenderer(
-	logger log.Logger,
-	inline inline.Renderer,
+	bb *templates.BuilderBuilder,
 	fs afero.Afero,
+	inline inline.Renderer,
+	logger log.Logger,
 ) Renderer {
 	return &LocalRenderer{
-		Logger: logger,
-		Inline: inline,
-		Fs:     fs,
+		BuilderBuilder: bb,
+		Fs:             fs,
+		Inline:         inline,
+		Logger:         logger,
 	}
 }
 
@@ -56,6 +60,16 @@ func (r *LocalRenderer) Execute(
 	configGroups []libyaml.ConfigGroup,
 ) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
+
+		builder, err := r.BuilderBuilder.FullBuilder(meta, configGroups, templateContext)
+		if err != nil {
+			return errors.Wrap(err, "init builder")
+		}
+
+		asset, err = buildAsset(asset, builder)
+		if err != nil {
+			return errors.Wrap(err, "build asset")
+		}
 
 		contents, err := renderTerraformContents(asset)
 		if err != nil {
@@ -91,6 +105,85 @@ func (r *LocalRenderer) Execute(
 		}
 		return nil
 	}
+}
+
+func buildAsset(asset api.EKSAsset, builder *templates.Builder) (api.EKSAsset, error) {
+	var err error
+
+	asset.ClusterName, err = builder.String(asset.ClusterName)
+	if err != nil {
+		return asset, errors.Wrap(err, "build cluster_name")
+	}
+	asset.Region, err = builder.String(asset.Region)
+	if err != nil {
+		return asset, errors.Wrap(err, "build region")
+	}
+
+	// build created vpc
+	if asset.CreatedVPC != nil {
+		asset.CreatedVPC.VPCCIDR, err = builder.String(asset.CreatedVPC.VPCCIDR)
+		if err != nil {
+			return asset, errors.Wrap(err, "build vpc_cidr")
+		}
+
+		for idx, zone := range asset.CreatedVPC.Zones {
+			asset.CreatedVPC.Zones[idx], err = builder.String(zone)
+			if err != nil {
+				return asset, errors.Wrap(err, fmt.Sprintf("build vpc zone %d", idx))
+			}
+		}
+		for idx, subnet := range asset.CreatedVPC.PublicSubnets {
+			asset.CreatedVPC.PublicSubnets[idx], err = builder.String(subnet)
+			if err != nil {
+				return asset, errors.Wrap(err, fmt.Sprintf("build vpc public subnet %d", idx))
+			}
+		}
+		for idx, subnet := range asset.CreatedVPC.PrivateSubnets {
+			asset.CreatedVPC.PrivateSubnets[idx], err = builder.String(subnet)
+			if err != nil {
+				return asset, errors.Wrap(err, fmt.Sprintf("build vpc private subnet zone %d", idx))
+			}
+		}
+	}
+
+	// build existing vpc
+	if asset.ExistingVPC != nil {
+		asset.ExistingVPC.VPCID, err = builder.String(asset.ExistingVPC.VPCID)
+		if err != nil {
+			return asset, errors.Wrap(err, "build vpc_id")
+		}
+
+		for idx, subnet := range asset.ExistingVPC.PublicSubnets {
+			asset.ExistingVPC.PublicSubnets[idx], err = builder.String(subnet)
+			if err != nil {
+				return asset, errors.Wrap(err, fmt.Sprintf("build vpc public subnet %d", idx))
+			}
+		}
+		for idx, subnet := range asset.ExistingVPC.PrivateSubnets {
+			asset.ExistingVPC.PrivateSubnets[idx], err = builder.String(subnet)
+			if err != nil {
+				return asset, errors.Wrap(err, fmt.Sprintf("build vpc private subnet zone %d", idx))
+			}
+		}
+	}
+
+	// build autoscaling groups
+	for idx, group := range asset.AutoscalingGroups {
+		asset.AutoscalingGroups[idx].Name, err = builder.String(group.Name)
+		if err != nil {
+			return asset, errors.Wrap(err, fmt.Sprintf("build autoscaling group %d name", idx))
+		}
+		asset.AutoscalingGroups[idx].GroupSize, err = builder.String(group.GroupSize)
+		if err != nil {
+			return asset, errors.Wrap(err, fmt.Sprintf("build autoscaling group %d group_size", idx))
+		}
+		asset.AutoscalingGroups[idx].MachineType, err = builder.String(group.MachineType)
+		if err != nil {
+			return asset, errors.Wrap(err, fmt.Sprintf("build autoscaling group %d machine_type", idx))
+		}
+	}
+
+	return asset, nil
 }
 
 func renderTerraformContents(asset api.EKSAsset) (string, error) {

--- a/pkg/lifecycle/render/googlegke/render.go
+++ b/pkg/lifecycle/render/googlegke/render.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Masterminds/sprig"
 	"github.com/go-kit/kit/log"
+	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/libyaml"
 	"github.com/replicatedhq/ship/pkg/api"
@@ -109,40 +110,33 @@ func (r *LocalRenderer) Execute(
 
 func buildAsset(asset api.GKEAsset, builder *templates.Builder) (api.GKEAsset, error) {
 	var err error
+	var multiErr *multierror.Error
+
 	asset.Credentials, err = builder.String(asset.Credentials)
-	if err != nil {
-		return asset, errors.Wrap(err, "build credentials")
-	}
+	multiErr = multierror.Append(multiErr, errors.Wrap(err, "build credentials"))
 	asset.Project, err = builder.String(asset.Project)
-	if err != nil {
-		return asset, errors.Wrap(err, "build project")
-	}
+	multiErr = multierror.Append(multiErr, errors.Wrap(err, "build project"))
+
 	asset.Region, err = builder.String(asset.Region)
-	if err != nil {
-		return asset, errors.Wrap(err, "build region")
-	}
+	multiErr = multierror.Append(multiErr, errors.Wrap(err, "build region"))
+
 	asset.ClusterName, err = builder.String(asset.ClusterName)
-	if err != nil {
-		return asset, errors.Wrap(err, "build cluster_name")
-	}
+	multiErr = multierror.Append(multiErr, errors.Wrap(err, "build cluster_name"))
+
 	asset.Zone, err = builder.String(asset.Zone)
-	if err != nil {
-		return asset, errors.Wrap(err, "build zone")
-	}
+	multiErr = multierror.Append(multiErr, errors.Wrap(err, "build zone"))
+
 	asset.InitialNodeCount, err = builder.String(asset.InitialNodeCount)
-	if err != nil {
-		return asset, errors.Wrap(err, "build initial_node_count")
-	}
+	multiErr = multierror.Append(multiErr, errors.Wrap(err, "build initial_node_count"))
+
 	asset.MachineType, err = builder.String(asset.MachineType)
-	if err != nil {
-		return asset, errors.Wrap(err, "build machine_type")
-	}
+	multiErr = multierror.Append(multiErr, errors.Wrap(err, "build machine_type"))
+
 	asset.AdditionalZones, err = builder.String(asset.AdditionalZones)
-	if err != nil {
-		return asset, errors.Wrap(err, "build additional_zones")
-	}
+	multiErr = multierror.Append(multiErr, errors.Wrap(err, "build additional_zones"))
+
 	// NOTE: items not configurable by the end user include MinMasterVersion
-	return asset, nil
+	return asset, multiErr.ErrorOrNil()
 }
 
 func renderTerraformContents(asset api.GKEAsset) (string, error) {

--- a/pkg/lifecycle/render/googlegke/render_test.go
+++ b/pkg/lifecycle/render/googlegke/render_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
-	"reflect"
 	"testing"
 
 	"github.com/go-kit/kit/log"
@@ -71,7 +70,7 @@ func TestRenderer(t *testing.T) {
 			v := viper.New()
 			bb := templates.NewBuilderBuilder(testLogger, v)
 			renderer := &LocalRenderer{
-				Logger:         &logger.TestLogger{T: t},
+				Logger:         testLogger,
 				BuilderBuilder: bb,
 				Inline:         mockInline,
 			}
@@ -238,14 +237,16 @@ func TestBuildAsset(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
 			got, err := buildAsset(tt.args.asset, tt.args.builder)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("buildAsset() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			if !tt.wantErr {
+				req.NoErrorf(err, "buildAsset() error = %v", err)
+			} else {
+				req.Error(err)
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("buildAsset() = %v, want %v", got, tt.want)
-			}
+
+			req.Equal(got, tt.want)
 		})
 	}
 }


### PR DESCRIPTION
What I Did
------------
Added templating to the amazon_eks asset, fixing #478 


How I Did it
------------
I copied the basic 'render everything' code structure from the GKE asset code, and also changed the type of 'EKS autoscaling group size' to string from int.

How to verify it
------------
Look at the unit tests of the templater or at the updated `ship init_app` integration test using this.

Description for the Changelog
------------
`amazon_eks` asset parameters can now be templated


Picture of a Boat (not required but encouraged)
------------

![USS Asheville (PG-84)](https://upload.wikimedia.org/wikipedia/commons/6/66/USS_Asheville_%28PG-84%29_underway_in_1966.jpg "USS Asheville (PG-84)")










<!-- (thanks https://github.com/docker/docker for this template) -->

