### PR TITLE
serialize requested upstream as well

### DIFF
--- a/integration/init_app/amazon-eks-template/expected/.ship/state.json
+++ b/integration/init_app/amazon-eks-template/expected/.ship/state.json
@@ -1,6 +1,7 @@
 {
   "v1": {
     "config": {},
+    "upstream": "staging.replicated.app/some-cool-ci-tool?installation_id=arpUWXmV5JnELQ449wRACqVnlqtJlfZy&customer_id=-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
     "metadata": {
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
       "installationID": "arpUWXmV5JnELQ449wRACqVnlqtJlfZy",

--- a/integration/init_app/basic/expected/.ship/state.json
+++ b/integration/init_app/basic/expected/.ship/state.json
@@ -1,1 +1,11 @@
-{"v1":{"config":{}, "metadata":{"customerID":"-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G","installationID":"3Z6uuPbVz6jTxRuXHn_l6UlYQz3hWz6-","version":"1.0.0-SNAPSHOT"}}}
+{
+  "v1": {
+    "config": {},
+    "upstream": "staging.replicated.app/some-cool-ci-tool?installation_id=3Z6uuPbVz6jTxRuXHn_l6UlYQz3hWz6-&customer_id=-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+    "metadata": {
+      "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+      "installationID": "3Z6uuPbVz6jTxRuXHn_l6UlYQz3hWz6-",
+      "version": "1.0.0-SNAPSHOT"
+    }
+  }
+}

--- a/integration/init_app/github-template-func/expected/.ship/state.json
+++ b/integration/init_app/github-template-func/expected/.ship/state.json
@@ -1,1 +1,13 @@
-{"v1":{"config":{"option":"abc123"},"metadata":{"customerID":"-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G","installationID":"SGhsB1wdjOF0N2KBRoMBW0zw4tHiF4ZR","version":"1.0.1-SNAPSHOT"}}}
+{
+  "v1": {
+    "config": {
+      "option": "abc123"
+    },
+    "upstream": "staging.replicated.app/some-cool-ci-tool?installation_id=SGhsB1wdjOF0N2KBRoMBW0zw4tHiF4ZR&customer_id=-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+    "metadata": {
+      "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+      "installationID": "SGhsB1wdjOF0N2KBRoMBW0zw4tHiF4ZR",
+      "version": "1.0.1-SNAPSHOT"
+    }
+  }
+}

--- a/integration/init_app/helm-github/expected/.ship/state.json
+++ b/integration/init_app/helm-github/expected/.ship/state.json
@@ -1,1 +1,11 @@
-{"v1":{"config":{},"metadata":{"customerID":"-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G","installationID":"OafdEI-lF2IQV0Il3bfzrIl5mUdHCb3j","version":"1.0.0-SNAPSHOT"}}}
+{
+  "v1": {
+    "config": {},
+    "upstream": "staging.replicated.app/some-cool-ci-tool?installation_id=OafdEI-lF2IQV0Il3bfzrIl5mUdHCb3j&customer_id=-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+    "metadata": {
+      "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+      "installationID": "OafdEI-lF2IQV0Il3bfzrIl5mUdHCb3j",
+      "version": "1.0.0-SNAPSHOT"
+    }
+  }
+}

--- a/integration/init_app/installation-template-func/expected/.ship/state.json
+++ b/integration/init_app/installation-template-func/expected/.ship/state.json
@@ -1,1 +1,11 @@
-{"v1":{"config":{},"metadata":{"customerID":"-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G","installationID": "mTYFJCyJsJIC82QbUTSMmfmttVYCKAzl","version": "1.0.1-SNAPSHOT"}}}
+{
+  "v1": {
+    "config": {},
+    "upstream": "staging.replicated.app/some-cool-ci-tool?installation_id=mTYFJCyJsJIC82QbUTSMmfmttVYCKAzl&customer_id=-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+    "metadata": {
+      "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+      "installationID": "mTYFJCyJsJIC82QbUTSMmfmttVYCKAzl",
+      "version": "1.0.1-SNAPSHOT"
+    }
+  }
+}

