### PR TITLE
Move modal CSS into global scope, scope needed utilities to modal

### DIFF
--- a/web/init/src/components/kustomize/kustomize_overlay/KustomizeOverlay.jsx
+++ b/web/init/src/components/kustomize/kustomize_overlay/KustomizeOverlay.jsx
@@ -380,7 +380,7 @@ export default class KustomizeOverlay extends React.Component {
           <div className="Modal-header">
             <p>Are you sure you want to discard this overlay?</p>
           </div>
-          <div className="flex flex-column u-modalPadding">
+          <div className="flex flex-column Modal-body">
             <p className="u-fontSize--large u-fontWeight--normal u-color--dustyGray u-lineHeight--more">It will not be applied to the kustomization.yaml file that is generated for you.</p>
             <div className="flex justifyContent--flexEnd u-marginTop--20">
               <button className="btn secondary u-marginRight--10" onClick={() => this.toggleModal("")}>Cancel</button>

--- a/web/init/src/scss/index.scss
+++ b/web/init/src/scss/index.scss
@@ -1,5 +1,6 @@
 @import "./utilities/reset.scss"; // Scoped to "ship-init"
 @import "./utilities/base.scss"; // Scoped to "ship-init"
+@import "./utilities/modals.scss";
 
 #ship-init-component {
   display: flex;
@@ -13,7 +14,6 @@
   @import "./utilities/flexbox.scss";
   @import "./utilities/forms.scss";
   @import "./utilities/icons.scss";
-  @import "./utilities/modals.scss";
   @import "./utilities/tooltip.scss";
   @import "./utilities/prism.css";
   @import "./utilities/terminal.css";

--- a/web/init/src/scss/utilities/modals.scss
+++ b/web/init/src/scss/utilities/modals.scss
@@ -8,6 +8,9 @@
     z-index: 500;
     overflow: auto;
 
+    @import "./buttons.scss";
+    @import "./utilities.scss";
+
     .Modal {
         position: absolute;
         top: 50%;


### PR DESCRIPTION
What I Did
------------
Move all modal CSS into the global scope, and scope necessary utilities to modal CSS.

How I Did it
------------
Moved the CSS modal import outside of `#ship-init-component`. Imported button and utility stylesheets within the scope of `.ReactModal__Overlay`.

How to verify it
------------
Run the ship init UI.

Description for the Changelog
------------
Fixed bug related to missing modal on Kustomize view.

Picture of a Boat (not required but encouraged)
------------
⛵️ 











<!-- (thanks https://github.com/docker/docker for this template) -->

