### PR TITLE
fix bug in basePathFs, better logging

### DIFF
--- a/pkg/lifecycle/render/root/fs.go
+++ b/pkg/lifecycle/render/root/fs.go
@@ -24,7 +24,7 @@ func NewRootFS(fs afero.Afero, root string) Fs {
 	if root == "" {
 		root = constants.InstallerPrefixPath
 	}
-	if root != "." {
+	if root != "." && root != "./" {
 		fs = afero.Afero{
 			Fs: afero.NewBasePathFs(fs.Fs, root),
 		}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -31,7 +31,7 @@ func (c *compositeLogger) Log(keyvals ...interface{}) error {
 // New builds a logger from env using viper
 func New(v *viper.Viper, fs afero.Afero) log.Logger {
 
-	fullPathCaller := pathCaller(5)
+	fullPathCaller := pathCaller(6)
 	var stdoutLogger log.Logger
 	stdoutLogger = withFormat(viper.GetString("log-format"))
 	stdoutLogger = log.With(stdoutLogger, "ts", log.DefaultTimestampUTC)


### PR DESCRIPTION
What I Did
------------

fix bug in basePathFs where a render root of "./" was treated differently than ".", better logging

How I Did it
------------

fix `NewRootFS`, change logger.pathCaller depth to 6

How to verify it
------------

run a ship.yaml with

```
- render:
    root: ./
```

And ensure inline and github assets render correctly. Also, check out
real actual filenames in the logs!

```json
{
  "caller": "github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemon.go",
  "event": "server.shutdown",
  "level": "debug",
  "method": "serve",
  "struct": "daemon",
  "ts": "2018-10-03T22:24:20.581963Z"
}
{
  "caller": "github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemon.go",
  "context canceled": "err",
  "event": "daemon.startonce.exit",
  "level": "info",
  "struct": "daemon",
  "ts": "2018-10-03T22:24:20.582187Z"
}
{
  "caller": "github.com/replicatedhq/ship/pkg/ship/ship.go",
  "err": "context canceled",
  "event": "shutdown",
  "level": "error",
  "reason": "error",
  "ts": "2018-10-03T22:24:20.582241Z"
}
```

Description for the Changelog
------------

Fix bug in RootFS where a render root of "./" was treated differently than ".", improve `caller` field when logging