### PR TITLE
Pull publish module in ship init deploy step using npx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,8 +257,8 @@ jobs:
           working_directory: ~/ship/web/init
           command: |
             echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-            # Run publish npm module
-            `yarn bin`/publish
+            # Run publish npm module, will pull latest
+            npx publish
 
   deploy_unstable:
     docker:


### PR DESCRIPTION
What I Did
------------
Fixes an issue (see [here]()) where the publish module is not found and causes the `@replicatedhq/ship-init` deploy step to fail.

How I Did it
------------
Use `npx` to pull the latest version of `node-publish`

How to verify it
------------
Merge this PR 🙂 

Description for the Changelog
------------
N/A


Picture of a Boat (not required but encouraged)
------------
🛶 











<!-- (thanks https://github.com/docker/docker for this template) -->

