### PR TITLE
Fix production init builds waiting for webpack dashboard port allocation

### DIFF
--- a/web/init/package.json
+++ b/web/init/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "webpack --config webpack.config.js",
     "build-dev": "npm run build -- --mode development",
-    "start": "webpack-dashboard -m -- npm run build-dev -- --colors --watch",
+    "start": "cross-env DASHBOARD=true webpack-dashboard -m -- npm run build-dev -- --colors --watch",
     "test": "node scripts/test.js --env=jsdom"
   },
   "dependencies": {

--- a/web/init/webpack.config.js
+++ b/web/init/webpack.config.js
@@ -57,5 +57,5 @@ module.exports = {
           },
       ]
     },
-    plugins: [new DashboardPlugin()]
+    plugins: process.env.DASHBOARD ? [new DashboardPlugin()] : []
   };


### PR DESCRIPTION
What I Did
------------
Disable Webpack Dashboard plugin in dev/prod commands that do not make use of it

How I Did it
------------
Remove webpack-dashboard plugin from commands not using it in Webpack

How to verify it
------------
Running `yarn build` in the init directory should properly exit locally.

Description for the Changelog
------------
N/A


Picture of a Boat (not required but encouraged)
------------
⛵️ 











<!-- (thanks https://github.com/docker/docker for this template) -->

