### PR TITLE
make 'deploy' more like 'deploy_unstable'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,7 @@ jobs:
       - checkout
       - setup_remote_docker
       - attach_workspace:
-          at: /go/src/github.com/replicatedhq/ship/web/app
+          at: /go/src/github.com/replicatedhq/ship/web
       - run: make build-deps ci-embed-ui
       - run: git diff pkg/lifecycle/daemon/ui.bindatafs.go | cat
       - run: docker pull alpine:latest # make sure it's fresh


### PR DESCRIPTION
What I Did
------------
Attach workspace at `/go/src/github.com/replicatedhq/ship/web` not `/go/src/github.com/replicatedhq/ship/web/app` in the `deploy` step matching `deploy_unstable` step

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------


![USS Avenger MCM-1](https://upload.wikimedia.org/wikipedia/commons/thumb/d/d0/USS_Avenger_MCM-1.jpg/1600px-USS_Avenger_MCM-1.jpg "USS Avenger MCM-1")









<!-- (thanks https://github.com/docker/docker for this template) -->

