### PR TITLE
Scope body, reset to ship-init class, scope all other css to #ship-init-component

### DIFF
--- a/web/init/package.json
+++ b/web/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replicatedhq/ship-init",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Shared component that contains the Ship Init app",
   "author": "Replicated, Inc.",
   "license": "Apache-2.0",

--- a/web/init/src/Ship.jsx
+++ b/web/init/src/Ship.jsx
@@ -6,16 +6,30 @@ import { configureStore } from "./redux";
 import PropTypes from "prop-types";
 
 import "./scss/index.scss";
+const bodyClass = "ship-init";
 
-export const Ship = ({ apiEndpoint }) => (
-  <div id="ship-init-component">
-    <Provider store={configureStore(apiEndpoint)}>
-      <AppWrapper>
-        <RouteDecider />
-      </AppWrapper>
-    </Provider>
-  </div>
-);
+export class Ship extends React.Component {
+  componentDidMount() {
+    document.body.classList.add(bodyClass);
+  }
+  componentWillUnmount() {
+    document.body.classList.remove(bodyClass);
+  }
+
+  render() {
+    const { apiEndpoint } = this.props;
+
+    return (
+      <div id="ship-init-component">
+        <Provider store={configureStore(apiEndpoint)}>
+          <AppWrapper>
+            <RouteDecider />
+          </AppWrapper>
+        </Provider>
+      </div>
+    )
+  }
+}
 
 Ship.propTypes = {
   apiEndpoint: PropTypes.string.isRequired,

--- a/web/init/src/scss/index.scss
+++ b/web/init/src/scss/index.scss
@@ -1,6 +1,9 @@
+@import "./utilities/reset.scss"; // Scoped to "ship-init"
+@import "./utilities/base.scss"; // Scoped to "ship-init"
+
 #ship-init-component {
-  @import "./utilities/reset.scss";
-  @import "./utilities/base.scss";
+  display: flex;
+  
   @import "./utilities/typography.scss";
   @import "./utilities/buttons.scss";
   @import "./utilities/colors.scss";

--- a/web/init/src/scss/utilities/base.scss
+++ b/web/init/src/scss/utilities/base.scss
@@ -1,14 +1,10 @@
 @import "../variables/variables.scss";
 
-body,
 html {
-  margin: 0;
-  padding: 0;
-  width: 100%;
-  height: 100%;
+  height: 100%
 }
 
-body {
+body.ship-init {
   font-family: $font-family;
   font-weight: 400;
   color: $font-color;
@@ -16,149 +12,154 @@ body {
   flex-direction: column;
   flex: 1;
   -webkit-font-smoothing: antialiased;
-}
-
-* { 
-  box-sizing: border-box;
-}
-
-a {
-  text-decoration: none;
-  outline: none;
-  font-weight: 500;
-  color: $link-color;
-
-  &:hover {
-    cursor: pointer;
-    text-decoration: underline;
-  }
-}
-
-.field-section-header {
-  font-size: 16px;
-  line-height: 20px;
-  font-weight: 600;
-}
-.field-section-sub-header {
-  font-size: 14px;
-  line-height: 18px;
-  font-weight: 500;
-}
-.field.hidden {
-  display: none;
-}
-.header-color {
-  color: $header-color;
-}
-.sub-header-color {
-  color: $sub-header-color;
-}
-
-#root {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-}
-
-.container {
-  padding: 0 20px;
-  margin: 0 auto;
+  margin: 0;
+  padding: 0;
   width: 100%;
-}
+  height: 100%;
 
-/* don't let that chrome autofill yellow ruin the aesthetic of your site */
-input:-webkit-autofill {
-  background-color: #ffffff;
-}
-
-.layout-footer-actions {
-  box-shadow: 0 -1px 3px rgba(0,0,0,0.16);
-  padding: 12px 30px 11px;
-  background-color: #ffffff;
-  z-index: 110;
-
-  &.less-padding {
-    padding: 12px 20px 11px;
+  * { 
+    box-sizing: border-box;
   }
-}
-
-.spinningLoaderPath {
-  fill: $loader-color
-}
-
-.AceEditor--wrapper {
-  position: relative;
-  box-sizing: border-box;
   
-  .error-highlight {
-    background:#FBEDEB;
-    position: absolute;
+  a {
+    text-decoration: none;
+    outline: none;
+    font-weight: 500;
+    color: $link-color;
+  
+    &:hover {
+      cursor: pointer;
+      text-decoration: underline;
+    }
   }
-
-  .disabled-ace-editor {
-    opacity: .5;
+  
+  .field-section-header {
+    font-size: 16px;
+    line-height: 20px;
+    font-weight: 600;
   }
-
-  .ace_search {
-    left: 0;
-    right: auto;
+  .field-section-sub-header {
+    font-size: 14px;
+    line-height: 18px;
+    font-weight: 500;
   }
-}
-
-/*
-Apply this class to any icon using main_spritesheet. From there
-all you need to do is supply a `width: [value]` `height: [value]`
-and `background-position: [value]`
-*/
-.icon {
-  background-image: url("../assets/images/main_spritesheet.svg");
-  background-repeat: no-repeat;
-  background-size: initial;
-  display: inline-block;
-  cursor: default;
-  position: relative;
-}
-.icon.clickable {
-  cursor: pointer;
-}
-
-/* Media Queries */
-
-/* ≥ 568px */
-@media screen and (min-width: 35.5em) {
-
-}
-
-/* ≥ 768px */
-@media screen and (min-width: 48em) {
+  .field.hidden {
+    display: none;
+  }
+  .header-color {
+    color: $header-color;
+  }
+  .sub-header-color {
+    color: $sub-header-color;
+  }
+  
+  #root {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+  }
+  
   .container {
-    padding: 0 30px;
+    padding: 0 20px;
+    margin: 0 auto;
+    width: 100%;
   }
-}
-
-/* ≥ 960px */
-@media screen and (min-width: 60em) {
-
-}
-
-/* ≥ 1024px */
-@media screen and (min-width: 64em) {
-
-}
-
-/* ≥ 1280px */
-@media screen and (min-width: 80em) {
   
-}
-
-.hidden {
-  display: none;
-}
-
-.actions-wrapper {
-  padding-top: 12px;
-  padding-bottom: 12px;
-  background: #fff;
-  border-top: solid 1px #DFDFDF;
-  z-index: 10;
+  /* don't let that chrome autofill yellow ruin the aesthetic of your site */
+  input:-webkit-autofill {
+    background-color: #ffffff;
+  }
+  
+  .layout-footer-actions {
+    box-shadow: 0 -1px 3px rgba(0,0,0,0.16);
+    padding: 12px 30px 11px;
+    background-color: #ffffff;
+    z-index: 110;
+  
+    &.less-padding {
+      padding: 12px 20px 11px;
+    }
+  }
+  
+  .spinningLoaderPath {
+    fill: $loader-color
+  }
+  
+  .AceEditor--wrapper {
+    position: relative;
+    box-sizing: border-box;
+    
+    .error-highlight {
+      background:#FBEDEB;
+      position: absolute;
+    }
+  
+    .disabled-ace-editor {
+      opacity: .5;
+    }
+  
+    .ace_search {
+      left: 0;
+      right: auto;
+    }
+  }
+  
+  /*
+  Apply this class to any icon using main_spritesheet. From there
+  all you need to do is supply a `width: [value]` `height: [value]`
+  and `background-position: [value]`
+  */
+  .icon {
+    background-image: url("../assets/images/main_spritesheet.svg");
+    background-repeat: no-repeat;
+    background-size: initial;
+    display: inline-block;
+    cursor: default;
+    position: relative;
+  }
+  .icon.clickable {
+    cursor: pointer;
+  }
+  
+  /* Media Queries */
+  
+  /* ≥ 568px */
+  @media screen and (min-width: 35.5em) {
+  
+  }
+  
+  /* ≥ 768px */
+  @media screen and (min-width: 48em) {
+    .container {
+      padding: 0 30px;
+    }
+  }
+  
+  /* ≥ 960px */
+  @media screen and (min-width: 60em) {
+  
+  }
+  
+  /* ≥ 1024px */
+  @media screen and (min-width: 64em) {
+  
+  }
+  
+  /* ≥ 1280px */
+  @media screen and (min-width: 80em) {
+    
+  }
+  
+  .hidden {
+    display: none;
+  }
+  
+  .actions-wrapper {
+    padding-top: 12px;
+    padding-bottom: 12px;
+    background: #fff;
+    border-top: solid 1px #DFDFDF;
+    z-index: 10;
+  }
+  
 }

--- a/web/init/src/scss/utilities/reset.scss
+++ b/web/init/src/scss/utilities/reset.scss
@@ -3,46 +3,44 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
-}
-/* HTML5 display-role reset for older browsers */
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
-}
-body {
-	line-height: 1;
-}
-ol, ul {
-	list-style: none;
-}
-blockquote, q {
-	quotes: none;
-}
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
-}
-table {
-	border-collapse: collapse;
-	border-spacing: 0;
+body.ship-init {
+	&, div, span, applet, object, iframe,
+	h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+	a, abbr, acronym, address, big, cite, code,
+	del, dfn, em, img, ins, kbd, q, s, samp,
+	small, strike, strong, sub, sup, tt, var,
+	b, u, i, center,
+	dl, dt, dd, ol, ul, li,
+	fieldset, form, label, legend,
+	table, caption, tbody, tfoot, thead, tr, th, td,
+	article, aside, canvas, details, embed,
+	figure, figcaption, footer, header, hgroup,
+	menu, nav, output, ruby, section, summary,
+	time, mark, audio, video {
+		margin: 0;
+		padding: 0;
+		border: 0;
+		vertical-align: baseline;
+	}
+
+	article, aside, details, figcaption, figure,
+	footer, header, hgroup, menu, nav, section {
+		display: block;
+	}
+
+	ol, ul {
+		list-style: none;
+	}
+	blockquote, q {
+		quotes: none;
+	}
+	blockquote:before, blockquote:after,
+	q:before, q:after {
+		content: '';
+		content: none;
+	}
+	table {
+		border-collapse: collapse;
+		border-spacing: 0;
+	}
 }


### PR DESCRIPTION
What I Did
------------
Added a `ship-init` class on mount to body tag to scope reset and base styles to ship-init app.

How I Did it
------------
Changed the Ship.jsx component to a class, added `componentDidMount` and `componentDidMount` lifecycle methods to handle class addition. Moved all reset and base styles underneath `body.ship-init` and scoped all component styles to `#ship-init-component`.


How to verify it
------------
Run the web app in dev mode

Description for the Changelog
------------
Namespaced ship-init UI CSS


Picture of a Boat (not required but encouraged)
------------
![Boat](https://media.giphy.com/media/5qVezULI35guQ/giphy.gif)











<!-- (thanks https://github.com/docker/docker for this template) -->

