### PR TITLE
Always pass a history prop to routing in Ship Init component

### DIFF
--- a/web/init/package.json
+++ b/web/init/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "brace": "^0.11.1",
+    "history": "^4.7.2",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.11",
     "rc-progress": "^2.2.5",

--- a/web/init/src/Ship.jsx
+++ b/web/init/src/Ship.jsx
@@ -4,6 +4,7 @@ import RouteDecider from "./containers/RouteDecider";
 import AppWrapper from "./containers/AppWrapper";
 import { configureStore } from "./redux";
 import PropTypes from "prop-types";
+import createBrowserHistory from 'history/createBrowserHistory'
 
 import "./scss/index.scss";
 
@@ -23,7 +24,7 @@ export class Ship extends React.Component {
 
   static defaultProps = {
     basePath: "",
-    history: null,
+    history: createBrowserHistory(),
     headerEnabled: false
   }
 

--- a/web/init/src/components/shared/RouteDecider.jsx
+++ b/web/init/src/components/shared/RouteDecider.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { BrowserRouter, Router, Route, Switch } from "react-router-dom";
+import { Router, Route, Switch } from "react-router-dom";
 import isEmpty from "lodash/isEmpty";
 import NavBar from "../../containers/Navbar";
 
@@ -62,7 +62,7 @@ export default class RouteDecider extends React.Component {
     ),
     basePath: PropTypes.string.isRequired,
     headerEnabled: PropTypes.bool.isRequired,
-    history: PropTypes.object,
+    history: PropTypes.object.isRequired,
     /** Callback function to be invoked at the finalization of the Ship Init flow */
     onCompletion: PropTypes.func,
   }
@@ -82,11 +82,7 @@ export default class RouteDecider extends React.Component {
       }
       if (isRootPath(basePath)) {
         const defaultRoute = `${basePath}/${routes[0].id}`;
-        if (this.props.history !== null) {
-          this.props.history.push(defaultRoute);
-        } else {
-          window.location.replace(defaultRoute);
-        }
+        this.props.history.push(defaultRoute);
       }
     }
   }
@@ -113,18 +109,11 @@ export default class RouteDecider extends React.Component {
     }
     return (
       <div className="u-minHeight--full u-minWidth--full flex-column flex1">
-        { history ?
-          <Router history={history}>
-            <ShipRoutesWrapper
-              {...routeProps}
-            />
-          </Router> :
-          <BrowserRouter basename={basePath}>
-            <ShipRoutesWrapper
-              {...routeProps}
-            />
-          </BrowserRouter>
-        }
+        <Router history={history}>
+          <ShipRoutesWrapper
+            {...routeProps}
+          />
+        </Router>
       </div>
     );
   }


### PR DESCRIPTION
What I Did
------------
Change behavior of the Ship Init component to always use the `Router` component rather than `BrowserRouter`. This allows us to simplify how we do default redirects and makes the way we set up a router more consistent.

The `history` prop will continue to remain optional.

How I Did it
------------
Always pass a `history` prop to the `RouteDecider` component by using the `history` package

How to verify it
------------
Tests should continue to pass. This should also make E2E tests faster (no more `window.location.replace`) and more reliable (occasionally page does not load in time and causes a failure)

Description for the Changelog
------------
- Always pass a history prop to routing in Ship Init component


Picture of a Boat (not required but encouraged)
------------
![](http://www.iro.umontreal.ca/~vaucher/History/Prehistoric_Craft/images/Titicaca_boat.jpg)











<!-- (thanks https://github.com/docker/docker for this template) -->

