### PR TITLE
Revert change to ci-embed-ui make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,7 +270,7 @@ mark-ui-gitignored:
 embed-ui: mark-ui-gitignored build-ui-dev pkg/lifeycle/daemon/ui.bindatafs.go
 
 
-ci-embed-ui: mark-ui-gitignored ci-build-ui-dev pkg/lifeycle/daemon/ui.bindatafs.go
+ci-embed-ui: mark-ui-gitignored pkg/lifeycle/daemon/ui.bindatafs.go
 build-ui:
 	$(MAKE) -C web build_ship
 


### PR DESCRIPTION
What I Did
------------
Revert change to ci-embed-ui make command for deploy step

How I Did it
------------
Remove building UI from ci-embed-ui Make command

How to verify it
------------
Running the command should no longer build the UI (will run much quicker)

Description for the Changelog
------------
N/A


Picture of a Boat (not required but encouraged)
------------
⛵️ 











<!-- (thanks https://github.com/docker/docker for this template) -->

