### PR TITLE
Use the targz archiver in the asset uploader code

### DIFF
--- a/pkg/util/http_upload.go
+++ b/pkg/util/http_upload.go
@@ -25,12 +25,10 @@ type assetUploader struct {
 func NewAssetUploader(
 	logger log.Logger,
 	client *http.Client,
-	tar archiver.Archiver,
 ) AssetUploader {
 	return &assetUploader{
 		logger: log.With(logger, "struct", "assetUploader"),
 		client: client,
-		tar:    tar,
 	}
 
 }
@@ -50,6 +48,11 @@ func (a *assetUploader) UploadAssets(target string) error {
 		return errors.Wrapf(err, "create temp dir")
 	}
 	defer os.RemoveAll(tmpdir)
+
+	// in normal use this means that the targz archiver will be used, but tests can set something else if needed
+	if a.tar == nil {
+		a.tar = archiver.TarGz
+	}
 
 	debug.Log("event", "archive.create")
 	archivePath := path.Join(tmpdir, "assets.tar.gz")


### PR DESCRIPTION
What I Did
------------
Set the archiver type explicitly

How I Did it
------------


How to verify it
------------
Uploaded files should now be tar.gz formatted.

Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------
!["USS Bainbridge DD-1"](https://upload.wikimedia.org/wikipedia/commons/8/82/USS_Bainbridge_DD-1-650px.jpg "USS Bainbridge DD-1")











<!-- (thanks https://github.com/docker/docker for this template) -->

