### PR TITLE
Update overlay editor to show diff of unsaved patches

### DIFF
--- a/web/src/components/kustomize/kustomize_overlay/KustomizeOverlay.jsx
+++ b/web/src/components/kustomize/kustomize_overlay/KustomizeOverlay.jsx
@@ -10,6 +10,7 @@ import pick from "lodash/pick";
 import keyBy from "lodash/keyBy";
 import find from "lodash/find";
 import defaultTo from "lodash/defaultTo";
+import debounce from "lodash/debounce";
 
 import FileTree from "./FileTree";
 import Loader from "../../shared/Loader";
@@ -210,6 +211,14 @@ export default class KustomizeOverlay extends React.Component {
     this.aceEditorOverlay = editor;
   }
 
+  updateModifiedPatch = debounce((patch) => {
+    // We already circumvent React's lifecycle state system for updates
+    // Set the current patch state to the changed value to avoid
+    // React re-rendering the ACE Editor
+    this.state.patch = patch; // eslint-disable-line
+    this.handleApplyPatch()
+  }, 500);
+
   render() {
     const { dataLoading } = this.props;
     const {
@@ -317,6 +326,7 @@ export default class KustomizeOverlay extends React.Component {
                         setOptions={{
                           scrollPastEnd: false
                         }}
+                        onChange={this.updateModifiedPatch}
                       />
                     </div>
                   </div>

--- a/web/src/redux/data/kustomizeOverlay/actions.js
+++ b/web/src/redux/data/kustomizeOverlay/actions.js
@@ -181,7 +181,7 @@ export function applyPatch(payload) {
         body: JSON.stringify(payload)
       });
       const { modified } = await response.json();
-      dispatch(receiveModified(modified));
+      dispatch(receiveModified(modified, payload.patch));
     } catch (error) {
       console.log(error)
       return;
@@ -189,11 +189,12 @@ export function applyPatch(payload) {
   };
 }
 
-export function receiveModified(modified) {
+export function receiveModified(modified, patch) {
   return {
     type: constants.RECEIVE_MODIFIED,
     payload: {
       modified,
+      patch,
     }
   };
 }

--- a/web/src/redux/data/kustomizeOverlay/reducer.js
+++ b/web/src/redux/data/kustomizeOverlay/reducer.js
@@ -26,15 +26,17 @@ export function kustomizeData(state = kustomizeState, action) {
     return Object.assign({}, state, {
       fileContents: updatedContents
     });
-  case constants.RECEIVE_PATCH:
+  case constants.RECEIVE_PATCH: {
     const { patch } = action.payload;
     return Object.assign({}, state, {
       patch,
     });
+  }
   case constants.RECEIVE_MODIFIED:
-    const { modified } = action.payload;
+    const { modified, patch } = action.payload;
     return Object.assign({}, state, {
       modified,
+      patch,
     });
   default:
     return state;


### PR DESCRIPTION
What I Did
------------
Update overlay editor to show diff of unsaved patches (previously, it only showed saved)

Fixes #487

How I Did it
------------
- Update receivedModified reducer to update patch prop
- Add method to detect changes to overlay editor and update diff

How to verify it
------------
If you go into the editor and update a value with the diff editor open, it should update the diff editor.

Description for the Changelog
------------
- Update overlay editor to show diff of unsaved patches


Picture of a Boat (not required but encouraged)
------------
![](https://www.marlinmag.com/sites/marlinmag.com/files/styles/1000_1x_/public/import/2013/files/_images/201310/top-sf-boats_16.jpg?itok=VhHmAKyk)











<!-- (thanks https://github.com/docker/docker for this template) -->

