### PR TITLE
reset lifecycle

### DIFF
--- a/pkg/ship/update.go
+++ b/pkg/ship/update.go
@@ -47,6 +47,11 @@ func (s *Ship) Update(ctx context.Context) error {
 	debug.Log("event", "fetch latest chart")
 	s.Daemon.SetProgress(daemontypes.StringProgress("kustomize", `Downloading latest from upstream `+upstreamURL))
 
+	debug.Log("event", "reset steps completed")
+	if err := s.StateManager.ResetLifecycle(); err != nil {
+		return errors.Wrap(err, "reset state.json completed lifecycle")
+	}
+
 	release, err := s.Resolver.ResolveRelease(ctx, upstreamURL)
 	if err != nil {
 		return errors.Wrapf(err, "resolve helm chart metadata for %s", upstreamURL)

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -35,6 +35,7 @@ type Manager interface {
 	SerializeShipMetadata(api.ShipAppMetadata) error
 	SerializeAppMetadata(api.ReleaseMetadata) error
 	Save(v VersionedState) error
+	ResetLifecycle() error
 }
 
 var _ Manager = &MManager{}
@@ -185,6 +186,20 @@ func (m *MManager) TryLoad() (State, error) {
 		err := fmt.Errorf("unsupported state-from value: %q", stateFrom)
 		return nil, errors.Wrap(err, "try load state")
 	}
+}
+
+func (m *MManager) ResetLifecycle() error {
+	debug := level.Debug(log.With(m.Logger, "method", "ResetLifecycle"))
+
+	debug.Log("event", "tryLoadState")
+	currentState, err := m.TryLoad()
+	if err != nil {
+		return errors.Wrap(err, "try load state")
+	}
+	versionedState := currentState.Versioned()
+	versionedState.V1.Lifecycle = &Lifeycle{StepsCompleted: nil}
+
+	return m.serializeAndWriteState(versionedState)
 }
 
 // tryLoadFromSecret will attempt to load the state from a secret

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -188,6 +188,8 @@ func (m *MManager) TryLoad() (State, error) {
 	}
 }
 
+// ResetLifecycle is used by `ship update --headed` to reset the saved stepsCompleted
+// in the state.json
 func (m *MManager) ResetLifecycle() error {
 	debug := level.Debug(log.With(m.Logger, "method", "ResetLifecycle"))
 
@@ -197,7 +199,7 @@ func (m *MManager) ResetLifecycle() error {
 		return errors.Wrap(err, "try load state")
 	}
 	versionedState := currentState.Versioned()
-	versionedState.V1.Lifecycle = &Lifeycle{StepsCompleted: nil}
+	versionedState.V1.Lifecycle = nil
 
 	return m.serializeAndWriteState(versionedState)
 }

--- a/pkg/state/manager_test.go
+++ b/pkg/state/manager_test.go
@@ -486,9 +486,7 @@ func TestMManager_ResetLifecycle(t *testing.T) {
 			},
 			expected: VersionedState{
 				V1: &V1{
-					Lifecycle: &Lifeycle{
-						StepsCompleted: nil,
-					},
+					Lifecycle: nil,
 				},
 			},
 		},

--- a/pkg/test-mocks/state/manager_mock.go
+++ b/pkg/test-mocks/state/manager_mock.go
@@ -47,6 +47,18 @@ func (mr *MockManagerMockRecorder) RemoveStateFile() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveStateFile", reflect.TypeOf((*MockManager)(nil).RemoveStateFile))
 }
 
+// ResetLifecycle mocks base method
+func (m *MockManager) ResetLifecycle() error {
+	ret := m.ctrl.Call(m, "ResetLifecycle")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ResetLifecycle indicates an expected call of ResetLifecycle
+func (mr *MockManagerMockRecorder) ResetLifecycle() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetLifecycle", reflect.TypeOf((*MockManager)(nil).ResetLifecycle))
+}
+
 // Save mocks base method
 func (m *MockManager) Save(arg0 state.VersionedState) error {
 	ret := m.ctrl.Call(m, "Save", arg0)


### PR DESCRIPTION
What I Did
------------
- Reset completed lifecycle steps when running `ship update --headed`

How I Did it
------------
- Add `ResetLifecycle` method to `Manager` interface, which resets the `lifecycle` key in state.json

How to verify it
------------
- Test
- Run `ship updated --headed` and attempt to navigate to a further step that requires another step

Description for the Changelog
------------
- Reset completed lifecycle steps when running `ship update --headed`


Picture of a Boat (not required but encouraged)
------------
🛶 











<!-- (thanks https://github.com/docker/docker for this template) -->

