### PR TITLE
Address config screen error

### DIFF
--- a/web/init/src/components/config_render/ConfigCheckbox.jsx
+++ b/web/init/src/components/config_render/ConfigCheckbox.jsx
@@ -23,7 +23,7 @@ export default class ConfigCheckbox extends React.Component {
         <span className="u-marginTop--10 config-errblock" id={`${this.props.name}-errblock`}></span>
         <div className="flex-auto flex u-marginRight--20">
           <input
-            ref="checkbox"
+            ref={(checkbox) => this.checkbox = checkbox}
             type="checkbox"
             name={this.props.name}
             default={this.props.default}
@@ -37,9 +37,9 @@ export default class ConfigCheckbox extends React.Component {
           <div>
             <label htmlFor={this.props.name} className={`u-marginLeft--small header-color field-section-sub-header u-userSelect--none ${this.props.readonly ? "u-cursor--default" : "u-cursor--pointer"}`}>
               {this.props.title} {
-                this.props.required ? 
+                this.props.required ?
                   <span className="field-label required">Required</span> :
-                  this.props.recommended ? 
+                  this.props.recommended ?
                     <span className="field-label recommended">Recommended</span> :
                     null}
             </label>

--- a/web/init/src/components/config_render/ConfigFileInput.jsx
+++ b/web/init/src/components/config_render/ConfigFileInput.jsx
@@ -12,7 +12,6 @@ export default class ConfigFileInput extends React.Component {
   }
 
   handleOnChange(value, data) {
-    ReactDOM.findDOMNode(this.refs.file).value = "";
     if (this.props.handleChange) {
       if (this.props.multiple) {
         this.props.handleChange(this.props.name, data, value);
@@ -52,7 +51,7 @@ export default class ConfigFileInput extends React.Component {
           <div>
             <span>
               <FileInput
-                ref="file"
+                ref={(file) => this.file = file}
                 name={this.props.name}
                 readOnly={this.props.readonly}
                 disabled={this.props.readonly}

--- a/web/init/src/components/config_render/FileInput.jsx
+++ b/web/init/src/components/config_render/FileInput.jsx
@@ -63,7 +63,7 @@ export default class FileInput extends React.Component {
         <span className={`${this.props.readonly ? "readonly" : ""} ${this.props.disabled ? "disabled" : ""}`}>
           <p className="sub-header-color field-section-sub-header u-marginTop--small u-marginBottom--small">{label}</p>
           <input
-            ref="file"
+            ref={(file) => this.file = file}
             type="file"
             name={this.props.name}
             className="form-control"


### PR DESCRIPTION
What I Did
------------
- Fix ship ui from not showing config lifecycle step

How I Did it
------------
- Remove ref string literal assignment in favor of assignment function
- Remove a `findDOMNode`

How to verify it
------------
- Run `ship app` with the following runbook 
```
config:
  v1:
    - name: hi
      items:
         - name: hi-name
           title: hi-title
           help_text: hi-help
           type: file
           required: true

lifecycle:
  v1:
    - message:
       contents: "hi"
    - config: {}
    - message:
       contents: "hi"
```

Description for the Changelog
------------
- Fix ship ui from not showing config lifecycle step


Picture of a Boat (not required but encouraged)
------------
🛶 











<!-- (thanks https://github.com/docker/docker for this template) -->

