### PR TITLE
persist content sha to state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ integration/*/_test_*
 /.state/
 /overlays/
 /base/
+web/.state/

--- a/integration/base/amazon-eks/expected/.ship/state.json
+++ b/integration/base/amazon-eks/expected/.ship/state.json
@@ -1,1 +1,11 @@
-{"v1":{"config":{},"metadata": {"customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G", "installationID": "Jn0nK8OlT3k9AYqpnq6SGqzo_srKjzjQ", "version": "0.0.1-b"}}}
+{
+  "v1": {
+    "config": {},
+    "contentSHA": "0f476537db7bf02980df88c12f4b43c87094314635477263a2a5468f3c74a2dc",
+    "metadata": {
+      "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+      "installationID": "Jn0nK8OlT3k9AYqpnq6SGqzo_srKjzjQ",
+      "version": "0.0.1-b"
+    }
+  }
+}

--- a/integration/base/azure-aks/expected/.ship/state.json
+++ b/integration/base/azure-aks/expected/.ship/state.json
@@ -8,6 +8,7 @@
       "azure_subscription_id": "e9570f00-dbe5-4d1d-aa67-0eb9463fd9ad",
       "azure_tenant_id": "affca702-704f-4a80-a90d-64e1381fb5f0"
     },
+    "contentSHA": "fe72c32ca04fb40f17ff1fe1e7a4bfe4d764fe1d4c30dc3fa6f05056019bba5c",
     "metadata": {
       "customerID": "placeholder",
       "installationID": "placeholder",

--- a/integration/base/basic-stateless/expected/.ship/state.json
+++ b/integration/base/basic-stateless/expected/.ship/state.json
@@ -1,1 +1,11 @@
-{"v1":{"config":{}, "metadata": {"customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G", "installationID": "RULNveQLrLj4GDum1yQhvKAcABh0GcLY", "version": "0.0.4"}}}
+{
+  "v1": {
+    "config": {},
+    "contentSHA": "af39a2dca324dad4488ac70eaca71806bf2def699bed604c1252b6333588309d",
+    "metadata": {
+      "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+      "installationID": "RULNveQLrLj4GDum1yQhvKAcABh0GcLY",
+      "version": "0.0.4"
+    }
+  }
+}

--- a/integration/base/basic/expected/.ship/state.json
+++ b/integration/base/basic/expected/.ship/state.json
@@ -1,1 +1,13 @@
-{"v1":{"config":{"test_option":"abc123_test-option-value"},"metadata": {"customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G", "installationID": "RULNveQLrLj4GDum1yQhvKAcABh0GcLY", "version": "0.0.4"}}}
+{
+  "v1": {
+    "config": {
+      "test_option": "abc123_test-option-value"
+    },
+    "contentSHA": "af39a2dca324dad4488ac70eaca71806bf2def699bed604c1252b6333588309d",
+    "metadata": {
+      "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+      "installationID": "RULNveQLrLj4GDum1yQhvKAcABh0GcLY",
+      "version": "0.0.4"
+    }
+  }
+}

--- a/integration/base/conditional-asset/expected/.ship/state.json
+++ b/integration/base/conditional-asset/expected/.ship/state.json
@@ -1,1 +1,13 @@
-{"v1":{"config":{"bool_option":"0"}, "metadata": {"customerID": "", "installationID": "", "version": ""}}}
+{
+  "v1": {
+    "config": {
+      "bool_option": "0"
+    },
+    "contentSHA": "e935ace16aacb22dc0fc5eccb3e7cc44c25ae8ffeca805c434317449d595800a",
+    "metadata": {
+      "customerID": "",
+      "installationID": "",
+      "version": ""
+    }
+  }
+}

--- a/integration/base/config-chain-override/expected/.ship/state.json
+++ b/integration/base/config-chain-override/expected/.ship/state.json
@@ -1,1 +1,15 @@
-{"v1":{"config":{"option":"abc123","t2_option":"abc123_abc123","t3_option":"abc123_abc123 + abc123"}, "metadata": {"customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G", "installationID": "t6-uzytbbkSoCiLtEfNO62LDIRLFec-2", "version": "0.0.1-test2"}}}
+{
+  "v1": {
+    "config": {
+      "option": "abc123",
+      "t2_option": "abc123_abc123",
+      "t3_option": "abc123_abc123 + abc123"
+    },
+    "contentSHA": "f256226c1517134c10dff4ba08dc3a6c55b28320f7ba0829b62c96ad84fe7106",
+    "metadata": {
+      "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+      "installationID": "t6-uzytbbkSoCiLtEfNO62LDIRLFec-2",
+      "version": "0.0.1-test2"
+    }
+  }
+}

--- a/integration/base/config-chain/expected/.ship/state.json
+++ b/integration/base/config-chain/expected/.ship/state.json
@@ -1,1 +1,15 @@
-{"v1":{"config":{"option":"abc123","t2_option":"abc123_abc123","t3_option":"abc123_abc123 + abc123"}, "metadata": {"customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G", "installationID": "t6-uzytbbkSoCiLtEfNO62LDIRLFec-2", "version": "0.0.1-test2"}}}
+{
+  "v1": {
+    "config": {
+      "option": "abc123",
+      "t2_option": "abc123_abc123",
+      "t3_option": "abc123_abc123 + abc123"
+    },
+    "contentSHA": "f256226c1517134c10dff4ba08dc3a6c55b28320f7ba0829b62c96ad84fe7106",
+    "metadata": {
+      "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+      "installationID": "t6-uzytbbkSoCiLtEfNO62LDIRLFec-2",
+      "version": "0.0.1-test2"
+    }
+  }
+}

--- a/integration/base/default-values/expected/.ship/state.json
+++ b/integration/base/default-values/expected/.ship/state.json
@@ -1,1 +1,16 @@
-{"v1":{"config":{"cluster":"Ovarb","environment":"Epsilon","namespace":"Alpha","scheduler":""}, "metadata": {"customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G", "installationID": "PYRBRKHcTSbMPFJqz3a_82p_kR00DPdz", "version": "0.1.4"}}}
+{
+  "v1": {
+    "config": {
+      "cluster": "Ovarb",
+      "environment": "Epsilon",
+      "namespace": "Alpha",
+      "scheduler": ""
+    },
+    "contentSHA": "377deb7eccf40c1fede60b7db73c69ba57f28eed0cfe0fdbb8cbe11ced3f64e4",
+    "metadata": {
+      "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+      "installationID": "PYRBRKHcTSbMPFJqz3a_82p_kR00DPdz",
+      "version": "0.1.4"
+    }
+  }
+}

--- a/integration/base/docker-layer/expected/.ship/state.json
+++ b/integration/base/docker-layer/expected/.ship/state.json
@@ -1,1 +1,13 @@
-{"v1":{"config":{"option":"value"}, "metadata": {"customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G", "installationID": "a5jOQ1Fnb5l-a2uXwFf-YFkUukeVWnbU", "version": "0.0.9"}}}
+{
+  "v1": {
+    "config": {
+      "option": "value"
+    },
+    "contentSHA": "181da1498e9c63c2b9a8b47446cce7dffd11c28b095814c7136a02391edbca8b",
+    "metadata": {
+      "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+      "installationID": "a5jOQ1Fnb5l-a2uXwFf-YFkUukeVWnbU",
+      "version": "0.0.9"
+    }
+  }
+}

--- a/integration/base/docker-push/expected/.ship/state.json
+++ b/integration/base/docker-push/expected/.ship/state.json
@@ -1,1 +1,14 @@
-{"v1":{"config":{"external_registry":"localhost:5000","test_option":"abc123_test-option-value"}, "metadata": {"customerID": "", "installationID": "", "version": ""}}}
+{
+  "v1": {
+    "config": {
+      "external_registry": "localhost:5000",
+      "test_option": "abc123_test-option-value"
+    },
+    "contentSHA": "f1a562de29d7dbb760c9d20382613a47bff882ecf71f21ad5f1c67bbffa9fedd",
+    "metadata": {
+      "customerID": "",
+      "installationID": "",
+      "version": ""
+    }
+  }
+}

--- a/integration/base/docker/expected/.ship/state.json
+++ b/integration/base/docker/expected/.ship/state.json
@@ -1,1 +1,13 @@
-{"v1":{"config":{"test_option":"abc123_test-option-value"}, "metadata": {"customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G", "installationID": "RULNveQLrLj4GDum1yQhvKAcABh0GcLY", "version": "0.0.9"}}}
+{
+  "v1": {
+    "config": {
+      "test_option": "abc123_test-option-value"
+    },
+    "contentSHA": "104541e8f52c5077198f4bd2f8a5021ee1a85c0e54d6058b3a757490add42f13",
+    "metadata": {
+      "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+      "installationID": "RULNveQLrLj4GDum1yQhvKAcABh0GcLY",
+      "version": "0.0.9"
+    }
+  }
+}

--- a/integration/base/google-gke-template/expected/.ship/state.json
+++ b/integration/base/google-gke-template/expected/.ship/state.json
@@ -10,6 +10,7 @@
       "machine_type": "n1-standard-4",
       "additional_zones": "us-east1-c,us-east1-d"
     },
+    "contentSHA": "ec78ca854922f211c0d9f15223d31e634cead6d0661bba615f12a4d754650741",
     "metadata": {
       "customerID": "placeholder",
       "installationID": "placeholder",

--- a/integration/base/helm-fetch/expected/.ship/state.json
+++ b/integration/base/helm-fetch/expected/.ship/state.json
@@ -1,1 +1,11 @@
-{"v1":{"config":{}, "metadata": {"customerID": "", "installationID": "", "version": ""}}}
+{
+  "v1": {
+    "config": {},
+    "contentSHA": "54e761100cb39926d58cb68ddc20437347240310f5cbdce01f00d7e085d4c2b1",
+    "metadata": {
+      "customerID": "",
+      "installationID": "",
+      "version": ""
+    }
+  }
+}

--- a/integration/base/helm-nginx/expected/.ship/state.json
+++ b/integration/base/helm-nginx/expected/.ship/state.json
@@ -1,1 +1,11 @@
-{"v1":{"config":{}, "metadata": {"customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G", "installationID": "WAtB86RsD8koFOgnAEX63TU0mafWsqAj", "version": "0.0.4"}}}
+{
+  "v1": {
+    "config": {},
+    "contentSHA": "b93b0ea7be591d5d017fe977093eab71958b9e89a062062e500961011fce7f39",
+    "metadata": {
+      "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+      "installationID": "WAtB86RsD8koFOgnAEX63TU0mafWsqAj",
+      "version": "0.0.4"
+    }
+  }
+}

--- a/integration/base/render-root/expected/.ship/state.json
+++ b/integration/base/render-root/expected/.ship/state.json
@@ -1,1 +1,11 @@
-{"v1":{"config":{}, "metadata": {"customerID": "", "installationID": "", "version": ""}}}
+{
+  "v1": {
+    "config": {},
+    "contentSHA": "43908c014adbcd9b9c7bd5eb548fc5086c7a9f85b009c70a16e2902097d73784",
+    "metadata": {
+      "customerID": "",
+      "installationID": "",
+      "version": ""
+    }
+  }
+}

--- a/integration/base/terraform/expected/.ship/state.json
+++ b/integration/base/terraform/expected/.ship/state.json
@@ -1,1 +1,13 @@
-{"v1":{"config":{"id_length":"1"}, "metadata": {"customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G", "installationID": "lZk73HnLmatQ-s1nk7l3Q3QKA45orDFi", "version": "0.0.4-alpha"}}}
+{
+  "v1": {
+    "config": {
+      "id_length": "1"
+    },
+    "contentSHA": "8bf48b8321de3daa8d3466f7dae76c6589e60873bde27b04f32ec593c905006f",
+    "metadata": {
+      "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+      "installationID": "lZk73HnLmatQ-s1nk7l3Q3QKA45orDFi",
+      "version": "0.0.4-alpha"
+    }
+  }
+}

--- a/integration/base/web/expected/.ship/state.json
+++ b/integration/base/web/expected/.ship/state.json
@@ -1,1 +1,14 @@
-{"v1":{"config":{"methodType":"GET","resourceURL":"https://gist.githubusercontent.com/kevinherro/14227298facda4815f00e28f2e2e2097/raw/2a16512278a49d6cb417feb859005850c8f753de/integration-test"}, "metadata": {"customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G", "installationID": "6-TGyWWOCG-6hmsa4R1zz9jOL9CWPJy7", "version": "0.0.6"}}}
+{
+  "v1": {
+    "config": {
+      "methodType": "GET",
+      "resourceURL": "https://gist.githubusercontent.com/kevinherro/14227298facda4815f00e28f2e2e2097/raw/2a16512278a49d6cb417feb859005850c8f753de/integration-test"
+    },
+    "contentSHA": "3dc528ef57edab157951c0b8dfbaf510c6d8667f0808d2c0e9bdf7ce508e10a3",
+    "metadata": {
+      "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+      "installationID": "6-TGyWWOCG-6hmsa4R1zz9jOL9CWPJy7",
+      "version": "0.0.6"
+    }
+  }
+}

--- a/integration/init_app/amazon-eks-template/expected/.ship/state.json
+++ b/integration/init_app/amazon-eks-template/expected/.ship/state.json
@@ -2,6 +2,7 @@
   "v1": {
     "config": {},
     "upstream": "staging.replicated.app/some-cool-ci-tool?installation_id=arpUWXmV5JnELQ449wRACqVnlqtJlfZy&customer_id=-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+    "contentSHA": "f1eaaa149478c1f7d4a4d42f603933b3b78d8a3df50cabf8ae209cbe990590de",
     "metadata": {
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
       "installationID": "arpUWXmV5JnELQ449wRACqVnlqtJlfZy",

--- a/integration/init_app/basic/expected/.ship/state.json
+++ b/integration/init_app/basic/expected/.ship/state.json
@@ -2,6 +2,7 @@
   "v1": {
     "config": {},
     "upstream": "staging.replicated.app/some-cool-ci-tool?installation_id=3Z6uuPbVz6jTxRuXHn_l6UlYQz3hWz6-&customer_id=-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+    "contentSHA": "2260e2110304496fc8544b8bf51c95352cdf9300270fe7c7fa9f6e1b76855d1c",
     "metadata": {
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
       "installationID": "3Z6uuPbVz6jTxRuXHn_l6UlYQz3hWz6-",

--- a/integration/init_app/github-template-func/expected/.ship/state.json
+++ b/integration/init_app/github-template-func/expected/.ship/state.json
@@ -4,6 +4,7 @@
       "option": "abc123"
     },
     "upstream": "staging.replicated.app/some-cool-ci-tool?installation_id=SGhsB1wdjOF0N2KBRoMBW0zw4tHiF4ZR&customer_id=-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+    "contentSHA": "9fb30c009a2bb7202d3b0dfe7683823f799e238fd6132316de1cdbc54062dc6f",
     "metadata": {
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
       "installationID": "SGhsB1wdjOF0N2KBRoMBW0zw4tHiF4ZR",

--- a/integration/init_app/helm-github/expected/.ship/state.json
+++ b/integration/init_app/helm-github/expected/.ship/state.json
@@ -2,6 +2,7 @@
   "v1": {
     "config": {},
     "upstream": "staging.replicated.app/some-cool-ci-tool?installation_id=OafdEI-lF2IQV0Il3bfzrIl5mUdHCb3j&customer_id=-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+    "contentSHA": "3f27933df35c90e60a3c943e6fa765bc6116e8e6e17f89cdb6976ccc52e1cb65",
     "metadata": {
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
       "installationID": "OafdEI-lF2IQV0Il3bfzrIl5mUdHCb3j",

--- a/integration/init_app/installation-template-func/expected/.ship/state.json
+++ b/integration/init_app/installation-template-func/expected/.ship/state.json
@@ -2,6 +2,7 @@
   "v1": {
     "config": {},
     "upstream": "staging.replicated.app/some-cool-ci-tool?installation_id=mTYFJCyJsJIC82QbUTSMmfmttVYCKAzl&customer_id=-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+    "contentSHA": "c8bbe58c7ee51e7185d42b717a6465cd3d9ec1b9f8eccda20f112fe54c155d3e",
     "metadata": {
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
       "installationID": "mTYFJCyJsJIC82QbUTSMmfmttVYCKAzl",

--- a/pkg/lifecycle/render/docker/step_test.go
+++ b/pkg/lifecycle/render/docker/step_test.go
@@ -32,19 +32,19 @@ func TestDockerStep(t *testing.T) {
 		Expect                  error
 	}{
 		{
-			name: "registry succeeds",
+			name:                    "registry succeeds",
 			RegistrySecretSaveError: nil,
 			InstallationIDSaveError: nil,
 			Expect:                  nil,
 		},
 		{
-			name: "registry fails, install id succeeds",
+			name:                    "registry fails, install id succeeds",
 			RegistrySecretSaveError: errors.New("noooope"),
 			InstallationIDSaveError: nil,
 			Expect:                  nil,
 		},
 		{
-			name: "registry fails, install id fails",
+			name:                    "registry fails, install id fails",
 			RegistrySecretSaveError: errors.New("noooope"),
 			InstallationIDSaveError: errors.New("nope nope nope"),
 			Expect:                  errors.New("docker save image, both auth methods failed: nope nope nope"),

--- a/pkg/specs/replicatedapp/resolver_test.go
+++ b/pkg/specs/replicatedapp/resolver_test.go
@@ -1,10 +1,16 @@
 package replicatedapp
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/constants"
+	"github.com/replicatedhq/ship/pkg/test-mocks/state"
+	"github.com/replicatedhq/ship/pkg/testing/logger"
+	"github.com/replicatedhq/ship/pkg/testing/matchers"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 )
@@ -24,4 +30,81 @@ func TestPersistSpec(t *testing.T) {
 	persistedSpec, err := r.FS.ReadFile(constants.ReleasePath)
 	req.NoError(err)
 	req.True(reflect.DeepEqual(desiredSpec, persistedSpec))
+}
+
+func TestPersistRelease(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputRelease  *ShipRelease
+		inputSelector *Selector
+		shaSummer     shaSummer
+		expectCalls   func(t *testing.T, stateManager *state.MockManager)
+		expectRelease *api.Release
+	}{
+		{
+			name: "happy path",
+			inputRelease: &ShipRelease{
+				ID: "12345",
+				Spec: `
+---
+assets: 
+  v1: []
+`,
+			},
+			inputSelector: &Selector{
+				CustomerID:     "kfbr",
+				InstallationID: "392",
+			},
+			shaSummer: func(bytes []byte) string {
+				return "abcdef"
+			},
+			expectCalls: func(t *testing.T, stateManager *state.MockManager) {
+				stateManager.EXPECT().SerializeAppMetadata(&matchers.Is{
+					Test: func(v interface{}) bool {
+						rm := v.(api.ReleaseMetadata)
+						t.Log("testing release metadata", fmt.Sprintf("%v", rm))
+						return rm.ReleaseID == "12345" &&
+							rm.CustomerID == "kfbr" &&
+							rm.InstallationID == "392"
+					},
+				})
+				stateManager.EXPECT().SerializeContentSHA("abcdef")
+			},
+			expectRelease: &api.Release{
+				Spec: api.Spec{
+					Assets: api.Assets{
+						V1: []api.Asset{},
+					},
+				},
+				Metadata: api.ReleaseMetadata{
+					ReleaseID:      "12345",
+					CustomerID:     "kfbr",
+					InstallationID: "392",
+					Images:         []api.Image{},
+					GithubContents: []api.GithubContent{},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := require.New(t)
+			mc := gomock.NewController(t)
+			stateManager := state.NewMockManager(mc)
+			defer mc.Finish()
+
+			test.expectCalls(t, stateManager)
+
+			resolver := &resolver{
+				Logger:       &logger.TestLogger{T: t},
+				StateManager: stateManager,
+				ShaSummer:    test.shaSummer,
+			}
+
+			result, err := resolver.persistRelease(test.inputRelease, test.inputSelector)
+
+			req.NoError(err)
+			req.Equal(test.expectRelease, result)
+		})
+	}
 }


### PR DESCRIPTION
What I Did
------------

Persist content SHA to state.json for `ship init replicated.app` and `ship app` calls. For now, content SHA for such apps will just be the hash of the `ship.yaml`, things like `github` resources with `ref: master` or `:latest` docker images will break this, but for many of those we can't know the content without running the ship flow, and I think the `ship watch` flow should be as lightweight as possible. In general we discourage pointing releases at resources that can change anyways.

How I Did it
------------

- add ShaSummer field to replicatedapp.resolver
- add some tests to replicatedapp.resolver for ensuring we persist things properly
- some small refactoring to the resolver to enable testing this new behavior without needing to mock/interface the GraphQLClient just yet.

How to verify it
------------

`ship init` or `ship app` with a replicated.app,  check that contentSHAis written to state.json

Description for the Changelog
------------

`ship init replicated.app` and `ship app` now persists the `ship.yaml` content SHA to state.json.

Picture of a Boat (not required but encouraged)
------------

![](https://upload.wikimedia.org/wikipedia/commons/thumb/b/b5/Shipwreck_at_Ocean_Beach.jpg/1920px-Shipwreck_at_Ocean_Beach.jpg)
