### PR TITLE
Fix incorrect publish of ship-init module

### DIFF
--- a/web/init/package.json
+++ b/web/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replicatedhq/ship-init",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Shared component that contains the Ship Init app",
   "author": "Replicated, Inc.",
   "license": "Apache-2.0",

--- a/web/init/yarn.lock
+++ b/web/init/yarn.lock
@@ -908,10 +908,6 @@ ansi-escapes@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
 
-ansi-regex@*:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
-
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -4037,7 +4033,7 @@ import-local@^1.0.0:
     pkg-dir "^2.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 


### PR DESCRIPTION
What I Did
------------
Bump version of `@replicatedhq/ship-init` to `v1.0.3` because `v1.0.2` build is broken
TODO: Unpublish 1.0.2

How I Did it
------------
Bump version of `@replicatedhq/ship-init` to `v1.0.3`

How to verify it
------------
It is published, build should pass

Description for the Changelog
------------
N/A


Picture of a Boat (not required but encouraged)
------------
:boat:











<!-- (thanks https://github.com/docker/docker for this template) -->

