### PR TITLE
Fix requirement not met step not being present in route find

### DIFF
--- a/web/init/package.json
+++ b/web/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replicatedhq/ship-init",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Shared component that contains the Ship Init app",
   "author": "Replicated, Inc.",
   "license": "Apache-2.0",

--- a/web/init/src/components/shared/DetermineComponentForRoute.jsx
+++ b/web/init/src/components/shared/DetermineComponentForRoute.jsx
@@ -119,9 +119,8 @@ export class DetermineComponentForRoute extends React.Component {
       location,
       initializeStep,
       routes,
-      basePath
     } = this.props;
-    const { id: routeId } = find(routes, { phase });
+    const { id: routeId } = find(routes, { phase }) || {};
 
     if (!phase || !phase.length) return null;
     switch (phase) {


### PR DESCRIPTION
What I Did
------------
Fix a regression where stepping to a route that has not had previous requirements yet would cause the app to crash

How I Did it
------------
Handle a client-side route, such as `requirementNotMet`, not being found in the fetched routes from the API.

How to verify it
------------
Clicking the stepper at the top should no longer cause the app to crash.

Description for the Changelog
------------
- Fix requirement not met step not being present in route find


Picture of a Boat (not required but encouraged)
------------
⛵️ 











<!-- (thanks https://github.com/docker/docker for this template) -->

