### PR TITLE
Fixed routing for external ship init flow, re-scoped CSS to #ship-ini…

### DIFF
--- a/web/app/src/App.tsx
+++ b/web/app/src/App.tsx
@@ -5,7 +5,11 @@ import * as React from "react";
 class App extends React.Component {
   render() {
     return (
-      <Ship apiEndpoint={process.env.REACT_APP_API_ENDPOINT} basePath="/" />
+      <Ship 
+        apiEndpoint={process.env.REACT_APP_API_ENDPOINT} 
+        basePath="" 
+        headerEnabled={true}
+      />
     );
   }
 }

--- a/web/app/src/App.tsx
+++ b/web/app/src/App.tsx
@@ -5,11 +5,7 @@ import * as React from "react";
 class App extends React.Component {
   render() {
     return (
-      <Ship 
-        apiEndpoint={process.env.REACT_APP_API_ENDPOINT} 
-        basePath="" 
-        headerEnabled={true}
-      />
+      <Ship apiEndpoint={process.env.REACT_APP_API_ENDPOINT} headerEnabled />
     );
   }
 }

--- a/web/init/package.json
+++ b/web/init/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "brace": "^0.11.1",
-    "history": "^4.7.2",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.11",
     "rc-progress": "^2.2.5",

--- a/web/init/package.json
+++ b/web/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replicatedhq/ship-init",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Shared component that contains the Ship Init app",
   "author": "Replicated, Inc.",
   "license": "Apache-2.0",
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "brace": "^0.11.1",
+    "history": "^4.7.2",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.11",
     "rc-progress": "^2.2.5",

--- a/web/init/src/Ship.jsx
+++ b/web/init/src/Ship.jsx
@@ -15,27 +15,33 @@ export class Ship extends React.Component {
     /**
      * Base path name for the internal Ship Init component router
      * */
-    basePath: PropTypes.string.isRequired,
-  }
-
-  componentDidMount() {
-    document.body.classList.add(bodyClass);
-  }
-  componentWillUnmount() {
-    document.body.classList.remove(bodyClass);
+    basePath: PropTypes.string,
+    /**
+     * Determines whether or not the Ship Init app will instantiate its own BrowserRouter
+     * */
+    headerEnabled: PropTypes.bool,
+    /**
+     * Parent history needed to sync ship routing with parent
+     * */
+    history: PropTypes.object
   }
 
   render() {
-    const { apiEndpoint, basePath } = this.props;
+    const { apiEndpoint, history = null, headerEnabled = false, basePath = "" } = this.props;
 
     return (
       <div id="ship-init-component">
         <Provider store={configureStore(apiEndpoint)}>
           <AppWrapper>
-            <RouteDecider basePath={basePath} />
+            <RouteDecider 
+              headerEnabled={headerEnabled}
+              basePath={basePath}
+              history={history}
+            />
           </AppWrapper>
         </Provider>
       </div>
     )
   }
 }
+

--- a/web/init/src/Ship.jsx
+++ b/web/init/src/Ship.jsx
@@ -25,9 +25,14 @@ export class Ship extends React.Component {
      * */
     history: PropTypes.object
   }
+  static defaultProps = {
+    basePath: "",
+    history: null,
+    headerEnabled: false
+  }
 
   render() {
-    const { apiEndpoint, history = null, headerEnabled = false, basePath = "" } = this.props;
+    const { apiEndpoint, history, headerEnabled, basePath } = this.props;
 
     return (
       <div id="ship-init-component">
@@ -44,4 +49,3 @@ export class Ship extends React.Component {
     )
   }
 }
-

