### PR TITLE
if no namespace specified in helm opts use 'default'

### DIFF
--- a/pkg/lifecycle/render/helm/template.go
+++ b/pkg/lifecycle/render/helm/template.go
@@ -166,19 +166,13 @@ func (f *LocalTemplater) Template(
 
 // checks to see if the specified arg is present in the list. If it is not, adds it set to the specified value
 func addArgIfNotPresent(existingArgs []string, newArg string, newDefault string) []string {
-	argPresent := false
 	for _, arg := range existingArgs {
 		if arg == newArg {
-			argPresent = true
-			break
+			return existingArgs
 		}
 	}
 
-	if !argPresent {
-		existingArgs = append(existingArgs, newArg, newDefault)
-	}
-
-	return existingArgs
+	return append(existingArgs, newArg, newDefault)
 }
 
 func (f *LocalTemplater) appendHelmValues(

--- a/pkg/lifecycle/render/helm/template.go
+++ b/pkg/lifecycle/render/helm/template.go
@@ -149,6 +149,8 @@ func (f *LocalTemplater) Template(
 		templateArgs = append(templateArgs, args...)
 	}
 
+	templateArgs = addArgIfNotPresent(templateArgs, "--namespace", "default")
+
 	debug.Log("event", "helm.template")
 	if err := f.Commands.Template(chartRoot, templateArgs); err != nil {
 		debug.Log("event", "helm.template.err")
@@ -160,6 +162,23 @@ func (f *LocalTemplater) Template(
 		return err
 	}
 	return f.cleanUpAndOutputRenderedFiles(rootFs, asset, tempRenderedChartDir)
+}
+
+// checks to see if the specified arg is present in the list. If it is not, adds it set to the specified value
+func addArgIfNotPresent(existingArgs []string, newArg string, newDefault string) []string {
+	argPresent := false
+	for _, arg := range existingArgs {
+		if arg == newArg {
+			argPresent = true
+			break
+		}
+	}
+
+	if !argPresent {
+		existingArgs = append(existingArgs, newArg, newDefault)
+	}
+
+	return existingArgs
 }
 
 func (f *LocalTemplater) appendHelmValues(


### PR DESCRIPTION
What I Did
------------
Specified a namespace in calls to "helm template" so that when running in a kubernetes container the current namespace would not change the generated files.

How I Did it
------------
If a `--namespace` flag is not present in calls to `helm template`, one is added (with the value `default`)

How to verify it
------------
Run this container in ship cloud

Description for the Changelog
------------
fixed bug where helm templates would be made in the pod namespace when running within a kubernetes pod


Picture of a Boat (not required but encouraged)
------------



![USS Paulding (DD22)](https://upload.wikimedia.org/wikipedia/commons/3/35/Paulding_%28DD22%29._Starboard_side%2C_camouflaged%2C_1918_-_NARA_-_530782.jpg "USS Paulding (DD22)")








<!-- (thanks https://github.com/docker/docker for this template) -->

