### PR TITLE
Open UI when headed flag is passed to update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,11 +108,10 @@ jobs:
           sudo mv /tmp/go ${GOROOT}
       - run: $GO get github.com/onsi/ginkgo/ginkgo
       - run: $GO get github.com/docker/distribution/cmd/registry
-      - run: cp $GOPATH/src/github.com/docker/distribution/cmd/registry/config-example.yml config.yml
       - run: sudo ./hack/get_run_deps.sh
       - run: sudo mkdir -p /var/lib/registry
       - run: |
-          sudo $GOPATH/bin/registry serve config.yml > /dev/null 2>&1 &
+          sudo $GOPATH/bin/registry serve integration/docker-registry.yaml > /dev/null 2>&1 &
           $GOPATH/bin/ginkgo -p -stream integration/base
           $GOPATH/bin/ginkgo -p -stream integration/update
           $GOPATH/bin/ginkgo -p -stream integration/init

--- a/integration/docker-registry.yaml
+++ b/integration/docker-registry.yaml
@@ -1,0 +1,18 @@
+version: 0.1
+log:
+  fields:
+    service: registry
+storage:
+  cache:
+    blobdescriptor: inmemory
+  filesystem:
+    rootdirectory: /var/lib/registry
+http:
+  addr: :5000
+  headers:
+    X-Content-Type-Options: [nosniff]
+health:
+  storagedriver:
+    enabled: true
+    interval: 10s
+    threshold: 3

--- a/pkg/lifecycle/daemon/daemon.go
+++ b/pkg/lifecycle/daemon/daemon.go
@@ -77,10 +77,11 @@ func (d *ShipDaemon) Serve(ctx context.Context, release *api.Release) error {
 		errChan <- server.ListenAndServe()
 	}()
 
-	openUrl := fmt.Sprintf("http://localhost:%d", apiPort)
+	openURL := fmt.Sprintf("http://localhost:%d", apiPort)
 	if !d.Viper.GetBool("no-open") {
 		go func() {
-			err := d.OpenWebConsole(d.UI, openUrl)
+			autoOpen := d.Viper.GetBool("headed")
+			err := d.OpenWebConsole(d.UI, openURL, autoOpen)
 			if err != nil {
 				debug.Log("event", "console.open.fail.ignore", "err", err)
 			}
@@ -88,7 +89,7 @@ func (d *ShipDaemon) Serve(ctx context.Context, release *api.Release) error {
 	} else {
 		d.UI.Info(fmt.Sprintf(
 			"\nPlease visit the following URL in your browser to continue the installation\n\n        %s\n\n ",
-			openUrl,
+			openURL,
 		))
 	}
 

--- a/pkg/lifecycle/daemon/daemon_channel_test.go
+++ b/pkg/lifecycle/daemon/daemon_channel_test.go
@@ -73,7 +73,7 @@ func TestDaemonChannel(t *testing.T) {
 					Viper:  v,
 
 					UI:             cli.NewMockUi(),
-					OpenWebConsole: func(ui cli.Ui, s string) error { return nil },
+					OpenWebConsole: func(ui cli.Ui, s string, b bool) error { return nil },
 				},
 				NavcycleRoutes: &NavcycleRoutes{
 					Shutdown: make(chan interface{}),

--- a/pkg/lifecycle/daemon/daemon_test.go
+++ b/pkg/lifecycle/daemon/daemon_test.go
@@ -45,7 +45,7 @@ func initTestDaemon(
 		Viper:            v,
 		UI:               cli.NewMockUi(),
 		MessageConfirmed: make(chan string, 1),
-		OpenWebConsole:   func(ui cli.Ui, s string) error { return nil },
+		OpenWebConsole:   func(ui cli.Ui, s string, b bool) error { return nil },
 	}
 
 	if v2 != nil {

--- a/pkg/lifecycle/daemon/open.go
+++ b/pkg/lifecycle/daemon/open.go
@@ -24,6 +24,7 @@ func tryOpenWebConsole(ui cli.Ui, url string, autoOpen bool) error {
 				"\nPlease visit the following URL in your browser to continue the installation\n\n        %s\n\n ",
 				url,
 			))
+			return nil
 		}
 	}
 

--- a/pkg/lifecycle/daemon/open.go
+++ b/pkg/lifecycle/daemon/open.go
@@ -9,24 +9,24 @@ import (
 	"github.com/skratchdot/open-golang/open"
 )
 
-type opener func(cli.Ui, string) error
+type opener func(cli.Ui, string, bool) error
 
-func tryOpenWebConsole(ui cli.Ui, url string) error {
-	openBrowser, err := ui.Ask("Open browser to continue? (Y/n)")
-	if err != nil {
-		return err
+func tryOpenWebConsole(ui cli.Ui, url string, autoOpen bool) error {
+	if !autoOpen {
+		openBrowser, err := ui.Ask("Open browser to continue? (Y/n)")
+		if err != nil {
+			return err
+		}
+
+		openBrowser = strings.ToLower(strings.Trim(openBrowser, " \r\n"))
+		if strings.Compare(openBrowser, "n") == 0 {
+			ui.Info(fmt.Sprintf(
+				"\nPlease visit the following URL in your browser to continue the installation\n\n        %s\n\n ",
+				url,
+			))
+		}
 	}
 
-	openBrowser = strings.ToLower(strings.Trim(openBrowser, " \r\n"))
-	if strings.Compare(openBrowser, "n") == 0 {
-		ui.Info(fmt.Sprintf(
-			"\nPlease visit the following URL in your browser to continue the installation\n\n        %s\n\n ",
-			url,
-		))
-	} else {
-		ui.Info("\n       Opening console at " + url + " ...")
-		err := open.Start(url)
-		return err
-	}
-	return nil
+	ui.Info("\n       Opening console at " + url + " ...")
+	return open.Start(url)
 }

--- a/pkg/lifecycle/render/config/daemonresolver_test.go
+++ b/pkg/lifecycle/render/config/daemonresolver_test.go
@@ -137,7 +137,7 @@ func TestDaemonResolver(t *testing.T) {
 					Viper:  v,
 
 					UI:             cli.NewMockUi(),
-					OpenWebConsole: func(ui cli.Ui, s string) error { return nil },
+					OpenWebConsole: func(ui cli.Ui, s string, b bool) error { return nil },
 				},
 				NavcycleRoutes: &daemon.NavcycleRoutes{
 					Shutdown: make(chan interface{}),


### PR DESCRIPTION
What I Did
------------
- Fix #482 

How I Did it
------------
- Read `headed` flag and pass to `tryOpenWebConsole`

How to verify it
------------
- Run `ship update --headed`

Description for the Changelog
------------
Remove prompt when running `ship update --headed`


Picture of a Boat (not required but encouraged)
------------
⛵️ 











<!-- (thanks https://github.com/docker/docker for this template) -->

