### PR TITLE
watch computes content sha

### DIFF
--- a/integration/update/app_basic/expected/.ship/release.yml
+++ b/integration/update/app_basic/expected/.ship/release.yml
@@ -1,0 +1,29 @@
+---
+assets:
+  v1:
+    - inline:
+        contents: |
+          #!/bin/bash
+          echo "installing nothing"
+          echo "config option: {{repl ConfigOption "test_option" }}"
+        dest: ./scripts/install.sh
+        mode: 0777
+    - inline:
+        contents: |
+          #!/bin/bash
+          echo "tested nothing"
+        dest: ./scripts/test.sh
+        mode: 0777
+config:
+  v1:
+    - name: test_options
+      title: Test Options
+      description: testing testing 123
+      items:
+      - name: test_option
+        title: Test Option
+        default: abc123_test-option-value
+        type: text
+lifecycle:
+  v1:
+    - render: {}

--- a/integration/update/app_basic/expected/.ship/state.json
+++ b/integration/update/app_basic/expected/.ship/state.json
@@ -1,0 +1,12 @@
+{
+  "v1": {
+    "config": {},
+    "upstream": "staging.replicated.app/some-cool-ci-tool?installation_id=3Z6uuPbVz6jTxRuXHn_l6UlYQz3hWz6-&customer_id=-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+    "contentSHA": "2260e2110304496fc8544b8bf51c95352cdf9300270fe7c7fa9f6e1b76855d1c",
+    "metadata": {
+      "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+      "installationID": "3Z6uuPbVz6jTxRuXHn_l6UlYQz3hWz6-",
+      "version": "1.0.0-SNAPSHOT"
+    }
+  }
+}

--- a/integration/update/app_basic/expected/installer/scripts/install.sh
+++ b/integration/update/app_basic/expected/installer/scripts/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "installing nothing"
+echo "config option: abc123_test-option-value"

--- a/integration/update/app_basic/expected/installer/scripts/test.sh
+++ b/integration/update/app_basic/expected/installer/scripts/test.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "tested nothing"

--- a/integration/update/app_basic/input/.ship/state.json
+++ b/integration/update/app_basic/input/.ship/state.json
@@ -1,0 +1,12 @@
+{
+  "v1": {
+    "config": {},
+    "upstream": "staging.replicated.app/some-cool-ci-tool?installation_id=3Z6uuPbVz6jTxRuXHn_l6UlYQz3hWz6-&customer_id=-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+    "contentSHA": "2260e2110304496fc8544b8bf51c95352cdf9300270fe7c7fa9f6e1b76855d1c",
+    "metadata": {
+      "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
+      "installationID": "3Z6uuPbVz6jTxRuXHn_l6UlYQz3hWz6-",
+      "version": "1.0.0-SNAPSHOT"
+    }
+  }
+}

--- a/integration/update/app_basic/metadata.yaml
+++ b/integration/update/app_basic/metadata.yaml
@@ -1,0 +1,3 @@
+args: []
+
+skip_cleanup: false

--- a/pkg/specs/chart.go
+++ b/pkg/specs/chart.go
@@ -152,6 +152,11 @@ func (r *Resolver) resolveMetadata(ctx context.Context, upstream, localPath stri
 		return nil, errors.Wrap(err, "resolve base metadata")
 	}
 
+	err = r.StateManager.SerializeContentSHA(baseMetadata.ContentSHA)
+	if err != nil {
+		return nil, errors.Wrap(err, "write content sha")
+	}
+
 	localChartPath := filepath.Join(localPath, "Chart.yaml")
 
 	exists, err := r.FS.Exists(localChartPath)
@@ -191,11 +196,6 @@ func (r *Resolver) ResolveBaseMetadata(upstream string, localPath string) (*api.
 		return nil, errors.Wrapf(err, "calculate chart sha")
 	}
 	md.ContentSHA = contentSHA
-
-	err = r.StateManager.SerializeContentSHA(contentSHA)
-	if err != nil {
-		return nil, errors.Wrap(err, "write content sha")
-	}
 
 	localReadmePath := filepath.Join(localPath, "README.md")
 	debug.Log("phase", "read-readme", "from", localReadmePath)
@@ -256,7 +256,7 @@ func (r *Resolver) maybeGetShipYAML(ctx context.Context, localPath string) (*api
 	return nil, nil
 }
 
-type shaSummer func(*Resolver, string) (string, error)
+type shaSummer func(r *Resolver, localPath string) (string, error)
 
 func (r *Resolver) calculateContentSHA(root string) (string, error) {
 	var contents []byte

--- a/pkg/test-mocks/replicatedapp/resolve_replicated_app.go
+++ b/pkg/test-mocks/replicatedapp/resolve_replicated_app.go
@@ -36,6 +36,19 @@ func (m *MockResolver) EXPECT() *MockResolverMockRecorder {
 	return m.recorder
 }
 
+// FetchRelease mocks base method
+func (m *MockResolver) FetchRelease(arg0 context.Context, arg1 *replicatedapp.Selector) (*replicatedapp.ShipRelease, error) {
+	ret := m.ctrl.Call(m, "FetchRelease", arg0, arg1)
+	ret0, _ := ret[0].(*replicatedapp.ShipRelease)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FetchRelease indicates an expected call of FetchRelease
+func (mr *MockResolverMockRecorder) FetchRelease(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchRelease", reflect.TypeOf((*MockResolver)(nil).FetchRelease), arg0, arg1)
+}
+
 // RegisterInstall mocks base method
 func (m *MockResolver) RegisterInstall(arg0 context.Context, arg1 replicatedapp.Selector, arg2 *api.Release) error {
 	ret := m.ctrl.Call(m, "RegisterInstall", arg0, arg1, arg2)


### PR DESCRIPTION
What I Did
------------

Update `ship watch` to read contentSHA for `replicated.app` applications. The full `ship watch && ship update` workflow should now work with replicated.app.

How I Did it
------------

- Create new non-destructive method on `specs.Resolver` for reading the content SHA without writing to state
- to do this, had to move the `SerializeContentSHA` call out of `ResolveBaseMetadata` and up a level, so we can use `ResolveBaseMetadata` for the above
- `ship watch` uses this `ReadContentSHAForWatch` method to get the SHA and compare to previous
- Add `FetchRelease` to the `replicatedapp.Resolver` interface, so we can pull the spec contents without mutating `state.json`.

How to verify it
------------

```
ship init 'replicated.app/...'
ship watch --interval 1m && ship update
```

while the watch is running, update release in console.replicated.com and
wait for the next watch interval.

Description for the Changelog
------------

The standard `ship watch && ship update` workflow is now compatible with `replicated.app` applications

Picture of a Boat (not required but encouraged)
------------

![](https://upload.wikimedia.org/wikipedia/commons/thumb/0/00/Shipwreck_%282760753988%29.jpg/1920px-Shipwreck_%282760753988%29.jpg)
By allen watkin from London, UK - Shipwreck, CC BY-SA 2.0, https://commons.wikimedia.org/w/index.php?curid=32039235
