### PR TITLE
fix empty 'env', 'args' and 'value' entries in generated helm yaml

### DIFF
--- a/pkg/lifecycle/render/helm/template.go
+++ b/pkg/lifecycle/render/helm/template.go
@@ -1,6 +1,8 @@
 package helm
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"path"
 	"path/filepath"
@@ -266,6 +268,11 @@ func (f *LocalTemplater) cleanUpAndOutputRenderedFiles(
 		return errors.Wrap(err, "unable to find tmp rendered chart")
 	}
 
+	err := f.validateGeneratedFiles(f.FS, tempRenderedChartDir)
+	if err != nil {
+		return errors.Wrapf(err, "unable to validate chart dir")
+	}
+
 	debug.Log("event", "readdir", "folder", tempRenderedChartTemplatesDir)
 	files, err := f.FS.ReadDir(tempRenderedChartTemplatesDir)
 	if err != nil {
@@ -346,4 +353,114 @@ func (f *LocalTemplater) writeStateHelmValuesTo(dest string, defaultValuesPath s
 	}
 
 	return nil
+}
+
+// validate each file to make sure that it conforms to the yaml spec
+// TODO replace this with an actual validation tool
+func (l *LocalTemplater) validateGeneratedFiles(
+	fs afero.Afero,
+	dir string,
+) error {
+	debug := level.Debug(log.With(l.Logger, "method", "validateGeneratedFiles"))
+
+	debug.Log("event", "readdir", "folder", dir)
+	files, err := fs.ReadDir(dir)
+	if err != nil {
+		debug.Log("event", "readdir.fail", "folder", dir)
+		return errors.Wrapf(err, "failed to read folder %s", dir)
+	}
+
+	for _, file := range files {
+		thisPath := filepath.Join(dir, file.Name())
+		if file.IsDir() {
+			err := l.validateGeneratedFiles(fs, thisPath)
+			if err != nil {
+				return err
+			}
+		} else {
+			contents, err := fs.ReadFile(thisPath)
+			if err != nil {
+				return errors.Wrapf(err, "failed to read file %s", thisPath)
+			}
+
+			scanner := bufio.NewScanner(bytes.NewReader(contents))
+
+			lines := []string{}
+			for scanner.Scan() {
+				lines = append(lines, scanner.Text())
+			}
+			if err := scanner.Err(); err != nil {
+				return errors.Wrapf(err, "failed to read lines from file %s", thisPath)
+			}
+
+			for idx, line := range lines {
+				if regexp.MustCompile(`^\s*args:\s*$`).MatchString(line) {
+					// line has `args:` and nothing else but whitespace
+					if !checkIsChild(line, nextLine(idx, lines)) {
+						// next line is not a child, so args has no contents, add an empty array
+						lines[idx] = line + " []"
+					}
+				} else if regexp.MustCompile(`^\s*env:\s*$`).MatchString(line) {
+					// line has `env:` and nothing else but whitespace
+					if !checkIsChild(line, nextLine(idx, lines)) {
+						// next line is not a child, so env has no contents, add an empty object
+						lines[idx] = line + " {}"
+					}
+				}
+			}
+
+			var outputFile bytes.Buffer
+			for idx, line := range lines {
+				if idx+1 != len(lines) || contents[len(contents)-1] == '\n' {
+					fmt.Fprintln(&outputFile, line)
+				} else {
+					// avoid adding trailing newlines
+					fmt.Fprintf(&outputFile, line)
+				}
+			}
+
+			err = fs.WriteFile(thisPath, outputFile.Bytes(), file.Mode())
+			if err != nil {
+				return errors.Wrapf(err, "failed to write file %s after fixup", thisPath)
+			}
+		}
+	}
+
+	return nil
+}
+
+// returns true if the second line is a child of the first
+func checkIsChild(firstLine, secondLine string) bool {
+	cutset := fmt.Sprintf(" \t")
+	firstIndentation := len(firstLine) - len(strings.TrimLeft(firstLine, cutset))
+	secondIndentation := len(secondLine) - len(strings.TrimLeft(secondLine, cutset))
+
+	if firstIndentation < secondIndentation {
+		// if the next line is more indented, it's a child
+		return true
+	}
+
+	if firstIndentation == secondIndentation {
+		if secondLine[secondIndentation] == '-' {
+			// if the next line starts with '-' and is on the same indentation, it's a child
+			return true
+		}
+	}
+
+	return false
+}
+
+// returns the next line after idx that is not entirely whitespace or a comment. If there are no lines meeting these criteria, returns ""
+func nextLine(idx int, lines []string) string {
+	if idx+1 >= len(lines) {
+		return ""
+	}
+
+	if len(strings.TrimSpace(lines[idx+1])) > 0 {
+		if strings.TrimSpace(lines[idx+1])[0] != '#' {
+			return lines[idx+1]
+		}
+	}
+
+	return nextLine(idx+1, lines)
 }

