### PR TITLE
Update Ship Init initial step redirect to use History API if provided

### DIFF
--- a/web/init/package.json
+++ b/web/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replicatedhq/ship-init",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Shared component that contains the Ship Init app",
   "author": "Replicated, Inc.",
   "license": "Apache-2.0",

--- a/web/init/src/components/shared/RouteDecider.jsx
+++ b/web/init/src/components/shared/RouteDecider.jsx
@@ -34,8 +34,8 @@ const ShipRoutesWrapper = ({ routes, headerEnabled, basePath }) => (
                   path={`${basePath}/${route.id}`}
                   render={() => <DetermineComponentForRoute
                     basePath={basePath}
-                    routes={routes} 
-                    routeId={route.id} 
+                    routes={routes}
+                    routeId={route.id}
                   />}
                 />
               ))}
@@ -58,7 +58,10 @@ export default class RouteDecider extends React.Component {
          description: PropTypes.string,
          phase: PropTypes.string,
       })
-    )
+    ),
+    basePath: PropTypes.string.isRequired,
+    headerEnabled: PropTypes.bool.isRequired,
+    history: PropTypes.object.isRequired
   }
 
   componentDidUpdate(lastProps) {
@@ -75,7 +78,12 @@ export default class RouteDecider extends React.Component {
         }
       }
       if (isRootPath(basePath)) {
-        window.location.replace(`${basePath}/${routes[0].id}`);
+        const defaultRoute = `${basePath}/${routes[0].id}`;
+        if (this.props.history !== null) {
+          this.props.history.push(defaultRoute);
+        } else {
+          window.location.replace(defaultRoute);
+        }
       }
     }
   }
@@ -101,14 +109,14 @@ export default class RouteDecider extends React.Component {
     }
     return (
       <div className="u-minHeight--full u-minWidth--full flex-column flex1">
-        { history ? 
+        { history ?
           <Router history={history}>
-            <ShipRoutesWrapper 
+            <ShipRoutesWrapper
               {...routeProps}
             />
           </Router> :
           <BrowserRouter basename={basePath}>
-            <ShipRoutesWrapper 
+            <ShipRoutesWrapper
               {...routeProps}
             />
           </BrowserRouter>


### PR DESCRIPTION
What I Did
------------
Updates Ship Init to use the `history` prop (if provided) for its initial intro step redirect.

How I Did it
------------
Update root path detection to use the `history` prop rather than a redirect with `window.location`. Maintain the same behavior on newly initialized `BrowserRouter`.

How to verify it
------------
Verified externally, no change in behavior for binary UI.

Description for the Changelog
------------
- Update Ship Init initial step redirect to use History API if provided


Picture of a Boat (not required but encouraged)
------------
🛶 











<!-- (thanks https://github.com/docker/docker for this template) -->

