### PR TITLE
kustomize requires base_path and dest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,12 +90,12 @@ jobs:
     working_directory: /home/circleci/go/src/github.com/replicatedhq/ship
     environment:
       GOPATH: /home/circleci/go
-      GO_SHA256SUM: fa1b0e45d3b647c252f51f5e1204aba049cde4af177ef9f2181f43004f901035
+      GO_SHA256SUM: fa04efdb17a275a0c6e137f969a1c4eb878939e91e1da16060ce42f02c2ec5ec
       GO: /usr/local/go/bin/go
     steps:
       - checkout
       - run: |
-          export GO_DOWNLOAD_URL=https://dl.google.com/go/go1.10.3.linux-amd64.tar.gz
+          export GO_DOWNLOAD_URL=https://dl.google.com/go/go1.10.4.linux-amd64.tar.gz
           export GOROOT=/usr/local/go
           export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
            # sudo apt update --fix-missing && apt upgrade -y

--- a/hack/docs/mutations.json
+++ b/hack/docs/mutations.json
@@ -273,6 +273,12 @@
     }
   },
   {
+    "path": "properties.assets.properties.v1.items.properties.helm.properties.values_from",
+    "merge": {
+      "description": "values_from"
+    }
+  },
+  {
     "path": "properties.assets.properties.v1.items.properties.helm.properties.when",
     "merge": {
       "description": "This asset will be included when 'when' is omitted or true"
@@ -955,7 +961,10 @@
       ]
     },
     "replace": {
-      "required": []
+      "required": [
+        "base_path",
+        "dest"
+      ]
     }
   },
 
@@ -979,8 +988,7 @@
       "kustomizeIntro",
       "helmIntro",
       "helmValues",
-      "kubectl_apply.properties.StepShared",
-      "helm.properties.values_from"
+      "kubectl_apply.properties.StepShared"
     ]
   }
 ]

--- a/hack/docs/schema.json
+++ b/hack/docs/schema.json
@@ -548,6 +548,7 @@
                     }
                   },
                   "values_from": {
+                    "description": "values_from",
                     "type": "object",
                     "properties": {
                       "lifecycle": {
@@ -905,7 +906,10 @@
                     }
                   }
                 },
-                "required": []
+                "required": [
+                  "base_path",
+                  "dest"
+                ]
               },
               "message": {
                 "description": "A `message` step will print a message to the console or UI.",


### PR DESCRIPTION
What I Did
------------
Added 'base_path' and 'dest' as required parameters for the Kustomize lifecycle step, fixes #533 

How I Did it
------------
Added them to the `required` array in /hack/docs/mutations.json and ran `make pipeline-strict`
Added a minimal description for `helm.values_from` to pass `make pipeline-strict`

How to verify it
------------
Look at the generated schema.json

Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------

![image](https://user-images.githubusercontent.com/2318911/44926528-f668a280-ad0e-11e8-8a14-6e3341b842ea.png)











<!-- (thanks https://github.com/docker/docker for this template) -->

