### PR TITLE
Add filepath trim option to GitHub asset

### DIFF
--- a/hack/docs/mutations.json
+++ b/hack/docs/mutations.json
@@ -219,7 +219,8 @@
     "path": "properties.assets.properties.v1.items.properties.helm.properties.github.properties",
     "delete": [
       "dest",
-      "mode"
+      "mode",
+      "strip_path"
     ]
   },
   {
@@ -352,15 +353,17 @@
           "ref": "8fcaebe55af67fe6789fa678faaa76fa867fbc",
           "path": "k8s-yamls/",
           "dest": "./k8s/",
-          "source": "private"
+          "source": "private",
+          "strip_path": ""
         },
         {
           "repo": "github.com/replicatedhq/ship",
           "ref": "master",
           "path": "hack/docs/",
-          "dest": "./docs/",
+          "dest": "./docs{{repl Add 1 1}}/",
           "source": "public",
-          "mode": 644
+          "mode": 644,
+          "strip_path": "{{repl ParseBool \"true\"}}"
         }
       ]
     },
@@ -407,6 +410,12 @@
     "path": "properties.assets.properties.v1.items.properties.github.properties.source",
     "merge": {
       "description": "One of `public` or `private`, if `private`, access to the repo can be validated on release creation"
+    }
+  },
+  {
+    "path": "properties.assets.properties.v1.items.properties.github.properties.strip_path",
+    "merge": {
+      "description": "If true, the github directory will not be included in the filepath of the generated files. For instance, when outputting all files within 'source/' in the repository to the 'dest/' directory, the file 'source/a/file.txt' would be placed at 'dest/source/a/file.txt' when this is false and 'dest/a/file.txt' when this is true."
     }
   },
   {

--- a/hack/docs/schema.json
+++ b/hack/docs/schema.json
@@ -308,15 +308,17 @@
                     "ref": "8fcaebe55af67fe6789fa678faaa76fa867fbc",
                     "path": "k8s-yamls/",
                     "dest": "./k8s/",
-                    "source": "private"
+                    "source": "private",
+                    "strip_path": ""
                   },
                   {
                     "repo": "github.com/replicatedhq/ship",
                     "ref": "master",
                     "path": "hack/docs/",
-                    "dest": "./docs/",
+                    "dest": "./docs{{repl Add 1 1}}/",
                     "source": "public",
-                    "mode": 644
+                    "mode": 644,
+                    "strip_path": "{{repl ParseBool \"true\"}}"
                   }
                 ],
                 "type": "object",
@@ -346,6 +348,10 @@
                   },
                   "source": {
                     "description": "One of `public` or `private`, if `private`, access to the repo can be validated on release creation",
+                    "type": "string"
+                  },
+                  "strip_path": {
+                    "description": "If true, the github directory will not be included in the filepath of the generated files. For instance, when outputting all files within 'source/' in the repository to the 'dest/' directory, the file 'source/a/file.txt' would be placed at 'dest/source/a/file.txt' when this is false and 'dest/a/file.txt' when this is true.",
                     "type": "string"
                   },
                   "when": {

--- a/integration/init_app/github-template-func/expected/.ship/release.yml
+++ b/integration/init_app/github-template-func/expected/.ship/release.yml
@@ -20,6 +20,13 @@ assets:
         dest: ./github-noslash
         source: public
         ref: ad1e78d13c33fae7a7ce22ed19920945ceea23e9
+    - github:
+        repo: replicatedhq/test-charts
+        path: template-functions
+        dest: ./github-stripped
+        strip_path: "{{repl ParseBool \"true\"}}"
+        source: public
+        ref: ad1e78d13c33fae7a7ce22ed19920945ceea23e9
 config:
   v1:
     - name: option_group

--- a/integration/init_app/github-template-func/expected/installer/github-stripped/config.md
+++ b/integration/init_app/github-template-func/expected/installer/github-stripped/config.md
@@ -1,0 +1,3 @@
+#This file tests a part of the Config suite of template functions in Ship
+
+Config option: abc123

--- a/integration/init_app/github-template-func/expected/installer/github-stripped/installation.md
+++ b/integration/init_app/github-template-func/expected/installer/github-stripped/installation.md
@@ -1,0 +1,4 @@
+#This file tests a part of the Integration suite of template functions in Ship
+
+Release semver: 1.0.1-SNAPSHOT
+

--- a/integration/init_app/github-template-func/expected/installer/github-stripped/static.md
+++ b/integration/init_app/github-template-func/expected/installer/github-stripped/static.md
@@ -1,0 +1,4 @@
+#This file tests a part of the Static suite of template functions in Ship
+
+TwoPlusTwo: 4
+UPPERCASE: UPPERCASE

--- a/integration/init_app/github-template-func/input/.ship/release.yml
+++ b/integration/init_app/github-template-func/input/.ship/release.yml
@@ -20,6 +20,13 @@ assets:
         dest: ./github-noslash
         source: public
         ref: ad1e78d13c33fae7a7ce22ed19920945ceea23e9
+    - github:
+        repo: replicatedhq/test-charts
+        path: template-functions
+        dest: ./github-stripped
+        strip_path: "{{repl ParseBool \"true\"}}"
+        source: public
+        ref: ad1e78d13c33fae7a7ce22ed19920945ceea23e9
 config:
   v1:
     - name: option_group

--- a/pkg/api/asset.go
+++ b/pkg/api/asset.go
@@ -62,6 +62,7 @@ type GitHubAsset struct {
 	Ref         string `json:"ref" yaml:"ref" hcl:"ref"`
 	Path        string `json:"path" yaml:"path" hcl:"path"`
 	Source      string `json:"source" yaml:"source" hcl:"source"`
+	StripPath   string `json:"strip_path" yaml:"strip_path" hcl:"strip_path"`
 }
 
 // WebAsset is an asset whose contents are specified by the HTML at the corresponding URL

--- a/pkg/lifecycle/render/amazoneks/render_test.go
+++ b/pkg/lifecycle/render/amazoneks/render_test.go
@@ -1003,7 +1003,7 @@ func TestBuildAsset(t *testing.T) {
 				req.Error(err)
 			}
 
-			req.Equal(got, tt.want)
+			req.Equal(tt.want, got)
 		})
 	}
 }

