### PR TITLE
add support for saving non-patch files like resources

### DIFF
--- a/pkg/lifecycle/daemon/routes_navcycle_kustomize_test.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_kustomize_test.go
@@ -1,0 +1,169 @@
+package daemon
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/go-test/deep"
+	"github.com/golang/mock/gomock"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
+	"github.com/replicatedhq/ship/pkg/state"
+	mockstate "github.com/replicatedhq/ship/pkg/test-mocks/state"
+	"github.com/replicatedhq/ship/pkg/testing/logger"
+	"github.com/replicatedhq/ship/pkg/testing/matchers"
+	"github.com/stretchr/testify/require"
+)
+
+type kustomizeSaveFileTestCase struct {
+	Name        string
+	InState     state.V1
+	Body        SaveOverlayRequest
+	ExpectState state.Kustomize
+}
+
+func TestV2KustomizeSaveFile(t *testing.T) {
+	tests := []kustomizeSaveFileTestCase{
+		{
+			Name: "empty add patch",
+			Body: SaveOverlayRequest{
+				Contents: "foo/bar/baz",
+				Path:     "deployment.yaml",
+			},
+			ExpectState: state.Kustomize{
+				Overlays: map[string]state.Overlay{
+					"ship": {
+						Patches: map[string]string{
+							"deployment.yaml": "foo/bar/baz",
+						},
+						Resources: map[string]string{},
+					},
+				},
+			},
+		},
+		{
+			Name: "empty add resource",
+			Body: SaveOverlayRequest{
+				Contents:   "foo/bar/baz",
+				Path:       "deployment.yaml",
+				IsResource: true,
+			},
+			ExpectState: state.Kustomize{
+				Overlays: map[string]state.Overlay{
+					"ship": {
+						Patches: map[string]string{},
+						Resources: map[string]string{
+							"deployment.yaml": "foo/bar/baz",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "add resource when patch exists",
+			Body: SaveOverlayRequest{
+				Contents:   "foo/bar/baz",
+				Path:       "service.yaml",
+				IsResource: true,
+			},
+			InState: state.V1{
+				Kustomize: &state.Kustomize{
+					Overlays: map[string]state.Overlay{
+						"ship": {
+							Patches: map[string]string{
+								"deployment.yaml": "foo/bar/baz",
+							},
+						},
+					},
+				},
+			},
+			ExpectState: state.Kustomize{
+				Overlays: map[string]state.Overlay{
+					"ship": {
+						Patches: map[string]string{
+							"deployment.yaml": "foo/bar/baz",
+						},
+						Resources: map[string]string{
+							"service.yaml": "foo/bar/baz",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "merge into existing",
+			Body: SaveOverlayRequest{
+				Contents:   "foo/bar/baz",
+				Path:       "service.yaml",
+				IsResource: true,
+			},
+			InState: state.V1{
+				Kustomize: &state.Kustomize{
+					Overlays: map[string]state.Overlay{
+						"ship": {
+							Resources: map[string]string{
+								"deployment.yaml": "foo/bar/baz",
+							},
+							Patches: map[string]string{
+								"deployment.yaml": "foo/bar/baz",
+							},
+						},
+					},
+				},
+			},
+			ExpectState: state.Kustomize{
+				Overlays: map[string]state.Overlay{
+					"ship": {
+						Resources: map[string]string{
+							"deployment.yaml": "foo/bar/baz",
+							"service.yaml":    "foo/bar/baz",
+						},
+						Patches: map[string]string{
+							"deployment.yaml": "foo/bar/baz",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			req := require.New(t)
+
+			mc := gomock.NewController(t)
+			fakeState := mockstate.NewMockManager(mc)
+			testLogger := &logger.TestLogger{T: t}
+			progressmap := &daemontypes.ProgressMap{}
+
+			v2 := &NavcycleRoutes{
+				Logger:       testLogger,
+				StateManager: fakeState,
+				StepProgress: progressmap,
+			}
+
+			fakeState.EXPECT().TryLoad().Return(state.VersionedState{
+				V1: &test.InState,
+			}, nil).AnyTimes()
+
+			fakeState.EXPECT().SaveKustomize(&matchers.Is{
+				Test: func(v interface{}) bool {
+					c, ok := v.(*state.Kustomize)
+					if !ok {
+						return false
+					}
+					diff := deep.Equal(&test.ExpectState, c)
+					if len(diff) != 0 {
+						fmt.Print(fmt.Sprintf("Failed diff compare with %s", strings.Join(diff, "\n")))
+						return false
+					}
+					return true
+				},
+				Describe: fmt.Sprintf("expect state equal to %s", test.ExpectState),
+			}).Return(nil).AnyTimes()
+
+			err := v2.kustomizeDoSaveOverlay(test.Body)
+			req.NoError(err)
+			mc.Finish()
+		})
+	}
+}

--- a/pkg/state/models.go
+++ b/pkg/state/models.go
@@ -103,19 +103,26 @@ type Overlay struct {
 	KustomizationYAML string            `json:"kustomization_yaml,omitempty" yaml:"kustomization_yaml,omitempty" hcl:"kustomization_yaml,omitempty"`
 }
 
+func NewOverlay() Overlay {
+	return Overlay{
+		Patches:   map[string]string{},
+		Resources: map[string]string{},
+	}
+}
+
 type Kustomize struct {
 	Overlays map[string]Overlay `json:"overlays,omitempty" yaml:"overlays,omitempty" hcl:"overlays,omitempty"`
 }
 
 func (k *Kustomize) Ship() Overlay {
 	if k.Overlays == nil {
-		return Overlay{}
+		return NewOverlay()
 	}
 	if ship, ok := k.Overlays["ship"]; ok {
 		return ship
 	}
 
-	return Overlay{}
+	return NewOverlay()
 }
 
 func (v VersionedState) CurrentKustomize() *Kustomize {


### PR DESCRIPTION
What I Did
------------

add support for saving non-patch files like resources

How I Did it
------------

Check for an `isResource` flag on the `kustomizeSaveOverlay` endpoint. If set, write to Resources instead of Patches.

How to verify it
------------

ship init, navigate to kustomize step, then

```
curl -X POST localhost:8800/api/v1/kustomize/save --data-binary '{
"path": "/fake.yaml",
"contents": "lol",
"isResource": true
}'
```

Then refresh browser and see resource showing

Description for the Changelog
------------

Add API support for saving non-patch files like resources

:rowboat: