### PR TITLE
set content length to avoid transfer-encoding header not supported by s3

### DIFF
--- a/pkg/util/http_upload.go
+++ b/pkg/util/http_upload.go
@@ -73,6 +73,12 @@ func (a *assetUploader) UploadAssets(target string) error {
 		return errors.Wrap(err, "create request")
 	}
 
+	stat, err := archive.Stat()
+	if err != nil {
+		return errors.Wrap(err, "get archive info")
+	}
+	request.ContentLength = stat.Size()
+
 	debug.Log("event", "request.send")
 	resp, err := a.client.Do(request)
 	if err != nil {


### PR DESCRIPTION
What I Did
------------
Set content length explicitly to avoid "Transfer-Encoding" header, which is not supported by S3. See [here](https://stackoverflow.com/a/47275961/5657035)

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------
![USS Smith (DD-17)](https://upload.wikimedia.org/wikipedia/commons/0/02/USS_Smith_%28DD-17%29.jpg "USS Smith (DD-17)")











<!-- (thanks https://github.com/docker/docker for this template) -->

