### PR TITLE
E2E/deploy CI improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,8 +109,6 @@ jobs:
     working_directory: ~/ship
     steps:
       - checkout
-      - attach_workspace:
-          at: ~/
       - restore_cache:
           keys:
             - ship-e2e-setup-cy-3.1.0
@@ -129,17 +127,15 @@ jobs:
             - ~/.cache/Cypress
             - web/app/node_modules/cypress
           key: ship-e2e-setup-cy-3.1.0
-      - persist_to_workspace:
-          root: ~/
-          paths:
-            - ship/web/app/node_modules/cypress
-            - .cache/Cypress
   e2e_init:
     docker:
       - image: cypress/browsers:chrome67
     working_directory: ~/ship
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - ship-e2e-setup-cy-3.1.0
       - attach_workspace:
           at: ~/
       - run:
@@ -185,13 +181,11 @@ jobs:
           export GO_DOWNLOAD_URL=https://dl.google.com/go/go1.10.4.linux-amd64.tar.gz
           export GOROOT=/usr/local/go
           export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
-
           sudo apt update --fix-missing
           sudo apt install --no-install-recommends -y gcc
           curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
           sudo apt-get install -y nodejs
           sudo npm install -g http-echo-server
-
           wget "$GO_DOWNLOAD_URL" -O golang.tar.gz
           echo "${GO_SHA256SUM}  golang.tar.gz" | sha256sum -c -
           tar -zxvf golang.tar.gz -C /tmp
@@ -247,7 +241,7 @@ jobs:
       - run: |
           if [ "${CIRCLE_PROJECT_USERNAME}" != "replicatedhq" ]; then
             echo Unable to deploy, the project is currently on a fork.
-            exit 1
+            exit 0
           fi
       - checkout
       - attach_workspace:


### PR DESCRIPTION
What I Did
------------
Add some small improvements to E2E/deploy steps in Circle config

How I Did it
------------
- Disable workspace attaching in `e2e_setup`, instead use the cache key directly
- Exit 0 on Ship Init publish if on a fork

How to verify it
------------
Tests should continue to pass.

Description for the Changelog
------------
N/A


Picture of a Boat (not required but encouraged)
------------
🛶 











<!-- (thanks https://github.com/docker/docker for this template) -->