--- a/integration/init_app/integration_test.go
+++ b/integration/init_app/integration_test.go
@@ -89,11 +89,11 @@ var _ = Describe("ship init replicated.app/...", func() {
 					// read the test metadata
 					testMetadata = readMetadata(testPath)
 
-					// if a token is provided, try to ensure the release matches what we have here in the repo
 					if vendorToken == "" {
 						Fail("Please set SHIP_INTEGRATION_VENDOR_TOKEN to run the init_app test suite")
 					}
 
+					// try to ensure the release matches what we have here in the repo
 					channelName := fmt.Sprintf("integration replicated.app %s", filepath.Base(testPath))
 					installationID = createRelease(vendorEndpoint, vendorToken, testInputPath, testMetadata, channelName)
 					close(done)

--- a/pkg/specs/chart.go
+++ b/pkg/specs/chart.go
@@ -185,11 +185,6 @@ func (r *Resolver) ResolveBaseMetadata(upstream string, localPath string) (*api.
 	debug := level.Debug(log.With(r.Logger, "method", "resolveBaseMetaData"))
 	var md api.ShipAppMetadata
 	md.URL = upstream
-	debug.Log("event", "upstream.Serialize", "for", localPath, "upstream", upstream)
-	err := r.StateManager.SerializeUpstream(upstream)
-	if err != nil {
-		return nil, errors.Wrapf(err, "write upstream")
-	}
 	debug.Log("phase", "calculate-sha", "for", localPath)
 	contentSHA, err := r.shaSummer(r, localPath)
 	if err != nil {

--- a/pkg/specs/interface.go
+++ b/pkg/specs/interface.go
@@ -39,6 +39,12 @@ func (r *Resolver) ResolveRelease(ctx context.Context, upstream string) (*api.Re
 	debug.Log("event", "applicationType.resolve", "type", applicationType)
 	r.ui.Info(fmt.Sprintf("Detected application type %s", applicationType))
 
+	debug.Log("event", "upstream.Serialize", "for", localPath, "upstream", upstream)
+	err = r.StateManager.SerializeUpstream(upstream)
+	if err != nil {
+		return nil, errors.Wrapf(err, "write upstream")
+	}
+
 	switch applicationType {
 
 	case "helm":

--- a/pkg/specs/interface_test.go
+++ b/pkg/specs/interface_test.go
@@ -117,6 +117,7 @@ icon: https://kfbr.392/x5.png
 					}).After(inOrder)
 
 				inOrder = mockUi.EXPECT().Info("Detected application type replicated.app").After(inOrder)
+				inOrder = mockState.EXPECT().SerializeUpstream("replicated.app?customer_id=12345&installation_id=67890").After(inOrder)
 				mockAppResolver.EXPECT().ResolveAppRelease(ctx, &replicatedapp2.Selector{
 					CustomerID:     "12345",
 					InstallationID: "67890",


### PR DESCRIPTION
What I Did
------------

Serialize upstream to `state.json`. While `state.v1.metadata` will track
`replicated.app` resolved release, there may be a difference between
what was requested and what was resolved (e.g. request for a semver
range in the replicated.app upstream).

How I Did it
------------

Move upstream serialization out of helm-specific release logic, before
the app-type `switch` statement

How to verify it
------------

`ship init replicated.app/...`, ensure `upstream` is written to state.

Description for the Changelog
------------

`ship init replicated.app/...` will now write an `upstream` to
`state.json`.

![](https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/A._F._Lydon_Robinson_Crusoe_Plate_01_%281865%29.JPG/1024px-A._F._Lydon_Robinson_Crusoe_Plate_01_%281865%29.JPG)

<!-- (thanks https://github.com/docker/docker for this template) -->


What I Did
------------


How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->