### PR TITLE
Support for storing state in a secret in ship init

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -58,7 +58,7 @@ func RootCmd() *cobra.Command {
 	// TODO remove me, just always set this to true
 	cmd.PersistentFlags().BoolP("navcycle", "", true, "set to false to run ship in v1/non-navigable mode (deprecated)")
 
-	cmd.PersistentFlags().String("state-from", "", "type of resource to use when loading/saving state (currently supported values: 'file', 'secret'")
+	cmd.PersistentFlags().String("state-from", "file", "type of resource to use when loading/saving state (currently supported values: 'file', 'secret'")
 	cmd.PersistentFlags().String("state-file", "", fmt.Sprintf("path to the state file to read from, defaults to %s", constants.StatePath))
 	cmd.PersistentFlags().String("secret-namespace", "default", "namespace containing the state secret")
 	cmd.PersistentFlags().String("secret-name", "", "name of the secret to laod state from")

--- a/pkg/lifecycle/render/docker/step_test.go
+++ b/pkg/lifecycle/render/docker/step_test.go
@@ -32,19 +32,19 @@ func TestDockerStep(t *testing.T) {
 		Expect                  error
 	}{
 		{
-			name:                    "registry succeeds",
+			name: "registry succeeds",
 			RegistrySecretSaveError: nil,
 			InstallationIDSaveError: nil,
 			Expect:                  nil,
 		},
 		{
-			name:                    "registry fails, install id succeeds",
+			name: "registry fails, install id succeeds",
 			RegistrySecretSaveError: errors.New("noooope"),
 			InstallationIDSaveError: nil,
 			Expect:                  nil,
 		},
 		{
-			name:                    "registry fails, install id fails",
+			name: "registry fails, install id fails",
 			RegistrySecretSaveError: errors.New("noooope"),
 			InstallationIDSaveError: errors.New("nope nope nope"),
 			Expect:                  errors.New("docker save image, both auth methods failed: nope nope nope"),

--- a/pkg/ship/ship.go
+++ b/pkg/ship/ship.go
@@ -155,15 +155,17 @@ func (s *Ship) Execute(ctx context.Context) error {
 	}
 
 	// This is for integration tests to write the passed state.json to the correct path
-	stateFilePath := s.Viper.GetString("state-file")
-	if stateFilePath != "" {
-		debug.Log("phase", "move", "state-file", stateFilePath)
-		stateFile, err := s.FS.ReadFile(stateFilePath)
-		if err != nil {
-			return errors.Wrap(err, "read state-file")
-		}
-		if err := s.FS.WriteFile(constants.StatePath, stateFile, 0644); err != nil {
-			return errors.Wrap(err, "write passed state file to constants.StatePath")
+	if s.Viper.GetString("state-from") == "file" {
+		stateFilePath := s.Viper.GetString("state-file")
+		if stateFilePath != "" {
+			debug.Log("phase", "move", "state-file", stateFilePath)
+			stateFile, err := s.FS.ReadFile(stateFilePath)
+			if err != nil {
+				return errors.Wrap(err, "read state-file")
+			}
+			if err := s.FS.WriteFile(constants.StatePath, stateFile, 0644); err != nil {
+				return errors.Wrap(err, "write passed state file to constants.StatePath")
+			}
 		}
 	}
 

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -221,6 +222,11 @@ func (m *MManager) tryLoadFromSecret() (State, error) {
 	if !ok {
 		err := fmt.Errorf("key %q not found in secret %q", secretKey, secretName)
 		return nil, errors.Wrap(err, "get state from secret")
+	}
+
+	// An empty secret should be treated as empty state
+	if len(strings.TrimSpace(string(serialized))) == 0 {
+		return Empty{}, nil
 	}
 
 	// HACK -- try to deserialize it as VersionedState, otherwise, assume its a raw map of config values

--- a/pkg/util/warnings/warn.go
+++ b/pkg/util/warnings/warn.go
@@ -10,6 +10,8 @@ import (
 // to use "ship init" with a present state file on disk
 var WarnShouldUseUpdate = warning{msg: `To build on your progress, run "ship update"`}
 
+var WarnCannotRemoveState = warning{msg: `Existing state was found that Ship cannot automatically remove. Please delete the existing state and try again.`}
+
 // WarnShouldMoveDirectory is the message printed to the user when they attempt to run ship when files like `base` or
 // `overlays` are already present
 func WarnShouldMoveDirectory(dir string) error {


### PR DESCRIPTION
What I Did
------------
Add support for storing state in a secret in `ship init` (in cluster only)

How I Did it
------------
Used the same flags that are used in ship update. Allow the secret to exist with an empty key. Support checking the existence of this on ship init.

How to verify it
------------
ship init --state-from secret --secret-name something --secret-key state.json <chart>

Description for the Changelog
------------
Support for storing state in secret in ship init flow.


Picture of a Boat (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

