### PR TITLE
Improve developer experience/documentation of Ship init component

### DIFF
--- a/web/init/README.md
+++ b/web/init/README.md
@@ -11,6 +11,7 @@ yarn add @replicatedhq/ship-init monaco-editor
 
 ## Usage
 
+For documentation on props, see [props.md](props.md). Below is a minimal example:
 ```tsx
 import * as React from 'react'
 
@@ -19,10 +20,7 @@ import { Ship } from "@replicatedhq/ship-init";
 class App extends React.Component {
   render() {
     return (
-      <Ship
-        apiEndpoint="https://my-awesome-ship-api.com/api/v1"
-        basePath="/"
-      />;
+      <Ship apiEndpoint="https://my-awesome-ship-api.com/api/v1" />;
     );
   }
 }
@@ -33,8 +31,37 @@ To build in development mode and watch for changes, run the following command:
 ```
 yarn start
 ```
-Development mode uses [`webpack-dashboard`](https://github.com/FormidableLabs/webpack-dashboard) for more human-readable output.
 
+Dashboard mode mode uses [`webpack-dashboard`](https://github.com/FormidableLabs/webpack-dashboard) for more human-readable output.
+To run that mode, run the following command:
+```
+yarn dashboard
+```
+
+### Developing Ship Init in another project
+If you want to make changes to the component from another project, you can use `yarn link` to do this.
+```sh
+# from init folder
+yarn link
+```
+
+You will get a message like this:
+```
+success Registered "@replicatedhq/ship-init".
+info You can now run `yarn link "@replicatedhq/ship-init"` in the projects where you want to use this package and it will be used instead.
+```
+
+In the project you would like to link, run the command above and run a watching command like `yarn start` for the changes to carry across to the project specified.
+
+### Props Documentation
+As stated above, you can view the docs for the props on `<Ship />` [here](props.md).
+
+If you have added new props or updated documentation, run the following command to generate up-to-date markdown docs:
+```sh
+yarn gen-prop-docs
+```
+
+## Building
 To build the project without watching:
 - Development build (no minification, warnings off):
   ```

--- a/web/init/package.json
+++ b/web/init/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "webpack --config webpack.config.js",
     "build-dev": "npm run build -- --mode development",
