### PR TITLE
Improve build time of make build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ ci-upload-coverage: .state/coverage.out .state/cc-test-reporter
 	./.state/cc-test-reporter format-coverage -o .state/codeclimate/codeclimate.json -t gocov .state/coverage.out
 	./.state/cc-test-reporter upload-coverage -i .state/codeclimate/codeclimate.json
 
-build: fmt embed-ui test bin/ship
+build: fmt embed-ui-dev test bin/ship
 
 build-ci: ci-embed-ui bin/ship
 
@@ -269,6 +269,7 @@ mark-ui-gitignored:
 
 embed-ui: mark-ui-gitignored build-ui pkg/lifeycle/daemon/ui.bindatafs.go
 
+embed-ui-dev: mark-ui-gitignored build-ui-dev pkg/lifeycle/daemon/ui.bindatafs.go
 
 ci-embed-ui: mark-ui-gitignored pkg/lifeycle/daemon/ui.bindatafs.go
 build-ui:

--- a/web/app/Makefile
+++ b/web/app/Makefile
@@ -8,37 +8,47 @@ $SRC = $(shell find . -path "./node_modules" -prune -o -path "./build" -prune -o
 	@mkdir -p .state
 	@touch .state/package
 
+.state/package-init: ../init/package.json ../init/yarn.lock
+	cd ../init && \
+		yarn --pure-lockfile && \
+		yarn build && \
+		yarn link
+		yarn link @replicatedhq/ship-init
+	@mkdir -p .state
+	@touch .state/package-init
+
+.state/package-init-dev: ../init/package.json ../init/yarn.lock
+	cd ../init && \
+		yarn --pure-lockfile && \
+		yarn build-dev && \
+		yarn link
+		yarn link @replicatedhq/ship-init
+	@mkdir -p .state
+	@touch .state/package-init-dev
+
 clean_build_artifacts:
 	rm -rf build
 	rm -rf dist
+	rm -rf ../init/dist
 
 clean: clean_build_artifacts
 	rm -rf node_modules
+	rm -rf ../init/node_modules
 	rm -rf .state
 
-deps: .state/package
-	cd ../init && \
-	yarn --pure-lockfile && \
-	yarn build && \
-	yarn link
-	yarn link @replicatedhq/ship-init
+deps: .state/package .state/package-init
 
-deps-dev: .state/package
-	cd ../init && \
-	yarn --pure-lockfile && \
-	yarn build-dev && \
-	yarn link
-	yarn link @replicatedhq/ship-init
+deps-dev: .state/package .state/package-init-dev
 
 serve_ship:
 	yarn start
 
-.state/build_ship: deps $(shell find src -type f) clean_build_artifacts
+.state/build_ship: deps $(shell find src -type f)
 	yarn build
 	@mkdir -p .state
 	@touch .state/build_ship
 
-.state/build_ship_dev: deps-dev clean_build_artifacts
+.state/build_ship_dev: deps-dev
 	yarn build
 	@mkdir -p .state
 	@touch .state/build_ship_dev


### PR DESCRIPTION
What I Did
------------
Update Makefile to more aggressively cache and avoid repeating tasks on second run

How I Did it
------------
Add additional state to avoid repeating setup tasks

How to verify it
------------
Run the following commands locally:
```
make clean
time make build
time make build
```
The second `time make build` command should be significantly faster than the first.

Description for the Changelog
------------
N/A


Picture of a Boat (not required but encouraged)
------------
⛵️ 











<!-- (thanks https://github.com/docker/docker for this template) -->

