### PR TITLE
If the mode provided is not 0, use it for github assets

### DIFF
--- a/hack/docs/mutations.json
+++ b/hack/docs/mutations.json
@@ -353,6 +353,14 @@
           "path": "k8s-yamls/",
           "dest": "./k8s/",
           "source": "private"
+        },
+        {
+          "repo": "github.com/replicatedhq/ship",
+          "ref": "master",
+          "path": "hack/docs/",
+          "dest": "./docs/",
+          "source": "public",
+          "mode": 644
         }
       ]
     },
@@ -372,10 +380,10 @@
     }
   },
   {
-    "path": "properties.assets.properties.v1.items.properties.github.properties",
-    "delete": [
-      "mode"
-    ]
+    "path": "properties.assets.properties.v1.items.properties.github.properties.mode",
+    "merge": {
+      "description": "If present, overrides the file mode of all files included by this asset."
+    }
   },
   {
     "path": "properties.assets.properties.v1.items.properties.github.properties.path",

--- a/hack/docs/schema.json
+++ b/hack/docs/schema.json
@@ -309,6 +309,14 @@
                     "path": "k8s-yamls/",
                     "dest": "./k8s/",
                     "source": "private"
+                  },
+                  {
+                    "repo": "github.com/replicatedhq/ship",
+                    "ref": "master",
+                    "path": "hack/docs/",
+                    "dest": "./docs/",
+                    "source": "public",
+                    "mode": 644
                   }
                 ],
                 "type": "object",
@@ -319,6 +327,10 @@
                   "dest": {
                     "description": "Destination directory",
                     "type": "string"
+                  },
+                  "mode": {
+                    "description": "If present, overrides the file mode of all files included by this asset.",
+                    "type": "integer"
                   },
                   "path": {
                     "description": "Path in repo from which to pull file or directory",

--- a/pkg/lifecycle/render/github/render.go
+++ b/pkg/lifecycle/render/github/render.go
@@ -110,6 +110,9 @@ func (r *LocalRenderer) Execute(
 			}
 
 			mode := os.FileMode(0644) // TODO: how to get mode info from github?
+			if asset.AssetShared.Mode != os.FileMode(0000) {
+				mode = asset.AssetShared.Mode
+			}
 			if err := rootFs.WriteFile(filePath, []byte(built), mode); err != nil {
 				debug.Log("event", "execute.fail", "err", err)
 				return errors.Wrapf(err, "Write inline asset to %s", filePath)


### PR DESCRIPTION
What I Did
------------
Changed the github asset file mode to not be hardcoded as `644`

How I Did it
------------
I check if the mode provided as part of the asset is 0, and if it is not use it instead of `644`.

How to verify it
------------


Description for the Changelog
------------
File modes are respected as part of github assets


Picture of a Boat (not required but encouraged)
------------

![image](https://user-images.githubusercontent.com/2318911/45180478-5f995b80-b1d0-11e8-9422-9d1ebbc35745.png)











<!-- (thanks https://github.com/docker/docker for this template) -->

