### PR TITLE
support for fallback app slug for use with console

### DIFF
--- a/pkg/images/image.go
+++ b/pkg/images/image.go
@@ -47,7 +47,13 @@ func (r *URLResolver) ResolvePullURL(asset api.DockerAsset, meta api.ReleaseMeta
 			return "", errors.Wrapf(err, "parse image url %s", asset.Image)
 		}
 
-		url := fmt.Sprintf("%s/%s/%s.%s:%s", replicatedRegistry(), image.AppSlug, image.ImageKey, imageName, imageTag)
+		// for third-party registries hosted on console.replicated.com
+		slug := image.AppSlug
+		if slug == "" {
+			slug = "ship"
+		}
+
+		url := fmt.Sprintf("%s/%s/%s.%s:%s", replicatedRegistry(), slug, image.ImageKey, imageName, imageTag)
 		return url, nil
 	}
 

--- a/pkg/images/image_test.go
+++ b/pkg/images/image_test.go
@@ -123,6 +123,14 @@ func TestResolvePullUrl(t *testing.T) {
 			},
 			ExpectURL: fmt.Sprintf("%s/awesomeapp/jjzpr9u62gaz4.chatops:f3c689e", replicatedRegistry()),
 		},
+		{
+			Name: "private proxied image with no slug",
+			Asset: api.DockerAsset{
+				Image:  "quay.io/redacted/hugops:f3c689e",
+				Source: "quayio",
+			},
+			ExpectURL: fmt.Sprintf("%s/ship/jjzpr9u62gaz4.hugops:f3c689e", replicatedRegistry()),
+		},
 	}
 	meta := api.ReleaseMetadata{
 		Images: []api.Image{
@@ -136,6 +144,11 @@ func TestResolvePullUrl(t *testing.T) {
 				URL:      "quay.io/redacted/chatops:f3c689e",
 				Source:   "quayio",
 				AppSlug:  "awesomeapp",
+				ImageKey: "jjzpr9u62gaz4",
+			},
+			{
+				URL:      "quay.io/redacted/hugops:f3c689e",
+				Source:   "quayio",
 				ImageKey: "jjzpr9u62gaz4",
 			},
 		},


### PR DESCRIPTION
What I Did
------------

Add support for proxied docker images hosted from console.replicated.com


How I Did it
------------

Default slug to `ship`


How to verify it
------------

Link a registry on `console.replicated.com` and use it in a ship.yaml


Description for the Changelog
------------

Add support for proxied docker images hosted from console.replicated.com

![By Christopher Michel - Shipwreck, CC BY 2.0, https://commons.wikimedia.org/w/index.php?curid=24283774](https://upload.wikimedia.org/wikipedia/commons/5/57/Shipwreck_%288326331719%29.jpg)