### PR TITLE
 Add a Go Report Card badge - currently A+

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Ship
 [![Maintainability](https://api.codeclimate.com/v1/badges/a00869c41469d016a3c8/maintainability)](https://codeclimate.com/github/replicatedhq/ship/maintainability)
 [![CircleCI](https://circleci.com/gh/replicatedhq/ship.svg?style=svg&circle-token=471765bf5ec85ede48fcf02ea6a886dc6c5a73f1)](https://circleci.com/gh/replicatedhq/ship)
 [![Docker Image](https://images.microbadger.com/badges/image/replicated/ship.svg)](https://microbadger.com/images/replicated/ship)
+[![Go Report Card](https://goreportcard.com/badge/github.com/replicatedhq/ship)](https://goreportcard.com/report/github.com/replicatedhq/ship)
 
 
 ![Replicated Ship](https://github.com/replicatedhq/ship/blob/master/logo/logo.png)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Ship
 [![CircleCI](https://circleci.com/gh/replicatedhq/ship.svg?style=svg&circle-token=471765bf5ec85ede48fcf02ea6a886dc6c5a73f1)](https://circleci.com/gh/replicatedhq/ship)
 [![Docker Image](https://images.microbadger.com/badges/image/replicated/ship.svg)](https://microbadger.com/images/replicated/ship)
 [![Go Report Card](https://goreportcard.com/badge/github.com/replicatedhq/ship)](https://goreportcard.com/report/github.com/replicatedhq/ship)
+[![GitHub stars](https://img.shields.io/github/stars/replicatedhq/ship.svg)](https://github.com/replicatedhq/ship/stargazers)
 
 
 ![Replicated Ship](https://github.com/replicatedhq/ship/blob/master/logo/logo.png)


### PR DESCRIPTION
What I Did
------------
Added a badge for our Go report card (via goreportcard.com)
Also added a badge for our GitHub stars

How I Did it
------------
It's a badge!

How to verify it
------------
Click the "Display the rich diff" icon. Or look here:
[![Go Report Card](https://goreportcard.com/badge/github.com/replicatedhq/ship)](https://goreportcard.com/report/github.com/replicatedhq/ship)
[![GitHub stars](https://img.shields.io/github/stars/replicatedhq/ship.svg)](https://github.com/replicatedhq/ship/stargazers)

Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------
![image](https://user-images.githubusercontent.com/2318911/45240000-0991ea00-b29c-11e8-80fd-29a348789665.png)












<!-- (thanks https://github.com/docker/docker for this template) -->

