### PR TITLE
Homebrew formula

### DIFF
--- a/deploy/.goreleaser.unstable.yml
+++ b/deploy/.goreleaser.unstable.yml
@@ -3,6 +3,15 @@ release:
   github:
     owner: replicatedhq
     name: ship
+brew:
+  github:
+    owner: replicatedhq
+    name: homebrew-ship
+  folder: Formula
+  homepage: https://ship.replicated.com/
+  description: Deploy 3rd party applications through modern pipelines.
+  test: |
+    system "#{bin}/ship version"
 builds:
 - goos:
   - linux

--- a/deploy/.goreleaser.yml
+++ b/deploy/.goreleaser.yml
@@ -3,6 +3,15 @@ release:
   github:
     owner: replicatedhq
     name: ship
+brew:
+  github:
+    owner: replicatedhq
+    name: homebrew-ship
+  folder: Formula
+  homepage: https://ship.replicated.com/
+  description: Deploy 3rd party applications through modern pipelines.
+  test: |
+    system "#{bin}/ship version"
 builds:
 - goos:
   - linux


### PR DESCRIPTION
What I Did
------------

Added a goreleaser customization to deploy a homebrew formula

How I Did it
------------

Added a brew section to .goreleaser.yml and .goreleaser.unstable.yml

How to verify it
------------

```
goreleaser release --snapshot --config deploy/.goreleaser.unstable.yml
cat dist/ship.rb
```

I manually added the ship.rb generated with some modifications to https://github.com/replicatedhq/homebrew-ship

It remains to be seen if circleci has access to push to the homebrew-ship repo but i can play with this after merge.

You can now install ship with the following commands:

```
brew tap replicatedhq/ship
brew install ship
```

Description for the Changelog
------------

- Ship can now be installed on a mac using homebrew.

Picture of a Boat (not required but encouraged)
------------

![ship](https://cdn.beeradvocate.com/im/beers/74467.jpg)

<!-- (thanks https://github.com/docker/docker for this template) -->

