### PR TITLE
Workaround in UI for kustomize navcycle issue in #596

### DIFF
--- a/web/init/package.json
+++ b/web/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replicatedhq/ship-init",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Shared component that contains the Ship Init app",
   "author": "Replicated, Inc.",
   "license": "Apache-2.0",

--- a/web/init/src/components/shared/DetermineComponentForRoute.jsx
+++ b/web/init/src/components/shared/DetermineComponentForRoute.jsx
@@ -83,7 +83,12 @@ export class DetermineComponentForRoute extends React.Component {
     const kustomizeStepIndex = findIndex(routes, { phase: "kustomize" });
     const kustomizeStep = routes[kustomizeStepIndex];
     const stepAfterKustomize = routes[kustomizeStepIndex + 1];
-    const { actions: kustomizeActions } = await fetchContentForStep(apiEndpoint, kustomizeStep.id);
+
+    let { actions: kustomizeActions } = await fetchContentForStep(apiEndpoint, kustomizeStep.id);
+    // TODO: Revert when https://github.com/replicatedhq/ship/issues/596 is addressed
+    if (!kustomizeActions) {
+      ({ actions: kustomizeActions } = await fetchContentForStep(apiEndpoint, kustomizeStep.id));
+    }
     this.handleAction(kustomizeActions[0]);
 
     this.startPoll(kustomizeStep.id, () => this.gotoRoute(stepAfterKustomize));


### PR DESCRIPTION
What I Did
------------
Workaround the kustomize navcycle issue reported in #596 so the UI will get the action data for kustomize skip

How I Did it
------------
Re-request the navcycle step data from the API

How to verify it
------------
Skipping the kustomize step through the overlays window should work correctly.

Description for the Changelog
------------
- Workaround in UI for kustomize navcycle issue in #596


Picture of a Boat (not required but encouraged)
------------
🚢 











<!-- (thanks https://github.com/docker/docker for this template) -->

