### PR TITLE
docs typo fix

### DIFF
--- a/hack/docs/mutations.json
+++ b/hack/docs/mutations.json
@@ -685,7 +685,7 @@
   {
     "path": "properties.assets.properties.v1.items.properties.google_gke",
     "merge": {
-      "description": "An `google_gke` asset generates a terraform file that will create a Google GKE Cluster.",
+      "description": "A `google_gke` asset generates a terraform file that will create a Google GKE Cluster.",
       "extended_description": "It also populates a template function `GoogleGKE` that takes the name of the cluster and returns the path to the generated kubeconfig for the cluster. This template function is only valid after the asset has been generated as part of the `render` lifecycle step, but can be used by later assets within that step. The file itself is created when the generated terraform is applied, whether by the `terraform` lifecycle step or otherwise. This is intended to be used within the [kubectl_apply](/api/ship-lifecycle/lifecycle/kubectl_apply/) lifecycle step.",
       "examples": [
         {

--- a/hack/docs/schema.json
+++ b/hack/docs/schema.json
@@ -349,7 +349,7 @@
                 ]
               },
               "google_gke": {
-                "description": "An `google_gke` asset generates a terraform file that will create a Google GKE Cluster.",
+                "description": "A `google_gke` asset generates a terraform file that will create a Google GKE Cluster.",
                 "extended_description": "It also populates a template function `GoogleGKE` that takes the name of the cluster and returns the path to the generated kubeconfig for the cluster. This template function is only valid after the asset has been generated as part of the `render` lifecycle step, but can be used by later assets within that step. The file itself is created when the generated terraform is applied, whether by the `terraform` lifecycle step or otherwise. This is intended to be used within the [kubectl_apply](/api/ship-lifecycle/lifecycle/kubectl_apply/) lifecycle step.",
                 "examples": [
                   {


### PR DESCRIPTION
What I Did
------------
Fixed a grammar issue in the generated ship docs - `An` -> `A`

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------

![image](https://user-images.githubusercontent.com/2318911/44878361-864d1480-ac5b-11e8-86b9-d4e76e215be6.png)
I couldn't find a grammar nazi boat. Have a U-Boat instead










<!-- (thanks https://github.com/docker/docker for this template) -->

