### PR TITLE
Initial support for writing resources during kustomize

### DIFF
--- a/pkg/lifecycle/kustomize/daemonless.go
+++ b/pkg/lifecycle/kustomize/daemonless.go
@@ -74,7 +74,12 @@ func (l *Kustomizer) Execute(ctx context.Context, release *api.Release, step api
 		return err
 	}
 
-	err = l.writeOverlay(fs, step, relativePatchPaths)
+	relativeResourcePaths, err := l.writeResources(fs, shipOverlay, step.OverlayPath())
+	if err != nil {
+		return err
+	}
+
+	err = l.writeOverlay(fs, step, relativePatchPaths, relativeResourcePaths)
 	if err != nil {
 		return errors.Wrap(err, "write overlay")
 	}

--- a/pkg/lifecycle/kustomize/kustomizer_test.go
+++ b/pkg/lifecycle/kustomize/kustomizer_test.go
@@ -162,7 +162,7 @@ patchesStrategicMerge:
 				},
 				Daemon: mockDaemon,
 			}
-			if err := l.writeOverlay(mockFs, mockStep, tt.relativePatchPaths); (err != nil) != tt.wantErr {
+			if err := l.writeOverlay(mockFs, mockStep, tt.relativePatchPaths, nil); (err != nil) != tt.wantErr {
 				t.Errorf("kustomizer.writeOverlay() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
@@ -361,6 +361,57 @@ bases:
 - ../../base
 patchesStrategicMerge:
 - deployment.yaml
+`,
+				"base/kustomization.yaml": `kind: ""
+apiversion: ""
+resources:
+- deployment.yaml
+`,
+			},
+		},
+		{
+			name: "adding a resource",
+			kustomize: &state.Kustomize{
+				Overlays: map[string]state.Overlay{
+					"ship": {
+						Resources: map[string]string{
+							"/limitrange.yaml": `---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: mem-limit-range
+spec:
+  limits:
+  - default:
+      memory: 512Mi
+    defaultRequest:
+      memory: 256Mi
+    type: Container`,
+						},
+						KustomizationYAML: "",
+					},
+				},
+			},
+			expectFiles: map[string]string{
+				"overlays/ship/limitrange.yaml": `---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: mem-limit-range
+spec:
+  limits:
+  - default:
+      memory: 512Mi
+    defaultRequest:
+      memory: 256Mi
+    type: Container`,
+
+				"overlays/ship/kustomization.yaml": `kind: ""
+apiversion: ""
+bases:
+- ../../base
+resources:
+- limitrange.yaml
 `,
 				"base/kustomization.yaml": `kind: ""
 apiversion: ""

--- a/pkg/patch/patcher.go
+++ b/pkg/patch/patcher.go
@@ -202,7 +202,7 @@ func (p *ShipPatcher) ApplyPatch(patch []byte, step api.Kustomize, resource stri
 	}
 
 	kustomizationYaml := k8stypes.Kustomization{
-		Bases: []string{relativePathToBases},
+		Bases:                 []string{relativePathToBases},
 		PatchesStrategicMerge: []kustomizepatch.PatchStrategicMerge{TempYamlPath},
 	}
 

--- a/pkg/state/models.go
+++ b/pkg/state/models.go
@@ -99,6 +99,7 @@ func (l *Lifeycle) WithCompletedStep(step api.Step) *Lifeycle {
 
 type Overlay struct {
 	Patches           map[string]string `json:"patches,omitempty" yaml:"patches,omitempty" hcl:"patches,omitempty"`
+	Resources         map[string]string `json:"resources,omitempty" yaml:"resources,omitempty" hcl:"resources,omitempty"`
 	KustomizationYAML string            `json:"kustomization_yaml,omitempty" yaml:"kustomization_yaml,omitempty" hcl:"kustomization_yaml,omitempty"`
 }
 


### PR DESCRIPTION
What I Did
------------

Add support for reading additional resources from state.json and
including in kustomization.yaml


How I Did it
------------

dupe the `Kustomizer#writePatches` method to `Kustomize#writeResources`, and include the `relativeResourcePaths` in the overlays/ship/kustomization.yaml

How to verify it
------------

A little tricky right now, but in addition to unit tests, I tested writing `resources` to state.json mid-kustomize before finalizing.


Description for the Changelog
------------

Add support for reading additional kustomize `resources` from `state.json`


:boat: