### PR TITLE
Add flex:1 to #ship-init-component

### DIFF
--- a/web/init/src/scss/index.scss
+++ b/web/init/src/scss/index.scss
@@ -3,6 +3,7 @@
 
 #ship-init-component {
   display: flex;
+  flex: 1;
   
   @import "./utilities/typography.scss";
   @import "./utilities/buttons.scss";


### PR DESCRIPTION
What I Did
------------
Cypress tests were failing due to the height of the`#ship-init-component` div not being the height of the viewport. This caused the Cypress selectors targeting lines in the Ace Editor to fail.  I added a `flex: 1` CSS property to the `#ship-init-component` div to fix this.

How I Did it
------------
 I added a `flex: 1` CSS property to the `#ship-init-component` div in `index.scss`.

How to verify it
------------
Run the app, and then run the Cypress tests via `make cypress_base`.

Description for the Changelog
------------
Updated `index.scss`, made `#ship-init-component` span the height of the viewport.


Picture of a Boat (not required but encouraged)
------------
![Boat doggy](https://media.giphy.com/media/V7wIiq6FSPId2/source.gif)










<!-- (thanks https://github.com/docker/docker for this template) -->

