### PR TITLE
Update Kustomize code to use new PatchesStrategicMerge key

### DIFF
--- a/integration/update/basic/expected/overlays/ship/kustomization.yaml
+++ b/integration/update/basic/expected/overlays/ship/kustomization.yaml
@@ -2,5 +2,5 @@ kind: ""
 apiversion: ""
 bases:
 - ../../base
-patches:
+patchesStrategicMerge:
 - templates/deployment.yaml

--- a/integration/update/modify-chart/expected/overlays/ship/kustomization.yaml
+++ b/integration/update/modify-chart/expected/overlays/ship/kustomization.yaml
@@ -2,5 +2,5 @@ kind: ""
 apiversion: ""
 bases:
 - ../../base
-patches:
+patchesStrategicMerge:
 - templates/deployment.yaml

--- a/integration/update/values-static/expected/overlays/ship/kustomization.yaml
+++ b/integration/update/values-static/expected/overlays/ship/kustomization.yaml
@@ -2,5 +2,5 @@ kind: ""
 apiversion: ""
 bases:
 - ../../base
-patches:
+patchesStrategicMerge:
 - deployment.yaml

--- a/integration/update/values-update/expected/overlays/ship/kustomization.yaml
+++ b/integration/update/values-update/expected/overlays/ship/kustomization.yaml
@@ -2,5 +2,5 @@ kind: ""
 apiversion: ""
 bases:
 - ../../base
-patches:
+patchesStrategicMerge:
 - deployment.yaml

--- a/pkg/lifecycle/kustomize/kustomizer_test.go
+++ b/pkg/lifecycle/kustomize/kustomizer_test.go
@@ -116,18 +116,15 @@ func Test_kustomizer_writeOverlay(t *testing.T) {
 		Overlay: path.Join("overlays", "ship"),
 	}
 
-	type args struct {
-		patches []patch.PatchStrategicMerge
-	}
 	tests := []struct {
-		name       string
-		patches    []patch.PatchStrategicMerge
-		expectFile string
-		wantErr    bool
+		name               string
+		relativePatchPaths []patch.PatchStrategicMerge
+		expectFile         string
+		wantErr            bool
 	}{
 		{
-			name:    "No patches",
-			patches: []patch.PatchStrategicMerge{},
+			name:               "No patches",
+			relativePatchPaths: []patch.PatchStrategicMerge{},
 			expectFile: `kind: ""
 apiversion: ""
 bases:
@@ -135,8 +132,8 @@ bases:
 `,
 		},
 		{
-			name:    "Patches provided",
-			patches: []patch.PatchStrategicMerge{"a.yaml", "b.yaml", "c.yaml"},
+			name:               "Patches provided",
+			relativePatchPaths: []patch.PatchStrategicMerge{"a.yaml", "b.yaml", "c.yaml"},
 			expectFile: `kind: ""
 apiversion: ""
 bases:
@@ -165,7 +162,7 @@ patchesStrategicMerge:
 				},
 				Daemon: mockDaemon,
 			}
-			if err := l.writeOverlay(mockFs, mockStep, tt.patches); (err != nil) != tt.wantErr {
+			if err := l.writeOverlay(mockFs, mockStep, tt.relativePatchPaths); (err != nil) != tt.wantErr {
 				t.Errorf("kustomizer.writeOverlay() error = %v, wantErr %v", err, tt.wantErr)
 			}
 


### PR DESCRIPTION
What I Did
------------
Migrate our built `kustomization.yaml` files to use the `patchesStrategicMerge` key rather than `patches`.

How I Did it
------------
- Update `kustomizer` and `patcher` packages to use new key/types in Kustomize structs
- Update respective unit/integration tests

How to verify it
------------
You can verify by running `kustomize build` against output and verifying the shape of that file is correct.

Description for the Changelog
------------
- Update Kustomize code to use new PatchesStrategicMerge key


Picture of a Boat (not required but encouraged)
------------
🛶 











<!-- (thanks https://github.com/docker/docker for this template) -->

