### PR TITLE
Allow Ship app to accept apiEndpoint as a prop

### DIFF
--- a/web/src/ShipV2Root.jsx
+++ b/web/src/ShipV2Root.jsx
@@ -1,21 +1,21 @@
 import React from "react";
 import { Provider } from "react-redux";
-import { hot } from "react-hot-loader";
-import { getStore } from "./redux";
 import RouteDecider from "./containers/RouteDecider";
 import AppWrapper from "./containers/AppWrapper";
 import "./scss/index.scss";
+import { configureStore } from "./redux";
+import PropTypes from "prop-types";
 
-class ShipRoot extends React.Component {
-  render() {
-    return (
-      <Provider store={getStore()}>
-        <AppWrapper>
-          <RouteDecider />
-        </AppWrapper>
-      </Provider>
-    );
-  }
+const ShipV2Root = ({ apiEndpoint }) => (
+  <Provider store={configureStore(apiEndpoint)}>
+    <AppWrapper>
+      <RouteDecider />
+    </AppWrapper>
+  </Provider>
+);
+
+ShipV2Root.propTypes = {
+  apiEndpoint: PropTypes.string.isRequired,
 }
 
-export default hot(module)(ShipRoot)
+export default ShipV2Root;

--- a/web/src/components/shared/DetermineComponentForRoute.jsx
+++ b/web/src/components/shared/DetermineComponentForRoute.jsx
@@ -18,8 +18,6 @@ import { fetchContentForStep } from "../../redux/data/appRoutes/actions";
 
 import "../../scss/components/shared/DetermineStep.scss";
 
-const apiEndpoint = window.env.API_ENDPOINT;
-
 export class DetermineComponentForRoute extends React.Component {
 
   constructor(props) {
@@ -63,7 +61,7 @@ export class DetermineComponentForRoute extends React.Component {
   }
 
   async handleShutdown() {
-    const url = `${apiEndpoint}/shutdown`;
+    const url = `${this.props.apiEndpoint}/shutdown`;
     await fetch(url, {
       method: "POST",
       headers: {

--- a/web/src/containers/DetermineComponentForRoute.js
+++ b/web/src/containers/DetermineComponentForRoute.js
@@ -20,6 +20,7 @@ const DetermineComponentForRoute = connect(
     phase: state.data.determineSteps.stepsData.phase,
     progress: state.data.determineSteps.stepsData.progress,
     isPolling: state.data.determineSteps.stepsData.isPolling,
+    apiEndpoint: state.apiEndpoint,
   }),
   dispatch => ({
     getChannel() { return dispatch(getChannel()); },

--- a/web/src/redux/data/appRoutes/actions.js
+++ b/web/src/redux/data/appRoutes/actions.js
@@ -2,8 +2,6 @@ import "isomorphic-fetch";
 import { loadingData } from "../../ui/main/actions";
 import { receiveCurrentStep } from "../determineSteps/actions";
 
-const apiEndpoint = window.env.API_ENDPOINT;
-
 export const constants = {
   RECEIVE_ROUTES: "RECEIVE_ROUTES",
   SET_PHASE: "SET_PHASE",
@@ -47,7 +45,8 @@ export function shutdownApp() {
 }
 
 export function getRoutes() {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
+    const { apiEndpoint } = getState();
     let response;
     dispatch(loadingData("routes", true));
     try {
@@ -72,7 +71,7 @@ export function getRoutes() {
   };
 }
 
-export async function fetchContentForStep(stepId) {
+export async function fetchContentForStep(apiEndpoint, stepId) {
   const url = `${apiEndpoint}/navcycle/step/${stepId}`;
   const response = await fetch(url, {
     method: "GET",
@@ -85,11 +84,12 @@ export async function fetchContentForStep(stepId) {
 }
 
 export function pollContentForStep(stepId, cb) {
-  return async(dispatch) => {
+  return async(dispatch, getState) => {
     dispatch(polling(true));
 
+    const { apiEndpoint } = getState();
     const intervalId = setInterval(async() => {
-      const body = await fetchContentForStep(stepId).catch(() => {
+      const body = await fetchContentForStep(apiEndpoint, stepId).catch(() => {
         dispatch(polling(false));
         clearInterval(intervalId);
         return;
@@ -120,7 +120,9 @@ export function pollContentForStep(stepId, cb) {
 }
 
 export function getContentForStep(stepId) {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
+    const { apiEndpoint } = getState();
+
     let response;
     dispatch(loadingData("getCurrentStep", true));
     try {
@@ -157,7 +159,8 @@ export function getContentForStep(stepId) {
 
 export function finalizeStep(payload) {
   const { uri, method, body } = payload.action.onclick;
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
+    const { apiEndpoint } = getState();
     let response;
     dispatch(loadingData("submitAction", true));
     try {
@@ -184,7 +187,8 @@ export function finalizeStep(payload) {
 }
 
 export function initializeStep(stepId) {
-  return async() => {
+  return async(dispatch, getState) => {
+    const { apiEndpoint } = getState();
     try {
       const url = `${apiEndpoint}/navcycle/step/${stepId}`;
       await fetch(url, {

--- a/web/src/redux/data/applicationSettings/actions.js
+++ b/web/src/redux/data/applicationSettings/actions.js
@@ -2,7 +2,6 @@ import "isomorphic-fetch";
 import { loadingData } from "../../ui/main/actions";
 import { Utilities } from "../../../utilities/utilities";
 
-const apiEndpoint = window.env.API_ENDPOINT;
 export const constants = {
   RECEIVE_APPLICATION_SETTINGS: "RECEIVE_APPLICATION_SETTINGS",
   SET_CONFIG_ERRORS: "SET_CONFIG_ERRORS"
@@ -23,8 +22,8 @@ export function setConfigErrors(error) {
 }
 
 export function getApplicationSettings(payload, shouldLoad = true) {
-  return async (dispatch) => {
-    // if (!appId) return;
+  return async (dispatch, getState) => {
+    const { apiEndpoint } = getState();
     let response;
     if (shouldLoad) {
       dispatch(loadingData("appSettingsFields", true));
@@ -61,8 +60,10 @@ export function getApplicationSettings(payload, shouldLoad = true) {
 }
 
 export function saveApplicationSettings(payload, validate) {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
     dispatch(loadingData("saveAppSettings", true));
+
+    const { apiEndpoint } = getState();
     let response;
     try {
       const url = `${apiEndpoint}/config`;
@@ -97,8 +98,10 @@ export function saveApplicationSettings(payload, validate) {
 }
 
 export function finalizeApplicationSettings(payload, validate) {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
     dispatch(loadingData("finalizeAppSettings", true));
+
+    const { apiEndpoint } = getState();
     let response;
     try {
       const url = `${apiEndpoint}/config/finalize`;
@@ -131,8 +134,10 @@ export function finalizeApplicationSettings(payload, validate) {
 }
 
 export function setApplicationState(payload) {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
     dispatch(loadingData("setAppState", true));
+
+    const { apiEndpoint } = getState();
     let response;
     try {
       const url = `${apiEndpoint}/state`;

--- a/web/src/redux/data/channelSettings/actions.js
+++ b/web/src/redux/data/channelSettings/actions.js
@@ -1,7 +1,6 @@
 import "isomorphic-fetch";
 import { loadingData } from "../../ui/main/actions";
 
-const apiEndpoint = window.env.API_ENDPOINT;
 export const constants = {
   RECEIVE_CHANNEL_DETAILS: "RECEIVE_CHANNEL_DETAILS"
 };
@@ -14,7 +13,8 @@ export function receiveChannelSettings(message) {
 }
 
 export function getChannel() {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
+    const { apiEndpoint } = getState();
     let response;
     dispatch(loadingData("getChannel", true));
     try {

--- a/web/src/redux/data/determineSteps/actions.js
+++ b/web/src/redux/data/determineSteps/actions.js
@@ -2,7 +2,6 @@ import "isomorphic-fetch";
 import { loadingData } from "../../ui/main/actions";
 import { Utilities } from "../../../utilities/utilities";
 
-const apiEndpoint = window.env.API_ENDPOINT;
 export const constants = {
   RECEIVE_CURRENT_STEP: "RECEIVE_CURRENT_STEP",
   SET_STEP_ERROR: "SET_STEP_ERROR"
@@ -23,7 +22,8 @@ export function setStepError(message) {
 }
 
 export function getCurrentStep(loaderType = "getCurrentStep") {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
+    const { apiEndpoint } = getState();
     let response;
     dispatch(loadingData(loaderType, true));
     try {
@@ -55,7 +55,8 @@ export function getCurrentStep(loaderType = "getCurrentStep") {
 
 export function submitAction(payload) {
   const { uri, method, body } = payload.action.onclick;
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
+    const { apiEndpoint } = getState();
     let response;
     dispatch(loadingData("submitAction", true));
     try {

--- a/web/src/redux/data/determineSteps/actions.js
+++ b/web/src/redux/data/determineSteps/actions.js
@@ -57,11 +57,10 @@ export function submitAction(payload) {
   const { uri, method, body } = payload.action.onclick;
   return async (dispatch, getState) => {
     const { apiEndpoint } = getState();
-    let response;
     dispatch(loadingData("submitAction", true));
     try {
       const url = `${apiEndpoint}${uri}`;
-      response = await fetch(url, {
+      await fetch(url, {
         method,
         body,
         headers: {
@@ -69,9 +68,6 @@ export function submitAction(payload) {
           "Content-Type": "application/json"
         },
       });
-      if (!response.ok) {
-        dispatch(loadingData("submitAction", false));
-      }
       dispatch(loadingData("submitAction", false));
       dispatch(getCurrentStep());
     } catch (error) {

--- a/web/src/redux/data/kustomizeOverlay/actions.js
+++ b/web/src/redux/data/kustomizeOverlay/actions.js
@@ -2,7 +2,6 @@ import "isomorphic-fetch";
 import { loadingData } from "../../ui/main/actions";
 import { getContentForStep } from "../appRoutes/actions";
 
-const apiEndpoint = window.env.API_ENDPOINT;
 export const constants = {
   RECEIVE_FILE_CONTENT: "RECEIVE_FILE_CONTENT",
   RECEIVE_PATCH: "RECEIVE_PATCH",
@@ -20,10 +19,11 @@ export function receiveFileContent(content, path) {
 }
 
 export function getFileContent(payload) {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
     let response;
     dispatch(loadingData("fileContent", true));
     try {
+      const { apiEndpoint } = getState();
       const url = `${apiEndpoint}/kustomize/file`;
       response = await fetch(url, {
         method: "POST",
@@ -50,7 +50,8 @@ export function getFileContent(payload) {
 }
 
 export function saveKustomizeOverlay(payload) {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
+    const { apiEndpoint } = getState();
     let response;
     dispatch(loadingData("saveKustomize", true));
     try {
@@ -79,7 +80,8 @@ export function saveKustomizeOverlay(payload) {
 }
 
 export function deleteOverlay(path) {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
+    const { apiEndpoint } = getState();
     let response;
     dispatch(loadingData("deleteOverlay", true));
     try {
@@ -109,7 +111,8 @@ export function deleteOverlay(path) {
 }
 
 export function finalizeKustomizeOverlay() {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
+    const { apiEndpoint } = getState();
     let response;
     dispatch(loadingData("finalizeKustomize", true));
     try {
@@ -145,7 +148,8 @@ export function receivePatch(patch) {
 }
 
 export function generatePatch(payload) {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
+    const { apiEndpoint } = getState();
     try {
       const url = `${apiEndpoint}/kustomize/patch`;
       const response = await fetch(url, {
@@ -169,7 +173,8 @@ export function generatePatch(payload) {
 }
 
 export function applyPatch(payload) {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
+    const { apiEndpoint } = getState();
     try {
       const url = `${apiEndpoint}/kustomize/apply`;
       const response = await fetch(url, {

--- a/web/src/redux/data/kustomizeSettings/actions.js
+++ b/web/src/redux/data/kustomizeSettings/actions.js
@@ -2,7 +2,6 @@ import "isomorphic-fetch";
 import { loadingData } from "../../ui/main/actions";
 //import { Utilities } from "../../../utilities/utilities";
 
-const apiEndpoint = window.env.API_ENDPOINT;
 export const constants = {
   RECEIVE_HELM_CHART_METADATA: "RECEIVE_HELM_CHART_METADATA",
   SET_HELM_CHART_ERROR: "SET_HELM_CHART_ERROR"
@@ -23,7 +22,8 @@ export function setHelmChartError(error) {
 }
 
 export function getHelmChartMetadata(loaderType = "getHelmChartMetadata") {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
+    const { apiEndpoint } = getState();
     let response;
     dispatch(loadingData(loaderType, true));
     try {
@@ -54,7 +54,8 @@ export function getHelmChartMetadata(loaderType = "getHelmChartMetadata") {
 }
 
 export function saveHelmChartValues(payload, loaderType = "saveHelmChartValues") {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
+    const { apiEndpoint } = getState();
     let response;
     dispatch(loadingData(loaderType, true));
     const url = `${apiEndpoint}/helm-values`;

--- a/web/src/redux/index.js
+++ b/web/src/redux/index.js
@@ -8,35 +8,32 @@ import UIReducers from "./ui";
 
 const tracker = createTracker();
 
-const appReducer = combineReducers({
-  data: DataReducers,
-  ui: UIReducers,
-});
-
-const rootReducer = (state, action) => {
-  if (action.type === "PURGE_ALL") {
-    state = undefined
-  }
-  return appReducer(state, action);
-};
-
 let store;
-export function configStore() {
-  const hasExtension = window.devToolsExtension;
-  return new Promise((resolve, reject) => {
-    try {
-      store = createStore(
-        rootReducer,
-        compose(
-          applyMiddleware(thunk, tracker),
-          hasExtension ? window.devToolsExtension() : f => f,
-        ),
-      );
-      resolve(store);
-    } catch (error) {
-      reject(error);
-    }
+
+export function configureStore(apiEndpoint) {
+  const appReducer = combineReducers({
+    data: DataReducers,
+    ui: UIReducers,
+    apiEndpoint: () => apiEndpoint
   });
+
+  const rootReducer = (state, action) => {
+    if (action.type === "PURGE_ALL") {
+      state = undefined
+    }
+    return appReducer(state, action);
+  };
+
+  const hasExtension = window.devToolsExtension;
+  store = createStore(
+    rootReducer,
+    compose(
+      applyMiddleware(thunk, tracker),
+      hasExtension ? window.devToolsExtension() : f => f,
+    ),
+  )
+
+  return store;
 }
 
 export function getStore() {

--- a/web/src/shipV2Index.jsx
+++ b/web/src/shipV2Index.jsx
@@ -1,8 +1,11 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import ShipV2Root from "./ShipV2Root";
-import { configStore } from "./redux";
+import ShipRoot from "./ShipV2Root";
+import { hot } from "react-hot-loader";
 
-configStore().then(() => {
-  ReactDOM.render((<ShipV2Root/>), document.getElementById("root"));
-});
+const ShipV2Root = hot(module)(ShipRoot)
+
+ReactDOM.render(
+  <ShipV2Root apiEndpoint={window.env.API_ENDPOINT} />,
+  document.getElementById("root")
+);


### PR DESCRIPTION
What I Did
------------
This change allows the `ShipV2Root` component to accept an `apiEndpoint` prop so that apps that decide to use this as a component can dynamically pass in the endpoint for the Ship binary server.

How I Did it
------------
- Pass in API endpoint as Prop to `ShipV2Root`
- Add additional reducer to get API endpoint
- Use `getState` to access API endpoint in actions (additional info [here](https://stackoverflow.com/a/35674575/9790584))

How to verify it
------------
Running a typical `ship init` workflow will continue to show the same behavior as before. Integration & E2E tests should continue to pass.

Description for the Changelog
------------
- Allow Ship app to accept apiEndpoint as a prop


Picture of a Boat (not required but encouraged)
------------
![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSAmmWcaHm9EcCyVaHfkAIql_Bn6qJJxfmFkcFmM_aW9rR03NVE)











<!-- (thanks https://github.com/docker/docker for this template) -->

