### PR TITLE
print help/usage on empty upstream

### DIFF
--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/replicatedhq/ship/pkg/ship"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -29,9 +30,12 @@ Upstream can be one of:
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := viper.GetViper()
-			if len(args) != 0 {
-				v.Set("target", args[0])
+			if len(args) == 0 {
+				cmd.Help()
+				return errors.New("Error: please supply an upstream")
 			}
+
+			v.Set("upstream", args[0])
 			s, err := ship.Get(v)
 			if err != nil {
 				return err

--- a/pkg/lifecycle/daemon/routes_navcycle_completestep_test.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_completestep_test.go
@@ -156,7 +156,7 @@ func TestV2CompleteStep(t *testing.T) {
 			POST: "/api/v1/navcycle/step/make-the-things",
 			// need to wait until the async task completes before we check all the expected mock calls,
 			// otherwise the state won't have been saved yet
-			WaitForCleanup: func() <-chan time.Time { return time.After(120 * time.Millisecond) },
+			WaitForCleanup: func() <-chan time.Time { return time.After(300 * time.Millisecond) },
 			OnExecute: func(d *NavcycleRoutes, step api.Step) error {
 				d.StepProgress.Store("make-the-things", daemontypes.StringProgress("unittest", "workin on it"))
 				time.Sleep(60 * time.Millisecond)

--- a/pkg/ship/kustomize.go
+++ b/pkg/ship/kustomize.go
@@ -65,7 +65,13 @@ func (s *Ship) Init(ctx context.Context) error {
 		}
 	}
 
-	release, err := s.Resolver.ResolveRelease(ctx, s.Viper.GetString("target"))
+	// we already check in the CMD, but no harm in being extra safe here
+	target := s.Viper.GetString("upstream")
+	if target == "" {
+		return errors.New("No upstream provided")
+	}
+
+	release, err := s.Resolver.ResolveRelease(ctx, target)
 	if err != nil {
 		return errors.Wrap(err, "resolve release")
 	}


### PR DESCRIPTION
What I Did
------------

Update `ship init` to print the command usage when upstream is absent.


How I Did it
------------

```
if len(args) == 0 {
    cmd.Help()
    return errors.New("Error: please supply an upstream")
}
```


How to verify it
------------

``` 
ship init 
```

Ensure help text gets printed, and exit code is nonzero

Description for the Changelog
------------

Update `ship init` to print the command usage when upstream is absent.

![](https://upload.wikimedia.org/wikipedia/commons/thumb/5/53/Fraser_Island_shipwreck_of_Maheno_%28ship_1905%29_IGP4364.jpg/1920px-Fraser_Island_shipwreck_of_Maheno_%28ship_1905%29_IGP4364.jpg)
By Alchemist-hp(talk) - Own work, FAL, https://commons.wikimedia.org/w/index.php?curid=20727181