### PR TITLE
Improve the error messaging for failed uploads by including the body

### DIFF
--- a/pkg/util/http_upload.go
+++ b/pkg/util/http_upload.go
@@ -81,6 +81,12 @@ func (a *assetUploader) UploadAssets(target string) error {
 		return errors.Errorf("request returned no error, but was nil")
 	}
 	if resp.StatusCode > 299 {
+		if resp.Body != nil {
+			body, err := ioutil.ReadAll(resp.Body)
+			if err == nil {
+				return errors.Errorf("request returned status code %d and body %q", resp.StatusCode, string(body))
+			}
+		}
 		return errors.Errorf("request returned status code %d", resp.StatusCode)
 	}
 	return nil


### PR DESCRIPTION
What I Did
------------
Included the body of the response to failed PUT requests in http-uploader if it exists

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------

![USS Truxtun (DD-14)](https://upload.wikimedia.org/wikipedia/commons/b/b0/USSTruxtunDD14.jpg "USS Truxtun (DD-14)")










<!-- (thanks https://github.com/docker/docker for this template) -->