--- a/web/init/src/components/shared/DetermineComponentForRoute.jsx
+++ b/web/init/src/components/shared/DetermineComponentForRoute.jsx
@@ -43,6 +43,7 @@ export class DetermineComponentForRoute extends React.Component {
 
   gotoRoute = (route) => {
     let nextRoute = route;
+    const { basePath } = this.props;
 
     if (!nextRoute) {
       const currRoute = find(this.props.routes, ["id", this.props.routeId]);
@@ -53,10 +54,12 @@ export class DetermineComponentForRoute extends React.Component {
     if (!nextRoute) {
       return this.handleShutdown();
     }
-    this.props.history.push(`/${nextRoute.id}`);
+    this.props.history.push(`${basePath}/${nextRoute.id}`);
+
   }
 
   handleShutdown = async () => {
+    const { basePath } = this.props;
     const url = `${this.props.apiEndpoint}/shutdown`;
     await fetch(url, {
       method: "POST",
@@ -65,7 +68,7 @@ export class DetermineComponentForRoute extends React.Component {
       },
     });
     await this.props.shutdownApp();
-    this.props.history.push("/done");
+    this.props.history.push(`${basePath}/done`);
   }
 
   skipKustomize = async () => {

--- a/web/init/src/components/shared/NavBar.jsx
+++ b/web/init/src/components/shared/NavBar.jsx
@@ -31,7 +31,8 @@ export class NavBar extends React.Component {
         [`${dropdownKey}Active`]: false
       });
     }
-    this.props.history.push(route);
+    const { basePath } = this.props;
+    this.props.history.push(`${basePath}/${route}`);
   }
 
   handleLogOut = (e) => {

--- a/web/init/src/components/shared/RouteDecider.jsx
+++ b/web/init/src/components/shared/RouteDecider.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { BrowserRouter, Route, Switch } from "react-router-dom";
+import { BrowserRouter, Router, Route, Switch } from "react-router-dom";
 import isEmpty from "lodash/isEmpty";
 import NavBar from "../../containers/Navbar";
 
@@ -10,13 +10,47 @@ import DetermineComponentForRoute from "../../containers/DetermineComponentForRo
 import StepDone from "./StepDone";
 
 const isRootPath = (basePath) => {
-  const formattedBasePath = basePath === "/" ? basePath : basePath.replace(/\/$/, "");
+  const formattedBasePath = basePath === "" ? "/" : basePath.replace(/\/$/, "");
   return window.location.pathname === formattedBasePath
 }
 
+const ShipRoutesWrapper = ({ routes, headerEnabled, basePath }) => (
+  <div className="flex-column flex1">
+    <div className="flex-column flex1 u-overflow--hidden u-position--relative">
+      {!routes ?
+        <div className="flex1 flex-column justifyContent--center alignItems--center">
+          <Loader size="60" />
+        </div>
+        :
+        <div className="u-minHeight--full u-minWidth--full flex-column flex1">
+          {headerEnabled && <NavBar hideLinks={true} routes={routes} basePath={basePath} />}
+          <StepNumbers basePath={basePath} steps={routes} />
+          <div className="flex-1-auto flex-column u-overflow--auto">
+            <Switch>
+              {routes && routes.map((route) => (
+                <Route
+                  exact
+                  key={route.id}
+                  path={`${basePath}/${route.id}`}
+                  render={() => <DetermineComponentForRoute
+                    basePath={basePath}
+                    routes={routes} 
+                    routeId={route.id} 
+                  />}
+                />
+              ))}
+              <Route exact path="/" component={() => <div className="flex1 flex-column justifyContent--center alignItems--center"><Loader size="60" /></div> } />
+              <Route exact path="/done" component={() =>  <StepDone />} />
+            </Switch>
+          </div>
+        </div>
+      }
+    </div>
+  </div>
+)
+
 export default class RouteDecider extends React.Component {
   static propTypes = {
-    basePath: PropTypes.string.isRequired,
     isDone: PropTypes.bool.isRequired,
     routes: PropTypes.arrayOf(
       PropTypes.shape({
@@ -29,9 +63,9 @@ export default class RouteDecider extends React.Component {
 
   componentDidUpdate(lastProps) {
     const {
-      basePath,
       routes,
       getHelmChartMetadata,
+      basePath
     } = this.props
     if (routes !== lastProps.routes && routes.length) {
       for (let i = 0; i < routes.length; i++) {
@@ -40,9 +74,8 @@ export default class RouteDecider extends React.Component {
           break;
         }
       }
-
       if (isRootPath(basePath)) {
-        window.location.replace(`${basePath}${routes[0].id}`);
+        window.location.replace(`${basePath}/${routes[0].id}`);
       }
     }
   }
@@ -55,44 +88,31 @@ export default class RouteDecider extends React.Component {
 
   render() {
     const {
-      basePath,
       routes,
-      isDone
+      isDone,
+      basePath,
+      history,
+      headerEnabled,
     } = this.props;
-    const isOnRoot = isRootPath(basePath)
-
+    const routeProps = {
+      routes,
+      basePath,
+      headerEnabled
+    }
     return (
       <div className="u-minHeight--full u-minWidth--full flex-column flex1">
-        <BrowserRouter basename={basePath}>
-          <div className="flex-column flex1">
-            <div className="flex-column flex1 u-overflow--hidden u-position--relative">
-              {!routes ?
-                <div className="flex1 flex-column justifyContent--center alignItems--center">
-                  <Loader size="60" />
-                </div>
-                :
-                <div className="u-minHeight--full u-minWidth--full flex-column flex1">
-                  {isOnRoot ? null : <NavBar hideLinks={true} routes={routes} />}
-                  {isOnRoot || isDone ? null : <StepNumbers steps={routes} />}
-                  <div className="flex-1-auto flex-column u-overflow--auto">
-                    <Switch>
-                      {routes && routes.map((route) => (
-                        <Route
-                          exact
-                          key={route.id}
-                          path={`/${route.id}`}
-                          render={() => <DetermineComponentForRoute routes={routes} routeId={route.id} />}
-                        />
-                      ))}
-                      <Route exact path="/" component={() => <div className="flex1 flex-column justifyContent--center alignItems--center"><Loader size="60" /></div> } />
-                      <Route exact path="/done" component={() =>  <StepDone />} />
-                    </Switch>
-                  </div>
-                </div>
-              }
-            </div>
-          </div>
-        </BrowserRouter>
+        { history ? 
+          <Router history={history}>
+            <ShipRoutesWrapper 
+              {...routeProps}
+            />
+          </Router> :
+          <BrowserRouter basename={basePath}>
+            <ShipRoutesWrapper 
+              {...routeProps}
+            />
+          </BrowserRouter>
+        }
       </div>
     );
   }

--- a/web/init/src/components/shared/StepNumbers.jsx
+++ b/web/init/src/components/shared/StepNumbers.jsx
@@ -31,7 +31,7 @@ class StepNumbers extends React.Component {
   setStepsToState = () => {
     const { steps } = this.props;
     const stateSteps = steps.map((step) => {
-      const cleanedPath = this.props.location.pathname.split("/")[1];
+      const cleanedPath = this.props.location.pathname.split("/").pop();
       const newStep = {
         ...step,
         isComplete: false,
@@ -61,8 +61,9 @@ class StepNumbers extends React.Component {
   }
 
   goToStep = (idx) => {
+    const { basePath } = this.props;
     const step = this.state.steps[idx];
-    this.props.history.push(`/${step.id}`);
+    this.props.history.push(`${basePath}/${step.id}`);
   }
 
   componentDidUpdate(lastProps, lastState) {

--- a/web/init/src/scss/index.scss
+++ b/web/init/src/scss/index.scss
@@ -4,7 +4,8 @@
 #ship-init-component {
   display: flex;
   flex: 1;
-  
+
+  @import "./utilities/ship-init-base.scss";
   @import "./utilities/typography.scss";
   @import "./utilities/buttons.scss";
   @import "./utilities/colors.scss";

--- a/web/init/src/scss/utilities/base.scss
+++ b/web/init/src/scss/utilities/base.scss
@@ -4,7 +4,7 @@ html {
   height: 100%
 }
 
-body.ship-init {
+body {
   font-family: $font-family;
   font-weight: 400;
   color: $font-color;
@@ -15,151 +15,15 @@ body.ship-init {
   margin: 0;
   padding: 0;
   width: 100%;
-  height: 100%;
+  height: 100%;  
+}
 
-  * { 
-    box-sizing: border-box;
-  }
-  
-  a {
-    text-decoration: none;
-    outline: none;
-    font-weight: 500;
-    color: $link-color;
-  
-    &:hover {
-      cursor: pointer;
-      text-decoration: underline;
-    }
-  }
-  
-  .field-section-header {
-    font-size: 16px;
-    line-height: 20px;
-    font-weight: 600;
-  }
-  .field-section-sub-header {
-    font-size: 14px;
-    line-height: 18px;
-    font-weight: 500;
-  }
-  .field.hidden {
-    display: none;
-  }
-  .header-color {
-    color: $header-color;
-  }
-  .sub-header-color {
-    color: $sub-header-color;
-  }
-  
-  #root {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-  }
-  
-  .container {
-    padding: 0 20px;
-    margin: 0 auto;
-    width: 100%;
-  }
-  
-  /* don't let that chrome autofill yellow ruin the aesthetic of your site */
-  input:-webkit-autofill {
-    background-color: #ffffff;
-  }
-  
-  .layout-footer-actions {
-    box-shadow: 0 -1px 3px rgba(0,0,0,0.16);
-    padding: 12px 30px 11px;
-    background-color: #ffffff;
-    z-index: 110;
-  
-    &.less-padding {
-      padding: 12px 20px 11px;
-    }
-  }
-  
-  .spinningLoaderPath {
-    fill: $loader-color
-  }
-  
-  .AceEditor--wrapper {
-    position: relative;
-    box-sizing: border-box;
-    
-    .error-highlight {
-      background:#FBEDEB;
-      position: absolute;
-    }
-  
-    .disabled-ace-editor {
-      opacity: .5;
-    }
-  
-    .ace_search {
-      left: 0;
-      right: auto;
-    }
-  }
-  
-  /*
-  Apply this class to any icon using main_spritesheet. From there
-  all you need to do is supply a `width: [value]` `height: [value]`
-  and `background-position: [value]`
-  */
-  .icon {
-    background-image: url("../assets/images/main_spritesheet.svg");
-    background-repeat: no-repeat;
-    background-size: initial;
-    display: inline-block;
-    cursor: default;
-    position: relative;
-  }
-  .icon.clickable {
-    cursor: pointer;
-  }
-  
-  /* Media Queries */
-  
-  /* ≥ 568px */
-  @media screen and (min-width: 35.5em) {
-  
-  }
-  
-  /* ≥ 768px */
-  @media screen and (min-width: 48em) {
-    .container {
-      padding: 0 30px;
-    }
-  }
-  
-  /* ≥ 960px */
-  @media screen and (min-width: 60em) {
-  
-  }
-  
-  /* ≥ 1024px */
-  @media screen and (min-width: 64em) {
-  
-  }
-  
-  /* ≥ 1280px */
-  @media screen and (min-width: 80em) {
-    
-  }
-  
-  .hidden {
-    display: none;
-  }
-  
-  .actions-wrapper {
-    padding-top: 12px;
-    padding-bottom: 12px;
-    background: #fff;
-    border-top: solid 1px #DFDFDF;
-    z-index: 10;
-  }
-  
+* { 
+  box-sizing: border-box;
+}
+
+#root {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
 }

--- a/web/init/src/scss/utilities/reset.scss
+++ b/web/init/src/scss/utilities/reset.scss
@@ -3,7 +3,7 @@
    License: none (public domain)
 */
 
-body.ship-init {
+body {
 	&, div, span, applet, object, iframe,
 	h1, h2, h3, h4, h5, h6, p, blockquote, pre,
 	a, abbr, acronym, address, big, cite, code,

--- a/web/init/src/scss/utilities/ship-init-base.scss
+++ b/web/init/src/scss/utilities/ship-init-base.scss
@@ -1,0 +1,109 @@
+.icon {
+  background-image: url("../assets/images/main_spritesheet.svg");
+  background-repeat: no-repeat;
+  background-size: initial;
+  display: inline-block;
+  cursor: default;
+  position: relative;
+}
+.icon.clickable {
+  cursor: pointer;
+}
+
+.hidden {
+  display: none;
+}
+
+.actions-wrapper {
+  padding-top: 12px;
+  padding-bottom: 12px;
+  background: #fff;
+  border-top: solid 1px #DFDFDF;
+  z-index: 10;
+}
+
+a {
+  text-decoration: none;
+  outline: none;
+  font-weight: 500;
+  color: $link-color;
+
+  &:hover {
+    cursor: pointer;
+    text-decoration: underline;
+  }
+}
+
+.field-section-header {
+  font-size: 16px;
+  line-height: 20px;
+  font-weight: 600;
+}
+.field-section-sub-header {
+  font-size: 14px;
+  line-height: 18px;
+  font-weight: 500;
+}
+.field.hidden {
+  display: none;
+}
+.header-color {
+  color: $header-color;
+}
+.sub-header-color {
+  color: $sub-header-color;
+}
+
+.container {
+  padding-right: 20px;
+  padding-left: 20px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+/* don't let that chrome autofill yellow ruin the aesthetic of your site */
+input:-webkit-autofill {
+  background-color: #ffffff;
+}
+
+.layout-footer-actions {
+  box-shadow: 0 -1px 3px rgba(0,0,0,0.16);
+  padding: 12px 30px 11px;
+  background-color: #ffffff;
+  z-index: 110;
+
+  &.less-padding {
+    padding: 12px 20px 11px;
+  }
+}
+
+.spinningLoaderPath {
+  fill: $loader-color
+}
+
+.AceEditor--wrapper {
+  position: relative;
+  box-sizing: border-box;
+  
+  .error-highlight {
+    background:#FBEDEB;
+    position: absolute;
+  }
+
+  .disabled-ace-editor {
+    opacity: .5;
+  }
+
+  .ace_search {
+    left: 0;
+    right: auto;
+  }
+}
+
+/* ≥ 768px */
+@media screen and (min-width: 48em) {
+  .container {
+    padding-right: 30px;
+    padding-left: 30px;
+  }
+}


### PR DESCRIPTION
…t-component

What I Did
------------
The ship init UI routing wasn't working in Ship Cloud UI because its own internal router was hijacking the browser. Made it so that Ship Init inherits the history prop from its parent component, or if a prop isn't provided--uses <BrowserRouter> instead. Also made some more scoping changes to our global CSS.

How I Did it
------------
Added `history` and `headerEnabled` props to the `Ship.jsx` component, which enable router inheritance and the header (with logo, etc). Also updated `RouteDecider.jsx` to switch between <Router> and <BrowserRouter> depending on if `history` is present. Stripped down `base.scss` to only include body and html global styles, the rest have been scoped to `#ship-init-component`.

How to verify it
------------
Run `yarn start` in the `init` folder, and `yarn start` in the `app` folder. Go through the flow normally.

Description for the Changelog
------------
Updated Ship Init routing to handle inherited router history, re-scoped global styles.


Picture of a Boat (not required but encouraged)
------------
⛵️ 











<!-- (thanks https://github.com/docker/docker for this template) -->

