### PR TITLE
Change logic for rm-dest-asset

### DIFF
--- a/pkg/lifecycle/render/noconfig.go
+++ b/pkg/lifecycle/render/noconfig.go
@@ -66,14 +66,14 @@ func (r *noconfigrenderer) Execute(ctx context.Context, release *api.Release, st
 		step.Root = constants.InstallerPrefixPath
 	}
 
-	if r.Viper.GetBool("rm-asset-dest") {
-		err := r.Fs.RemoveAll(step.Root)
-		if err != nil {
-			return errors.Wrapf(err, "remove asset dest %s", step.Root)
+	if step.Root != "." && step.Root != "./" {
+		if r.Viper.GetBool("rm-asset-dest") {
+			err := r.Fs.RemoveAll(step.Root)
+			if err != nil {
+				return errors.Wrapf(err, "remove asset dest %s", step.Root)
+			}
 		}
-	}
 
-	if step.Root != "." {
 		err = util.BailIfPresent(r.Fs, step.Root, r.Logger)
 		if err != nil {
 			return errors.Wrapf(err, "check for existing install directory %s", step.Root)

--- a/web/src/components/shared/StepBuildingAssets.jsx
+++ b/web/src/components/shared/StepBuildingAssets.jsx
@@ -46,11 +46,11 @@ export default class StepBuildingAssets extends React.Component {
   render() {
     const { status = {} } = this.props;
     const isJSON = status.type === "json";
-    const parsed = isJSON ? JSON.parse(status.detail) : null;
-    const message = parsed ? JSON.parse(status.detail).message : "";
+    const parsed = isJSON ? JSON.parse(status.detail) : {};
+    const message = parsed.message ? parsed.message : "";
     const isError = parsed && parsed.status === "error";
     const isSuccess = parsed && parsed.status === "success";
-    const progressDetail = parsed ? JSON.parse(status.detail).progressDetail : null;
+    const progressDetail = parsed.progressDetail ? parsed.progressDetail : null;
     let percent = progressDetail ? `${Utilities.calcPercent(progressDetail.current, progressDetail.total, 0)}` : 0;
     if (percent > 100) {
       percent = 100;


### PR DESCRIPTION
What I Did
------------
- Don't delete `.` or `./` when `--rm-dest-asset`
- Begin to address #531 

How I Did it
------------
- 

How to verify it
------------
- `ship init github.com/sourcegraph/deploy-sourcegraph --rm-asset-dest --log-level=debug`

Description for the Changelog
------------
Change logic for rm-dest-asset


Picture of a Boat (not required but encouraged)
------------
🛶 











<!-- (thanks https://github.com/docker/docker for this template) -->

