### PR TITLE
fix integration test image and ensure it passes before deploying it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,6 +147,7 @@ jobs:
       - checkout
       - setup_remote_docker
       - run: make build_ship_integration_test
+      - run: docker run -e SHIP_INTEGRATION_VENDOR_TOKEN --net="host" -it -v /var/run/docker.sock:/var/run/docker.sock replicated/ship-e2e-test:latest
       - deploy:
           command: |
             if [ "${CIRCLE_PROJECT_USERNAME}" == "replicatedhq" ]; then

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -42,7 +42,6 @@ WORKDIR /test
 COPY --from=build-step /usr/local/bin/terraform /usr/local/bin/terraform
 COPY --from=build-step /usr/local/bin/kubectl /usr/local/bin/kubectl
 COPY --from=build-step $GOPATH/bin/registry $GOPATH/bin/registry
-COPY --from=build-step $GOPATH/src/github.com/docker/distribution/cmd/registry/config-example.yml config.yml
 RUN apk update && apk add ca-certificates git openssh && rm -rf /var/cache/apk/*
 
 RUN mkdir -p /var/lib/registry

--- a/integration/integration_docker_start.sh
+++ b/integration/integration_docker_start.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Suppress logs from Docker Registry
-$GOPATH/bin/registry serve config.yml > /dev/null 2>&1 &
+$GOPATH/bin/registry serve docker-registry.yaml > /dev/null 2>&1 &
 sleep 2
 cd base/
 ./base.test


### PR DESCRIPTION
What I Did
------------
Fixed the integration test image and changed the CircleCI workflow so that the image is only pushed if it passes

How I Did it
------------
Included the integration test fix made by @Rob0h here: https://github.com/replicatedhq/ship/pull/540/commits/480d7f13a51a857da8131aa7394720dfc6e29a10

Changed the CircleCI workflow to run the newly generated integration test image before deploying it

How to verify it
------------
run `make build_ship_integration_test` and then `docker run -e SHIP_INTEGRATION_VENDOR_TOKEN --net="host" -it -v /var/run/docker.sock:/var/run/docker.sock replicated/ship-e2e-test:latest` with a vendor token set

Description for the Changelog
------------
The integration test image will no longer be deployed when it is failing


Picture of a Boat (not required but encouraged)
------------
![I-176](https://upload.wikimedia.org/wikipedia/commons/e/ec/I-176_submarine.jpg "I-176")











<!-- (thanks https://github.com/docker/docker for this template) -->