--- a/pkg/lifecycle/render/github/render_test.go
+++ b/pkg/lifecycle/render/github/render_test.go
@@ -1,0 +1,228 @@
+package github
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/replicatedhq/libyaml"
+	"github.com/replicatedhq/ship/pkg/api"
+	"github.com/replicatedhq/ship/pkg/templates"
+	"github.com/replicatedhq/ship/pkg/testing/logger"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_getDestPath(t *testing.T) {
+	type args struct {
+		githubPath string
+		asset      api.GitHubAsset
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "basic file",
+			args: args{
+				githubPath: "README.md",
+				asset: api.GitHubAsset{
+					Path:      "README.md",
+					StripPath: "",
+					AssetShared: api.AssetShared{
+						Dest: "./",
+					},
+				},
+			},
+			want:    "README.md",
+			wantErr: false,
+		},
+		{
+			name: "file in subdir",
+			args: args{
+				githubPath: "subdir/README.md",
+				asset: api.GitHubAsset{
+					Path:      "subdir/",
+					StripPath: "",
+					AssetShared: api.AssetShared{
+						Dest: "./",
+					},
+				},
+			},
+			want:    "subdir/README.md",
+			wantErr: false,
+		},
+		{
+			name: "file in subdir with dest dir",
+			args: args{
+				githubPath: "subdir/README.md",
+				asset: api.GitHubAsset{
+					Path:      "subdir/",
+					StripPath: "",
+					AssetShared: api.AssetShared{
+						Dest: "./dest",
+					},
+				},
+			},
+			want:    "dest/subdir/README.md",
+			wantErr: false,
+		},
+		{
+			name: "file in stripped subdir with dest dir",
+			args: args{
+				githubPath: "subdir/README.md",
+				asset: api.GitHubAsset{
+					Path:      "subdir/",
+					StripPath: "true",
+					AssetShared: api.AssetShared{
+						Dest: "./dest",
+					},
+				},
+			},
+			want:    "dest/README.md",
+			wantErr: false,
+		},
+		{
+			name: "literal file in stripped subdir with dest dir",
+			args: args{
+				githubPath: "dir/subdir/README.md",
+				asset: api.GitHubAsset{
+					Path:      "dir/subdir/README.md",
+					StripPath: "true",
+					AssetShared: api.AssetShared{
+						Dest: "dest",
+					},
+				},
+			},
+			want:    "dest/README.md",
+			wantErr: false,
+		},
+		{
+			name: "file in stripped subdir that lacks a trailing slash with dest dir",
+			args: args{
+				githubPath: "dir/subdir/README.md",
+				asset: api.GitHubAsset{
+					Path:      "dir/subdir",
+					StripPath: "true",
+					AssetShared: api.AssetShared{
+						Dest: "dest",
+					},
+				},
+			},
+			want:    "dest/README.md",
+			wantErr: false,
+		},
+		{
+			name: "templated dest dir",
+			args: args{
+				githubPath: "dir/subdir/README.md",
+				asset: api.GitHubAsset{
+					Path:      "dir/subdir",
+					StripPath: "false",
+					AssetShared: api.AssetShared{
+						Dest: "dest{{repl Add 1 1}}",
+					},
+				},
+			},
+			want:    "dest2/dir/subdir/README.md",
+			wantErr: false,
+		},
+		{
+			name: "templated stripPath (eval to true)",
+			args: args{
+				githubPath: "dir/subdir/README.md",
+				asset: api.GitHubAsset{
+					Path:      "dir/subdir",
+					StripPath: `{{repl ParseBool "true"}}`,
+					AssetShared: api.AssetShared{
+						Dest: "dest",
+					},
+				},
+			},
+			want:    "dest/README.md",
+			wantErr: false,
+		},
+		{
+			name: "templated stripPath (eval to false)",
+			args: args{
+				githubPath: "dir/subdir/README.md",
+				asset: api.GitHubAsset{
+					Path:      "dir/subdir",
+					StripPath: `{{repl ParseBool "false"}}`,
+					AssetShared: api.AssetShared{
+						Dest: "dest",
+					},
+				},
+			},
+			want:    "dest/dir/subdir/README.md",
+			wantErr: false,
+		},
+		{
+			name: "strip path of root dir file",
+			args: args{
+				githubPath: "README.md",
+				asset: api.GitHubAsset{
+					Path:      "",
+					StripPath: "true",
+					AssetShared: api.AssetShared{
+						Dest: "dest",
+					},
+				},
+			},
+			want:    "dest/README.md",
+			wantErr: false,
+		},
+		{
+			name: "not a valid template function (dest)",
+			args: args{
+				githubPath: "README.md",
+				asset: api.GitHubAsset{
+					Path:      "",
+					StripPath: "true",
+					AssetShared: api.AssetShared{
+						Dest: "{{repl NotATemplateFunction }}",
+					},
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "not a valid template function (stripPath)",
+			args: args{
+				githubPath: "README.md",
+				asset: api.GitHubAsset{
+					Path:      "",
+					StripPath: "{{repl NotATemplateFunction }}",
+					AssetShared: api.AssetShared{
+						Dest: "dest",
+					},
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			testLogger := &logger.TestLogger{T: t}
+			v := viper.New()
+			bb := templates.NewBuilderBuilder(testLogger, v)
+			builder, err := bb.FullBuilder(api.ReleaseMetadata{}, []libyaml.ConfigGroup{}, map[string]interface{}{})
+			req.NoError(err)
+
+			got, err := getDestPath(tt.args.githubPath, tt.args.asset, builder)
+			if !tt.wantErr {
+				req.NoErrorf(err, "getDestPath(%s, %+v, builder) error = %v", tt.args.githubPath, tt.args.asset, err)
+			} else {
+				req.Error(err)
+			}
+
+			// convert the returned file to forwardslash format before testing - otherwise this test fails when the separator isn't '/'
+			req.Equal(tt.want, filepath.ToSlash(got))
+		})
+	}
+}

--- a/pkg/lifecycle/render/googlegke/render_test.go
+++ b/pkg/lifecycle/render/googlegke/render_test.go
@@ -246,7 +246,7 @@ func TestBuildAsset(t *testing.T) {
 				req.Error(err)
 			}
 
-			req.Equal(got, tt.want)
+			req.Equal(tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
What I Did
------------
Added a way for GitHub assets to be written at paths that do not include their subdirectories, closes #476 
Added the ability to template the dest of a github asset.
Fixed the output of two test suites that had 'expected' and 'actual' reversed.

How I Did it
------------
A (templatable) parameter `strip_path` has been added to the github asset. If true, the github directory will not be included in the filepath of the generated files. For instance, when outputting all files within 'source/' in the repository to the 'dest/' directory, the file 'source/a/file.txt' would be placed at 'dest/source/a/file.txt' when this is false and 'dest/a/file.txt' when this is true.

How to verify it
------------
Look at the unit tests in context of the rest of the code or observe the integration test that will be included once replicated-lint has been updated to include the new `strip_path` param.

Description for the Changelog
------------
Subdirectories of GitHub repositories assets can now be placed directly within a destination directory using the `github` asset.


Picture of a Boat (not required but encouraged)
------------

![USS Thomas Hudner (DDG 116)](https://upload.wikimedia.org/wikipedia/commons/4/44/USS_Thomas_Hudner_%28DDG_116%29_returns_after_completing_acceptance_trials.jpg "USS Thomas Hudner (DDG 116)")










<!-- (thanks https://github.com/docker/docker for this template) -->