--- a/pkg/lifecycle/render/helm/template.go
+++ b/pkg/lifecycle/render/helm/template.go
@@ -359,11 +359,11 @@ func (f *LocalTemplater) writeStateHelmValuesTo(dest string, defaultValuesPath s
 
 // validate each file to make sure that it conforms to the yaml spec
 // TODO replace this with an actual validation tool
-func (l *LocalTemplater) validateGeneratedFiles(
+func (f *LocalTemplater) validateGeneratedFiles(
 	fs afero.Afero,
 	dir string,
 ) error {
-	debug := level.Debug(log.With(l.Logger, "method", "validateGeneratedFiles"))
+	debug := level.Debug(log.With(f.Logger, "method", "validateGeneratedFiles"))
 
 	debug.Log("event", "readdir", "folder", dir)
 	files, err := fs.ReadDir(dir)
@@ -375,7 +375,7 @@ func (l *LocalTemplater) validateGeneratedFiles(
 	for _, file := range files {
 		thisPath := filepath.Join(dir, file.Name())
 		if file.IsDir() {
-			err := l.validateGeneratedFiles(fs, thisPath)
+			err := f.validateGeneratedFiles(fs, thisPath)
 			if err != nil {
 				return err
 			}

--- a/pkg/lifecycle/render/helm/template.go
+++ b/pkg/lifecycle/render/helm/template.go
@@ -59,6 +59,8 @@ func NewTemplater(
 }
 
 var releaseNameRegex = regexp.MustCompile("[^a-zA-Z0-9\\-]")
+var argsLineRegex = regexp.MustCompile(`^\s*args:\s*$`)
+var envLineRegex = regexp.MustCompile(`^\s*env:\s*$`)
 
 // LocalTemplater implements Templater by using the Commands interface
 // from pkg/helm and creating the chart in place
@@ -394,13 +396,13 @@ func (l *LocalTemplater) validateGeneratedFiles(
 			}
 
 			for idx, line := range lines {
-				if regexp.MustCompile(`^\s*args:\s*$`).MatchString(line) {
+				if argsLineRegex.MatchString(line) {
 					// line has `args:` and nothing else but whitespace
 					if !checkIsChild(line, nextLine(idx, lines)) {
 						// next line is not a child, so args has no contents, add an empty array
 						lines[idx] = line + " []"
 					}
-				} else if regexp.MustCompile(`^\s*env:\s*$`).MatchString(line) {
+				} else if envLineRegex.MatchString(line) {
 					// line has `env:` and nothing else but whitespace
 					if !checkIsChild(line, nextLine(idx, lines)) {
 						// next line is not a child, so env has no contents, add an empty object

--- a/pkg/lifecycle/render/helm/template_test.go
+++ b/pkg/lifecycle/render/helm/template_test.go
@@ -483,6 +483,30 @@ func Test_validateGeneratedFiles(t *testing.T) {
 			},
 		},
 		{
+			name: "relevant_value_files",
+			dir:  "test",
+			inputFiles: []file{
+				{
+					path:     "test/something.yaml",
+					contents: `  value: {}`,
+				},
+				{
+					path:     "test/missingValue.yaml",
+					contents: `  value:`,
+				},
+			},
+			outputFiles: []file{
+				{
+					path:     "test/something.yaml",
+					contents: `  value: {}`,
+				},
+				{
+					path:     "test/missingValue.yaml",
+					contents: `  value: ""`,
+				},
+			},
+		},
+		{
 			name: "blank lines",
 			dir:  "test",
 			inputFiles: []file{


### PR DESCRIPTION
What I Did
------------
Wrote a basic tool to look through the yaml generated by helm and fix some obvious errors

How I Did it
------------
loop through every line in the files - if the only text is `env:`, `args:` or `value:`, verify that there is a child following this
if there is not, add `{}`, `[]` or `""` to the line to make it into k8s yaml that won't crash kustomize.

This is really rather ugly and I hope we find a better tool for it. I would prefer to either parse the AST (use k8s objects?) or use a linter.

How to verify it
------------


Description for the Changelog
------------
Patch a number of helm charts to not produce output that kustomize will not accept


Picture of a Boat (not required but encouraged)
------------


![USS Cassin (DD-43)](https://upload.wikimedia.org/wikipedia/commons/c/cd/USS_Cassin_%28DD-43%29_at_Queenstown%2C_Ireland%2C_circa_1918.jpg "USS Cassin (DD-43)")









<!-- (thanks https://github.com/docker/docker for this template) -->