-    "start": "cross-env DASHBOARD=true webpack-dashboard -m -- npm run build-dev -- --colors --watch",
+    "start": "npm run build-dev -- --colors --watch",
+    "dashboard": "cross-env DASHBOARD=true webpack-dashboard -m -- npm run start",
     "test": "node scripts/test.js --env=jsdom"
   },
   "dependencies": {

--- a/web/init/package.json
+++ b/web/init/package.json
@@ -11,6 +11,7 @@
     "build-dev": "npm run build -- --mode development",
     "start": "npm run build-dev -- --colors --watch",
     "dashboard": "cross-env DASHBOARD=true webpack-dashboard -m -- npm run start",
+    "gen-prop-docs": "rmd Ship src/Ship.jsx props.md",
     "test": "node scripts/test.js --env=jsdom"
   },
   "dependencies": {
@@ -73,6 +74,7 @@
     "publish": "^0.6.0",
     "react": "^16.5.1",
     "react-dom": "^16.5.1",
+    "react-markdown-gen": "^0.0.11",
     "redux-mock-store": "^1.5.3",
     "sass-loader": "^7.1.0",
     "source-map-support": "^0.5.9",

--- a/web/init/props.md
+++ b/web/init/props.md
@@ -1,0 +1,12 @@
+Ship
+====
+
+
+Props
+-----
+Prop                  | Type     | Default                   | Required | Description
+--------------------- | -------- | ------------------------- | -------- | -----------
+apiEndpoint|string||Yes|API endpoint for the Ship binary
+basePath|string|""|No|Base path name for the internal Ship Init component router<br>Note: If basePath is omitted, it will default the base route to "/"
+headerEnabled|bool|false|No|Determines whether default header is displayed
+history|object|null|No|Parent history needed to sync Ship routing with parent<br>Note: Defaults to instantiate own internal BrowserRouter if omitted.

--- a/web/init/src/Ship.jsx
+++ b/web/init/src/Ship.jsx
@@ -11,17 +11,11 @@ export class Ship extends React.Component {
   static propTypes = {
     /** API endpoint for the Ship binary */
     apiEndpoint: PropTypes.string.isRequired,
-    /**
-     * Base path name for the internal Ship Init component router
-     * */
+    /** Base path name for the internal Ship Init component router<br>Note: If basePath is omitted, it will default the base route to "/" */
     basePath: PropTypes.string,
-    /**
-     * Determines whether or not the Ship Init app will instantiate its own BrowserRouter
-     * */
+    /** Determines whether default header is displayed */
     headerEnabled: PropTypes.bool,
-    /**
-     * Parent history needed to sync ship routing with parent
-     * */
+    /** Parent history needed to sync Ship routing with parent<br>Note: Defaults to instantiate own internal BrowserRouter if omitted. */
     history: PropTypes.object
   }
 

--- a/web/init/webpack.config.js
+++ b/web/init/webpack.config.js
@@ -26,9 +26,6 @@ module.exports = {
         module: "empty"
     },
     module: {
-      // TODO: Monaco causes this error to show up,
-      //       possibly remove at some point
-      exprContextCritical: false,
       rules: [
         {
           test: /\.jsx?$/,

--- a/web/init/yarn.lock
+++ b/web/init/yarn.lock
@@ -1086,6 +1086,10 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
 
+ast-types@0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.10.1.tgz#f52fca9715579a14f841d67d7f8d25432ab6a3dd"
+
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
@@ -1749,7 +1753,7 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@6.x, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
+babel-runtime@6.x, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.9.2:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -1792,6 +1796,10 @@ babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.
 babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
+
+babylon@~5.8.3:
+  version "5.8.38"
+  resolved "http://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz#ec9b120b11bf6ccd4173a18bf217e60b79859ffd"
 
 backo2@1.0.2:
   version "1.0.2"
@@ -2447,7 +2455,7 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
-core-js@^2.4.0, core-js@^2.5.0:
+core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 
@@ -2784,7 +2792,7 @@ discontinuous-range@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
 
-doctrine@^2.1.0:
+doctrine@^2.0.0, doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   dependencies:
@@ -3135,6 +3143,10 @@ esprima@^3.1.3:
 esprima@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+
+esprima@~4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
 
 esquery@^1.0.1:
   version "1.0.1"
@@ -5571,6 +5583,12 @@ nice-try@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
 
+node-dir@^0.1.10:
+  version "0.1.17"
+  resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.17.tgz#5f5665d93351335caabef8f1c554516cf5f1e4e5"
+  dependencies:
+    minimatch "^3.0.2"
+
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -6406,7 +6424,7 @@ pretty-format@^23.6.0:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
-private@^0.1.6, private@^0.1.8:
+private@^0.1.6, private@^0.1.8, private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
@@ -6600,6 +6618,18 @@ react-ace@^6.1.4:
     lodash.isequal "^4.1.1"
     prop-types "^15.5.8"
 
+react-docgen@^2.7.0:
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-2.21.0.tgz#e8f9caf50e15510096616850771f243fadbb9d7d"
+  dependencies:
+    async "^2.1.4"
+    babel-runtime "^6.9.2"
+    babylon "~5.8.3"
+    commander "^2.9.0"
+    doctrine "^2.0.0"
+    node-dir "^0.1.10"
+    recast "^0.12.6"
+
 react-document-title@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/react-document-title/-/react-document-title-2.0.3.tgz#bbf922a0d71412fc948245e4283b2412df70f2b9"
@@ -6623,6 +6653,14 @@ react-is@^16.4.2, react-is@^16.5.1:
 react-lifecycles-compat@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+
+react-markdown-gen@^0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/react-markdown-gen/-/react-markdown-gen-0.0.11.tgz#cd03771d9977630e94b1643008c87ad2c0759b32"
+  dependencies:
+    commander "^2.9.0"
+    react-docgen "^2.7.0"
+    verbal-expressions "^0.2.1"
 
 react-modal@^3.5.1:
   version "3.5.1"
@@ -6845,6 +6883,16 @@ realpath-native@^1.0.0:
   resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.0.2.tgz#cd51ce089b513b45cf9b1516c82989b51ccc6560"
   dependencies:
     util.promisify "^1.0.0"
+
+recast@^0.12.6:
+  version "0.12.9"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.12.9.tgz#e8e52bdb9691af462ccbd7c15d5a5113647a15f1"
+  dependencies:
+    ast-types "0.10.1"
+    core-js "^2.4.1"
+    esprima "~4.0.0"
+    private "~0.1.5"
+    source-map "~0.6.1"
 
 redent@^1.0.0:
   version "1.0.0"
@@ -8200,6 +8248,10 @@ validate-npm-package-name@~2.2.2:
 value-equal@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
+
+verbal-expressions@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/verbal-expressions/-/verbal-expressions-0.2.1.tgz#28b845f760dd9f91d6bc351d2e0bb48fa95c6daf"
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
What I Did
------------
Add some improvements to Ship Init's dev process and update documentation to explain how this works.

How I Did it
------------
- Make `webpack-dashboard` opt-in by using the `dashboard` command rather than `start`
- Add more descriptive prop type docstrings
- Add utility to generate Markdown documentation for props
- Additional cleanup related to externalizing `monaco-editor`
- Update documentation

How to verify it
------------
Most of the changes to the code were development-related, tests should continue to pass.

Description for the Changelog
------------
- Improve developer experience/documentation of Ship init component


Picture of a Boat (not required but encouraged)
------------
🛶 











<!-- (thanks https://github.com/docker/docker for this template) -->

