### PR TITLE
fix links to kubectApply doc

### DIFF
--- a/hack/docs/README.md
+++ b/hack/docs/README.md
@@ -11,7 +11,7 @@ This is totally copy-pasted from [the support bundle docs generation](https://gi
  1. Make changes to the `api.Spec` type
  1. Run this in dev container
     ```
-    make deps build pipeline
+    make deps build pipeline-strict
     ```
  1. Copy generated `schema.json` file into the [replicatedhq/replicated-linter](https://github.com/replicatedhq/replicated-lint/tree/master/projects/replicated-ship) project.
  1. In `replicated-lint` project run

--- a/hack/docs/mutations.json
+++ b/hack/docs/mutations.json
@@ -575,7 +575,7 @@
     },
     "merge": {
       "description": "An `amazon_eks` asset generates a terraform file that will create an Amazon EKS Cluster.",
-      "extended_description": "It also populates a template function `AmazonEKS` that takes the name of the cluster and returns the path to the generated kubeconfig for the cluster. This template function is only valid after the asset has been generated as part of the `render` lifecycle step, but can be used by later assets within that step. The file itself is created when the generated terraform is applied, whether by the `terraform` lifecycle step or otherwise. This is intended to be used within the [kubectl_apply](/api/ship-lifecycle/lifecycle/kubectl_apply/) lifecycle step.",
+      "extended_description": "It also populates a template function `AmazonEKS` that takes the name of the cluster and returns the path to the generated kubeconfig for the cluster. This template function is only valid after the asset has been generated as part of the `render` lifecycle step, but can be used by later assets within that step. The file itself is created when the generated terraform is applied, whether by the `terraform` lifecycle step or otherwise. This is intended to be used within the [kubectlApply](/api/ship-lifecycle/kubectlapply/) lifecycle step.",
       "examples": [
         {
           "cluster_name": "existing-vpc-cluster",
@@ -767,7 +767,7 @@
     "path": "properties.assets.properties.v1.items.properties.azure_aks",
     "merge": {
       "description": "An `azure_aks` asset generates a terraform file that will create an Azure AKS Cluster.",
-      "extended_description": "It also populates a template function `AzureAKS` that takes the name of the cluster and returns the path to the generated kubeconfig for the cluster. This template function is only valid after the asset has been generated as part of the `render` lifecycle step, but can be used by later assets within that step. The file itself is created when the generated terraform is applied, whether by the `terraform` lifecycle step or otherwise. This is intended to be used within the [kubectl_apply](/api/ship-lifecycle/lifecycle/kubectl_apply/) lifecycle step.",
+      "extended_description": "It also populates a template function `AzureAKS` that takes the name of the cluster and returns the path to the generated kubeconfig for the cluster. This template function is only valid after the asset has been generated as part of the `render` lifecycle step, but can be used by later assets within that step. The file itself is created when the generated terraform is applied, whether by the `terraform` lifecycle step or otherwise. This is intended to be used within the [kubectlApply](/api/ship-lifecycle/kubectlapply/) lifecycle step.",
       "examples": [
         {
           "tenant_id": "5c87f096-eafc-41e1-82f3-1d2282887dff",
@@ -899,7 +899,7 @@
     "path": "properties.assets.properties.v1.items.properties.google_gke",
     "merge": {
       "description": "A `google_gke` asset generates a terraform file that will create a Google GKE Cluster.",
-      "extended_description": "It also populates a template function `GoogleGKE` that takes the name of the cluster and returns the path to the generated kubeconfig for the cluster. This template function is only valid after the asset has been generated as part of the `render` lifecycle step, but can be used by later assets within that step. The file itself is created when the generated terraform is applied, whether by the `terraform` lifecycle step or otherwise. This is intended to be used within the [kubectl_apply](/api/ship-lifecycle/lifecycle/kubectl_apply/) lifecycle step.",
+      "extended_description": "It also populates a template function `GoogleGKE` that takes the name of the cluster and returns the path to the generated kubeconfig for the cluster. This template function is only valid after the asset has been generated as part of the `render` lifecycle step, but can be used by later assets within that step. The file itself is created when the generated terraform is applied, whether by the `terraform` lifecycle step or otherwise. This is intended to be used within the [kubectlApply](/api/ship-lifecycle/kubectlapply/) lifecycle step.",
       "examples": [
         {
           "credentials": "<BASE64 ENCODED STRING>",

--- a/hack/docs/schema.json
+++ b/hack/docs/schema.json
@@ -13,7 +13,7 @@
             "properties": {
               "amazon_eks": {
                 "description": "An `amazon_eks` asset generates a terraform file that will create an Amazon EKS Cluster.",
-                "extended_description": "It also populates a template function `AmazonEKS` that takes the name of the cluster and returns the path to the generated kubeconfig for the cluster. This template function is only valid after the asset has been generated as part of the `render` lifecycle step, but can be used by later assets within that step. The file itself is created when the generated terraform is applied, whether by the `terraform` lifecycle step or otherwise. This is intended to be used within the [kubectl_apply](/api/ship-lifecycle/lifecycle/kubectl_apply/) lifecycle step.",
+                "extended_description": "It also populates a template function `AmazonEKS` that takes the name of the cluster and returns the path to the generated kubeconfig for the cluster. This template function is only valid after the asset has been generated as part of the `render` lifecycle step, but can be used by later assets within that step. The file itself is created when the generated terraform is applied, whether by the `terraform` lifecycle step or otherwise. This is intended to be used within the [kubectlApply](/api/ship-lifecycle/kubectlapply/) lifecycle step.",
                 "examples": [
                   {
                     "cluster_name": "existing-vpc-cluster",
@@ -207,7 +207,7 @@
               },
               "azure_aks": {
                 "description": "An `azure_aks` asset generates a terraform file that will create an Azure AKS Cluster.",
-                "extended_description": "It also populates a template function `AzureAKS` that takes the name of the cluster and returns the path to the generated kubeconfig for the cluster. This template function is only valid after the asset has been generated as part of the `render` lifecycle step, but can be used by later assets within that step. The file itself is created when the generated terraform is applied, whether by the `terraform` lifecycle step or otherwise. This is intended to be used within the [kubectl_apply](/api/ship-lifecycle/lifecycle/kubectl_apply/) lifecycle step.",
+                "extended_description": "It also populates a template function `AzureAKS` that takes the name of the cluster and returns the path to the generated kubeconfig for the cluster. This template function is only valid after the asset has been generated as part of the `render` lifecycle step, but can be used by later assets within that step. The file itself is created when the generated terraform is applied, whether by the `terraform` lifecycle step or otherwise. This is intended to be used within the [kubectlApply](/api/ship-lifecycle/kubectlapply/) lifecycle step.",
                 "examples": [
                   {
                     "tenant_id": "5c87f096-eafc-41e1-82f3-1d2282887dff",
@@ -466,7 +466,7 @@
               },
               "google_gke": {
                 "description": "A `google_gke` asset generates a terraform file that will create a Google GKE Cluster.",
-                "extended_description": "It also populates a template function `GoogleGKE` that takes the name of the cluster and returns the path to the generated kubeconfig for the cluster. This template function is only valid after the asset has been generated as part of the `render` lifecycle step, but can be used by later assets within that step. The file itself is created when the generated terraform is applied, whether by the `terraform` lifecycle step or otherwise. This is intended to be used within the [kubectl_apply](/api/ship-lifecycle/lifecycle/kubectl_apply/) lifecycle step.",
+                "extended_description": "It also populates a template function `GoogleGKE` that takes the name of the cluster and returns the path to the generated kubeconfig for the cluster. This template function is only valid after the asset has been generated as part of the `render` lifecycle step, but can be used by later assets within that step. The file itself is created when the generated terraform is applied, whether by the `terraform` lifecycle step or otherwise. This is intended to be used within the [kubectlApply](/api/ship-lifecycle/kubectlapply/) lifecycle step.",
                 "examples": [
                   {
                     "credentials": "<BASE64 ENCODED STRING>",


### PR DESCRIPTION
What I Did
------------
Updated helpcenter links to kubectlApply dock

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------
Updated links in generated docs to kubectlApply


Picture of a Boat (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

