### PR TITLE
Externalize monaco-editor dependency in Ship Init component

### DIFF
--- a/web/app/package.json
+++ b/web/app/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@replicatedhq/react-scripts": "1.0.0",
     "@replicatedhq/ship-init": "link:../init",
+    "monaco-editor": "^0.14.3",
     "react": "^16.5.0",
     "react-dom": "^16.5.0"
   },

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@replicatedhq/react-scripts": "1.0.0",
+    "@replicatedhq/react-scripts": "1.0.1",
     "@replicatedhq/ship-init": "link:../init",
     "monaco-editor": "^0.14.3",
     "react": "^16.5.0",

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -104,9 +104,9 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@replicatedhq/react-scripts@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@replicatedhq/react-scripts/-/react-scripts-1.0.0.tgz#760aeabf8bfa82a3c794cdf5fab970cd7ea13e72"
+"@replicatedhq/react-scripts@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@replicatedhq/react-scripts/-/react-scripts-1.0.1.tgz#341da1aeb765b6c7f7ccd42eb276917df34637d4"
   dependencies:
     autoprefixer "7.1.6"
     babel-jest "20.0.3"

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -5391,9 +5391,9 @@ monaco-editor-webpack-plugin@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-1.5.2.tgz#e113fa1d5759ede6fd776eb620cdd5930203b55a"
 
-monaco-editor@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.13.1.tgz#6b9ce20e4d1c945042d256825eb133cb23315a52"
+monaco-editor@^0.14.2, monaco-editor@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.14.3.tgz#7cc4a4096a3821f52fea9b10489b527ef3034e22"
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -6629,13 +6629,13 @@ react-modal@^3.5.1:
     react-lifecycles-compat "^3.0.0"
     warning "^3.0.0"
 
-react-monaco-editor@^0.17.2:
-  version "0.17.2"
-  resolved "https://registry.yarnpkg.com/react-monaco-editor/-/react-monaco-editor-0.17.2.tgz#6c85d291487f992a62ad71801d50a9339f43972e"
+react-monaco-editor@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/react-monaco-editor/-/react-monaco-editor-0.18.0.tgz#098d847733667905aee80a0cd2473e80ab7b1302"
   dependencies:
     "@types/react" "*"
-    monaco-editor "^0.13.1"
-    prop-types "^15.6.1"
+    monaco-editor "^0.14.2"
+    prop-types "^15.6.2"
 
 react-redux@^5.0.7:
   version "5.0.7"

--- a/web/init/README.md
+++ b/web/init/README.md
@@ -6,7 +6,7 @@
 ## Install
 
 ```bash
-yarn add @replicatedhq/ship-init
+yarn add @replicatedhq/ship-init monaco-editor
 ```
 
 ## Usage

--- a/web/init/package.json
+++ b/web/init/package.json
@@ -20,7 +20,7 @@
     "react-ace": "^6.1.4",
     "react-document-title": "^2.0.3",
     "react-modal": "^3.5.1",
-    "react-monaco-editor": "^0.17.2",
+    "react-monaco-editor": "^0.18.0",
     "react-redux": "^5.0.7",
     "react-remarkable": "^1.1.3",
     "react-router-dom": "^4.2.2",
@@ -33,6 +33,7 @@
     "yaml-ast-parser": "^0.0.41"
   },
   "peerDependencies": {
+    "monaco-editor": "^0.14.3",
     "prop-types": "^15.5.4",
     "react": "^15.0.0 || ^16.0.0",
     "react-dom": "^15.0.0 || ^16.0.0"

--- a/web/init/package.json
+++ b/web/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replicatedhq/ship-init",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Shared component that contains the Ship Init app",
   "author": "Replicated, Inc.",
   "license": "Apache-2.0",

--- a/web/init/package.json
+++ b/web/init/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "webpack --config webpack.config.js",
     "build-dev": "npm run build -- --mode development",
-    "start": "webpack-dashboard -m -- npm run build-dev -- --colors --watch",
+    "start": "cross-env DASHBOARD=true webpack-dashboard -m -- npm run build-dev -- --colors --watch",
     "test": "node scripts/test.js --env=jsdom"
   },
   "dependencies": {

--- a/web/init/webpack.config.js
+++ b/web/init/webpack.config.js
@@ -19,6 +19,7 @@ module.exports = {
     externals: {
       react: "react",
       "react-dom": "react-dom",
+      "monaco-editor": "monaco-editor",
     },
     node: {
         fs: "empty",

--- a/web/init/webpack.config.js
+++ b/web/init/webpack.config.js
@@ -57,5 +57,5 @@ module.exports = {
           },
       ]
     },
-    plugins: [new DashboardPlugin()]
+    plugins: process.env.DASHBOARD ? [new DashboardPlugin()] : []
   };

--- a/web/init/yarn.lock
+++ b/web/init/yarn.lock
@@ -5477,9 +5477,9 @@ mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkd
   dependencies:
     minimist "0.0.8"
 
-monaco-editor@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.13.1.tgz#6b9ce20e4d1c945042d256825eb133cb23315a52"
+monaco-editor@^0.14.2:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.14.3.tgz#7cc4a4096a3821f52fea9b10489b527ef3034e22"
 
 moo@^0.4.3:
   version "0.4.3"
@@ -6633,13 +6633,13 @@ react-modal@^3.5.1:
     react-lifecycles-compat "^3.0.0"
     warning "^3.0.0"
 
-react-monaco-editor@^0.17.2:
-  version "0.17.2"
-  resolved "https://registry.yarnpkg.com/react-monaco-editor/-/react-monaco-editor-0.17.2.tgz#6c85d291487f992a62ad71801d50a9339f43972e"
+react-monaco-editor@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/react-monaco-editor/-/react-monaco-editor-0.18.0.tgz#098d847733667905aee80a0cd2473e80ab7b1302"
   dependencies:
     "@types/react" "*"
-    monaco-editor "^0.13.1"
-    prop-types "^15.6.1"
+    monaco-editor "^0.14.2"
+    prop-types "^15.6.2"
 
 react-redux@^5.0.7:
   version "5.0.7"


### PR DESCRIPTION
What I Did
------------
Change `monaco-editor` to be a peer dependency and make necessary changes to the Ship binary app for compatibility.

How I Did it
------------
- Set monaco-editor as an external in the Init component Webpack config
- Make monaco-editor a peer dependency
- Update react-scripts to latest to fix Monaco Webpack plugin issue

How to verify it
------------
E2E test should continue to pass, this has been verified externally as well.

Description for the Changelog
------------
- Externalize monaco-editor dependency in Ship Init component


Picture of a Boat (not required but encouraged)
------------
⛵️ 











<!-- (thanks https://github.com/docker/docker for this template) -->

