### PR TITLE
Properly bind getNavItems function to context

### DIFF
--- a/web/init/package.json
+++ b/web/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replicatedhq/ship-init",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Shared component that contains the Ship Init app",
   "author": "Replicated, Inc.",
   "license": "Apache-2.0",

--- a/web/init/src/components/shared/NavBar.jsx
+++ b/web/init/src/components/shared/NavBar.jsx
@@ -144,8 +144,7 @@ export class NavBar extends React.Component {
         : "",
     );
 
-    const itemsArr = [];
-    itemsArr.push(this.getNavItems);
+    const itemsArr = [this.getNavItems.bind(this)];
     // build items
     const headerItems = this.combineItems(itemsArr)
       .filter(item => item)


### PR DESCRIPTION
What I Did
------------
Properly bind `getNavItems` function in `NavBar` component to the component's context

How I Did it
------------
Add a `.bind(this)` to `getNavItems`

How to verify it
------------
Tests should continue to pass, this has been verified in an external app by me

Description for the Changelog
------------
- Properly bind getNavItems function to context


Picture of a Boat (not required but encouraged)
------------
⛵️ 











<!-- (thanks https://github.com/docker/docker for this template) -->

