### PR TITLE
Add basePath prop to Ship init component 

### DIFF
--- a/web/app/src/App.tsx
+++ b/web/app/src/App.tsx
@@ -4,7 +4,9 @@ import * as React from "react";
 
 class App extends React.Component {
   render() {
-    return <Ship apiEndpoint={process.env.REACT_APP_API_ENDPOINT} />;
+    return (
+      <Ship apiEndpoint={process.env.REACT_APP_API_ENDPOINT} basePath="/" />
+    );
   }
 }
 

--- a/web/init/package.json
+++ b/web/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replicatedhq/ship-init",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Shared component that contains the Ship Init app",
   "author": "Replicated, Inc.",
   "license": "Apache-2.0",

--- a/web/init/src/Ship.jsx
+++ b/web/init/src/Ship.jsx
@@ -9,6 +9,15 @@ import "./scss/index.scss";
 const bodyClass = "ship-init";
 
 export class Ship extends React.Component {
+  static propTypes = {
+    /** API endpoint for the Ship binary */
+    apiEndpoint: PropTypes.string.isRequired,
+    /**
+     * Base path name for the internal Ship Init component router
+     * */
+    basePath: PropTypes.string.isRequired,
+  }
+
   componentDidMount() {
     document.body.classList.add(bodyClass);
   }
@@ -17,20 +26,16 @@ export class Ship extends React.Component {
   }
 
   render() {
-    const { apiEndpoint } = this.props;
+    const { apiEndpoint, basePath } = this.props;
 
     return (
       <div id="ship-init-component">
         <Provider store={configureStore(apiEndpoint)}>
           <AppWrapper>
-            <RouteDecider />
+            <RouteDecider basePath={basePath} />
           </AppWrapper>
         </Provider>
       </div>
     )
   }
-}
-
-Ship.propTypes = {
-  apiEndpoint: PropTypes.string.isRequired,
 }

--- a/web/init/src/components/shared/DetermineComponentForRoute.jsx
+++ b/web/init/src/components/shared/DetermineComponentForRoute.jsx
@@ -74,13 +74,14 @@ export class DetermineComponentForRoute extends React.Component {
     const {
       actions: kustomizeIntroActions,
       routes,
+      apiEndpoint,
     } = this.props;
     this.handleAction(kustomizeIntroActions[0]);
 
     const kustomizeStepIndex = findIndex(routes, { phase: "kustomize" });
     const kustomizeStep = routes[kustomizeStepIndex];
     const stepAfterKustomize = routes[kustomizeStepIndex + 1];
-    const { actions: kustomizeActions } = await fetchContentForStep(kustomizeStep.id);
+    const { actions: kustomizeActions } = await fetchContentForStep(apiEndpoint, kustomizeStep.id);
     this.handleAction(kustomizeActions[0]);
 
     this.startPoll(kustomizeStep.id, () => this.gotoRoute(stepAfterKustomize));


### PR DESCRIPTION
What I Did
------------
Adds a `basePath` prop to the `Ship` component for customizing the base route of the internal router.

Bumps version of component to `v1.1.0` due to the addition of a prop.

How I Did it
------------
- Update router to accept a base path parameter for using the routing system external from the Ship binary
- Fix regression where skipping kustomize step would fail

How to verify it
------------
Our existing E2E test should continue to pass, since I have provided the `basePath` we use for the project (`/`).

Description for the Changelog
------------
- Add basePath prop to Ship init component 


Picture of a Boat (not required but encouraged)
------------
⛵️ 











<!-- (thanks https://github.com/docker/docker for this template) -->

