### PR TITLE
update readme to refer to 0.15.0 downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ There are two ways you can get started with Ship:
 Ship is packaged as a single binary, and Linux and MacOS versions are distributed:
 - To download the latest Linux build, run:
 ```shell
-curl -sSL https://github.com/replicatedhq/ship/releases/download/v0.14.0/ship_0.14.0_linux_amd64.tar.gz | tar xv && sudo mv ship /usr/local/bin
+curl -sSL https://github.com/replicatedhq/ship/releases/download/v0.15.0/ship_0.15.0_linux_amd64.tar.gz | tar xv && sudo mv ship /usr/local/bin
 ```
 
 - To download the latest MacOS build, run:
 ```shell
-curl -sSL https://github.com/replicatedhq/ship/releases/download/v0.14.0/ship_0.14.0_darwin_amd64.tar.gz | tar xv && sudo mv ship /usr/local/bin
+curl -sSL https://github.com/replicatedhq/ship/releases/download/v0.15.0/ship_0.15.0_darwin_amd64.tar.gz | tar xv && sudo mv ship /usr/local/bin
 ```
 
 After ship is installed, run it with:


### PR DESCRIPTION
What I Did
------------
Updated the readme to refer to the new 0.15.0 downloads.

How I Did it
------------


How to verify it
------------
Look, it's a +2-2 change

Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------
![image](https://user-images.githubusercontent.com/2318911/45192945-6344d680-b200-11e8-8121-4cfed5f632fa.png)












<!-- (thanks https://github.com/docker/docker for this template) -->

