### PR TITLE
eks-template expects all variables to be strings now

### DIFF
--- a/integration/init_app/amazon-eks-template/expected/.ship/release.yml
+++ b/integration/init_app/amazon-eks-template/expected/.ship/release.yml
@@ -17,10 +17,10 @@ assets:
             - "10.0.130.0/24"
         autoscaling_groups:
           - name: alpha
-            group_size: 3
+            group_size: "3"
             machine_type: '{{repl ConfigOption "machine_source" }}'
           - name: bravo
-            group_size: 1
+            group_size: "1"
             machine_type: m5.4xlarge
     - inline:
         dest: install.sh

--- a/integration/init_app/amazon-eks-template/input/.ship/release.yml
+++ b/integration/init_app/amazon-eks-template/input/.ship/release.yml
@@ -17,10 +17,10 @@ assets:
             - "10.0.130.0/24"
         autoscaling_groups:
           - name: alpha
-            group_size: 3
+            group_size: "3"
             machine_type: '{{repl ConfigOption "machine_source" }}'
           - name: bravo
-            group_size: 1
+            group_size: "1"
             machine_type: m5.4xlarge
     - inline:
         dest: install.sh


### PR DESCRIPTION
What I Did
------------
Fixed the eks-template init_app integration test by changing `group_size` to be a string

How I Did it
------------


How to verify it
------------
Run the `init_app` integration tests

Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------


![image](https://user-images.githubusercontent.com/2318911/44932327-338a6000-ad22-11e8-9e45-604977383d00.png)










<!-- (thanks https://github.com/docker/docker for this template) -->

