### PR TITLE
Fix chart logo flash on intro step

### DIFF
--- a/web/src/components/shared/NavBar.jsx
+++ b/web/src/components/shared/NavBar.jsx
@@ -129,6 +129,7 @@ export class NavBar extends React.Component {
             imageLoaded: true,
           })
         })
+        .catch(() => this.setState({ updatedState }))
     } else {
       if (!isEmpty(updatedState)) {
         this.setState(updatedState);

--- a/web/src/components/shared/NavBar.jsx
+++ b/web/src/components/shared/NavBar.jsx
@@ -1,11 +1,10 @@
-import * as React from "react";
+import React, { Fragment } from "react";
 import assign from "object-assign";
 import autoBind from "react-autobind";
 import { Link, withRouter } from "react-router-dom";
 import upperFirst from "lodash/upperFirst";
 import NavItem from "./NavItem";
 import "../../scss/components/shared/NavBar.scss";
-import { Fragment } from "react";
 import { get, isEmpty } from "lodash";
 
 export class NavBar extends React.Component {

--- a/web/src/components/shared/NavBar.spec.js
+++ b/web/src/components/shared/NavBar.spec.js
@@ -23,8 +23,7 @@ const initProps = {
 
 describe("NavBar", () => {
   beforeAll(() => {
-    // Mocking Image.prototype.src to call the onload or onerror
-    // callbacks depending on the src passed to it
+    // Mocking Image.prototype.src to call onload immediately
     Object.defineProperty(global.Image.prototype, "src", {
       set() {
         this.onload()

--- a/web/src/components/shared/NavBar.spec.js
+++ b/web/src/components/shared/NavBar.spec.js
@@ -22,6 +22,16 @@ const initProps = {
 };
 
 describe("NavBar", () => {
+  beforeAll(() => {
+    // Mocking Image.prototype.src to call the onload or onerror
+    // callbacks depending on the src passed to it
+    Object.defineProperty(global.Image.prototype, "src", {
+      set() {
+        this.onload()
+      },
+    });
+  });
+
   describe("provided shipAppMetadata", () => {
     const wrapper = mount(
       <MemoryRouter initialEntries={["/"]} initialIndex={0}>
@@ -31,7 +41,7 @@ describe("NavBar", () => {
         />
       </MemoryRouter>
     );
-      it("sets navDetails via shipAppMetadata", () => {
+      it("sets navDetails via shipAppMetadata", async () => {
         wrapper.setProps({
           children: React.cloneElement(
             wrapper.props().children,
@@ -44,6 +54,7 @@ describe("NavBar", () => {
             },
           ),
         });
+        await wrapper.update();
         const navBar = wrapper.find(NavBar).instance();
         const navDetails = navBar.state.navDetails;
         expect(navDetails.name).toEqual("testHelm");
@@ -59,7 +70,7 @@ describe("NavBar", () => {
         />
       </MemoryRouter>
     );
-      it("sets navDetails via channelDetails", () => {
+      it("sets navDetails via channelDetails", async () => {
         wrapper.setProps({
           children: React.cloneElement(
             wrapper.props().children,
@@ -72,6 +83,7 @@ describe("NavBar", () => {
             },
           ),
         });
+        await wrapper.update();
         const navBar = wrapper.find(NavBar).instance();
         const navDetails = navBar.state.navDetails;
         expect(navDetails.name).toEqual("testChannelDetails");

--- a/web/src/scss/components/shared/NavBar.scss
+++ b/web/src/scss/components/shared/NavBar.scss
@@ -1,6 +1,7 @@
 @import "../../variables/variables.scss";
 
 .NavBarWrapper {
+  min-height: 66px;
   width: 100%;
   padding: 0;
   background-color: $navbar-background;
@@ -107,5 +108,5 @@
 
 /* ≥ 1024px */
 @media screen and (min-width: 64em) {
-  
+
 }


### PR DESCRIPTION
Fixes #486 

What I Did
------------
Prevent logo from flashing by pre-loading image before rendering.

How I Did it
------------
Updated `NavBar` to preload image and then update state. If there is no logo found, we default it to be header title only.

How to verify it
------------
Load the `/intro` step of this chart by running this command:
```sh
ship init github.com/helm/charts/stable/grafana
```

Description for the Changelog
------------
- Fix chart logo flash on intro step


Picture of a Boat (not required but encouraged)
------------
![](https://pre00.deviantart.net/3062/th/pre/i/2014/294/f/5/legend_of_korra___wind_waker__part_2__by_wolf_waldemar-d83oci6.jpg)











<!-- (thanks https://github.com/docker/docker for this template) -->

