### PR TITLE
Update skipKustomize function to be more reliable 

### DIFF
--- a/web/init/package.json
+++ b/web/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replicatedhq/ship-init",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Shared component that contains the Ship Init app",
   "author": "Replicated, Inc.",
   "license": "Apache-2.0",

--- a/web/init/src/components/shared/DetermineComponentForRoute.jsx
+++ b/web/init/src/components/shared/DetermineComponentForRoute.jsx
@@ -89,25 +89,26 @@ export class DetermineComponentForRoute extends React.Component {
   }
 
   skipKustomize = async () => {
-    const {
-      actions: kustomizeIntroActions,
-      routes,
-      apiEndpoint,
-    } = this.props;
-    this.handleAction(kustomizeIntroActions[0]);
+    const { apiEndpoint } = this.props;
+    const { actions, progress } = await fetchContentForStep(apiEndpoint, "kustomize");
 
-    const kustomizeStepIndex = findIndex(routes, { phase: "kustomize" });
-    const kustomizeStep = routes[kustomizeStepIndex];
-    const stepAfterKustomize = routes[kustomizeStepIndex + 1];
-
-    let { actions: kustomizeActions } = await fetchContentForStep(apiEndpoint, kustomizeStep.id);
-    // TODO: Revert when https://github.com/replicatedhq/ship/issues/596 is addressed
-    if (!kustomizeActions) {
-      ({ actions: kustomizeActions } = await fetchContentForStep(apiEndpoint, kustomizeStep.id));
+    let stepValid = true;
+    if (progress && progress.detail) {
+      const { status } = JSON.parse(progress.detail);
+      stepValid = status !== error;
     }
-    this.handleAction(kustomizeActions[0]);
 
-    this.startPoll(kustomizeStep.id, () => this.gotoRoute(stepAfterKustomize));
+    if (stepValid) {
+      const [finalizeKustomize] = actions;
+      await this.props.finalizeStep({ action: finalizeKustomize });
+
+      this.startPoll("kustomize", this.gotoRoute);
+    } else {
+      // TODO: Handle case where error detected in Kustomize step on skip
+      //       This can occur even if no overlays created since kustomize
+      //       build is always executed.
+      console.log("Error detected, cancelling kustomize step skip.")
+    }
   }
 
   startPoll = async (routeId, cb) => {

--- a/web/init/src/components/shared/DetermineComponentForRoute.jsx
+++ b/web/init/src/components/shared/DetermineComponentForRoute.jsx
@@ -93,9 +93,11 @@ export class DetermineComponentForRoute extends React.Component {
     const { actions, progress } = await fetchContentForStep(apiEndpoint, "kustomize");
 
     let stepValid = true;
+    let kustomizeErrorMessage = "";
     if (progress && progress.detail) {
-      const { status } = JSON.parse(progress.detail);
-      stepValid = status !== error;
+      const { status, message } = JSON.parse(progress.detail);
+      stepValid = status !== "error";
+      kustomizeErrorMessage = message;
     }
 
     if (stepValid) {
@@ -107,7 +109,7 @@ export class DetermineComponentForRoute extends React.Component {
       // TODO: Handle case where error detected in Kustomize step on skip
       //       This can occur even if no overlays created since kustomize
       //       build is always executed.
-      console.log("Error detected, cancelling kustomize step skip.")
+      alert(`Error detected, cancelling kustomize step skip. Error below: \n${kustomizeErrorMessage}`);
     }
   }
 

--- a/web/init/src/components/shared/DetermineComponentForRoute.spec.js
+++ b/web/init/src/components/shared/DetermineComponentForRoute.spec.js
@@ -7,6 +7,7 @@ jest.mock("../kustomize/kustomize_overlay/AceEditorHOC");
 
 const mockPollContentForStep = jest.fn();
 const mockKustomizeIntroProps = {
+  apiEndpoint: "https://ship-api.com",
   phase: "kustomize-intro",
   dataLoading: {},
   actions: ["mockKustomizeIntroAction"],
@@ -27,7 +28,7 @@ const mockKustomizeIntroProps = {
 
 describe("DetermineComponentForRoute", () => {
   describe("skipKustomize", () => {
-    it("calls the kustomizeIntro action, kustomize action, and then polls for the kustomize step", async() => {
+    it("completes kustomize step and polls for the outro", async() => {
       const mockHandleAction = jest.fn();
 
       const mockFetchContentForStep = jest.fn();
@@ -36,18 +37,22 @@ describe("DetermineComponentForRoute", () => {
       }));
       RewireAPI.__set__("fetchContentForStep", mockFetchContentForStep);
 
-      const wrapper = shallow(<DetermineComponentForRoute {...mockKustomizeIntroProps} />);
+      const wrapper = shallow(
+        <DetermineComponentForRoute
+          {...mockKustomizeIntroProps}
+          fetchContentForStep={mockFetchContentForStep}
+        />
+      );
       wrapper.instance().handleAction = mockHandleAction;
       wrapper.update();
 
       await wrapper.instance().skipKustomize();
 
-      expect(mockHandleAction.mock.calls).toHaveLength(2);
-      expect(mockHandleAction.mock.calls[0][0]).toEqual("mockKustomizeIntroAction");
-      expect(mockHandleAction.mock.calls[1][0]).toEqual("mockKustomizeAction");
+      expect(mockFetchContentForStep.mock.calls).toHaveLength(1);
+      expect(mockFetchContentForStep.mock.calls[0]).toEqual(["https://ship-api.com", "kustomize"]);
 
       expect(mockPollContentForStep).toHaveBeenCalled();
-      expect(mockPollContentForStep.mock.calls[0][0]).toEqual("mockKustomizeId");
+      expect(mockPollContentForStep.mock.calls[0][0]).toEqual("kustomize");
     });
   });
 });

--- a/web/init/src/components/shared/RouteDecider.jsx
+++ b/web/init/src/components/shared/RouteDecider.jsx
@@ -62,7 +62,7 @@ export default class RouteDecider extends React.Component {
     ),
     basePath: PropTypes.string.isRequired,
     headerEnabled: PropTypes.bool.isRequired,
-    history: PropTypes.object.isRequired,
+    history: PropTypes.object,
     /** Callback function to be invoked at the finalization of the Ship Init flow */
     onCompletion: PropTypes.func,
   }


### PR DESCRIPTION
Work to address #596

What I Did
------------
Simplies the `skipKustomize` function, which should make it more reliable. A follow-on task is displaying Kustomize errors in a more friendly way to the UI.

How I Did it
------------
Update the `DetermineComponentForRoute` helper to directly call the finalize kustomize endpoint.

How to verify it
------------
Verified against the Grafana Helm chart, but it does need additional verification.

Description for the Changelog
------------
- Update skipKustomize function to be more reliable 


Picture of a Boat (not required but encouraged)
------------
🛶 











<!-- (thanks https://github.com/docker/docker for this template) -->

