### PR TITLE
Log a stack trace on a failed completestep

### DIFF
--- a/pkg/lifecycle/daemon/routes_navcycle_completestep.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_completestep.go
@@ -114,7 +114,8 @@ func (d *NavcycleRoutes) awaitAsyncStep(errChan chan error, debug log.Logger, st
 		// listen on err chan for step
 		case err := <-errChan:
 			if err != nil {
-				level.Error(debug).Log("event", "async.fail", "err", err, "progress", d.progress(step))
+				errToPrint := fmt.Sprintf("%+v", err) // log a stack trace on failed completestep
+				level.Error(debug).Log("event", "async.fail", "err", err, "errorWithStack", errToPrint, "progress", d.progress(step))
 				return err
 			}
 			level.Info(debug).Log("event", "task.complete", "progess", d.progress(step))


### PR DESCRIPTION
What I Did
------------

Log a stack trace on a failed completestep

How I Did it
------------

similar to `Ship#ExitWithError`, use `fmt.Sprintf("%+v", err)` to log
the full stack trace if present.


How to verify it
------------

run `ship init <chart>`, delete the `base` folder before finalizing kustomize, see nice errors:

```
tailf .ship/debug.log | jq -r .errorWithStack
null
null
null
lstat base: no such file or directory
failed to walk path
github.com/replicatedhq/ship/pkg/lifecycle/kustomize.(*Kustomizer).writeBase.func1
        /Users/dex/go/src/github.com/replicatedhq/ship/pkg/lifecycle/kustomize/kustomizer.go:231
github.com/replicatedhq/ship/vendor/github.com/spf13/afero.Walk
        /Users/dex/go/src/github.com/replicatedhq/ship/vendor/github.com/spf13/afero/path.go:105
github.com/replicatedhq/ship/vendor/github.com/spf13/afero.Afero.Walk
        /Users/dex/go/src/github.com/replicatedhq/ship/vendor/github.com/spf13/afero/path.go:99
github.com/replicatedhq/ship/pkg/lifecycle/kustomize.(*Kustomizer).writeBase
        /Users/dex/go/src/github.com/replicatedhq/ship/pkg/lifecycle/kustomize/kustomizer.go:226
github.com/replicatedhq/ship/pkg/lifecycle/kustomize.(*Kustomizer).Execute
        /Users/dex/go/src/github.com/replicatedhq/ship/pkg/lifecycle/kustomize/daemonless.go:39
github.com/replicatedhq/ship/pkg/lifecycle/daemon.(*NavcycleRoutes).execute
        /Users/dex/go/src/github.com/replicatedhq/ship/pkg/lifecycle/daemon/routes_navcycle_completestep.go:169
github.com/replicatedhq/ship/pkg/lifecycle/daemon.NewV2Router.func1
        /Users/dex/go/src/github.com/replicatedhq/ship/pkg/lifecycle/daemon/constructors.go:77
github.com/replicatedhq/ship/pkg/lifecycle/daemon.(*NavcycleRoutes).completeStep.func1
        /Users/dex/go/src/github.com/replicatedhq/ship/pkg/lifecycle/daemon/routes_navcycle_completestep.go:67
runtime.goexit
        /Users/dex/opt/go/src/runtime/asm_amd64.s:1333
write base kustomization
github.com/replicatedhq/ship/pkg/lifecycle/kustomize.(*Kustomizer).Execute
        /Users/dex/go/src/github.com/replicatedhq/ship/pkg/lifecycle/kustomize/daemonless.go:41
github.com/replicatedhq/ship/pkg/lifecycle/daemon.(*NavcycleRoutes).execute
        /Users/dex/go/src/github.com/replicatedhq/ship/pkg/lifecycle/daemon/routes_navcycle_completestep.go:169
github.com/replicatedhq/ship/pkg/lifecycle/daemon.NewV2Router.func1
        /Users/dex/go/src/github.com/replicatedhq/ship/pkg/lifecycle/daemon/constructors.go:77
github.com/replicatedhq/ship/pkg/lifecycle/daemon.(*NavcycleRoutes).completeStep.func1
        /Users/dex/go/src/github.com/replicatedhq/ship/pkg/lifecycle/daemon/routes_navcycle_completestep.go:67
runtime.goexit
        /Users/dex/opt/go/src/runtime/asm_amd64.s:1333
execute kustomize step
github.com/replicatedhq/ship/pkg/lifecycle/daemon.(*NavcycleRoutes).execute
        /Users/dex/go/src/github.com/replicatedhq/ship/pkg/lifecycle/daemon/routes_navcycle_completestep.go:170
github.com/replicatedhq/ship/pkg/lifecycle/daemon.NewV2Router.func1
        /Users/dex/go/src/github.com/replicatedhq/ship/pkg/lifecycle/daemon/constructors.go:77
github.com/replicatedhq/ship/pkg/lifecycle/daemon.(*NavcycleRoutes).completeStep.func1
        /Users/dex/go/src/github.com/replicatedhq/ship/pkg/lifecycle/daemon/routes_navcycle_completestep.go:67
runtime.goexit
        /Users/dex/opt/go/src/runtime/asm_amd64.s:1333
null
```


Description for the Changelog
------------

Log a stack trace if an interactive step fails.