### PR TITLE
ship metadata should be a struct not a map[string]string

### DIFF
--- a/integration/base/conditional-asset/expected/.ship/state.json
+++ b/integration/base/conditional-asset/expected/.ship/state.json
@@ -6,8 +6,6 @@
     "contentSHA": "e935ace16aacb22dc0fc5eccb3e7cc44c25ae8ffeca805c434317449d595800a",
     "metadata": {
       "applicationType": "replicated.app",
-      "customerID": "",
-      "installationID": "",
       "releaseNotes": "",
       "version": ""
     }

--- a/integration/base/docker-push/expected/.ship/state.json
+++ b/integration/base/docker-push/expected/.ship/state.json
@@ -7,8 +7,6 @@
     "contentSHA": "f1a562de29d7dbb760c9d20382613a47bff882ecf71f21ad5f1c67bbffa9fedd",
     "metadata": {
       "applicationType": "replicated.app",
-      "customerID": "",
-      "installationID": "",
       "releaseNotes": "",
       "version": ""
     }

--- a/integration/base/helm-fetch/expected/.ship/state.json
+++ b/integration/base/helm-fetch/expected/.ship/state.json
@@ -4,8 +4,6 @@
     "contentSHA": "54e761100cb39926d58cb68ddc20437347240310f5cbdce01f00d7e085d4c2b1",
     "metadata": {
       "applicationType": "replicated.app",
-      "customerID": "",
-      "installationID": "",
       "releaseNotes": "",
       "version": ""
     }

--- a/integration/base/render-root/expected/.ship/state.json
+++ b/integration/base/render-root/expected/.ship/state.json
@@ -4,8 +4,6 @@
     "contentSHA": "43908c014adbcd9b9c7bd5eb548fc5086c7a9f85b009c70a16e2902097d73784",
     "metadata": {
       "applicationType": "replicated.app",
-      "customerID": "",
-      "installationID": "",
       "releaseNotes": "",
       "version": ""
     }

--- a/integration/init/git-root-directory/expected/.ship/state.json
+++ b/integration/init/git-root-directory/expected/.ship/state.json
@@ -6,7 +6,6 @@
     "upstream": "https://github.com/replicatedhq/test-chart-root-dir/tree/507feecae588c958ebe82bcf701b8be63f34ac9b/",
     "metadata": {
       "applicationType": "helm",
-      "icon": "",
       "name": "values-update",
       "releaseNotes": "test chart",
       "version": "0.1.0"

--- a/integration/update/basic/expected/.ship/state.json
+++ b/integration/update/basic/expected/.ship/state.json
@@ -14,7 +14,6 @@
     },
     "metadata": {
       "applicationType": "helm",
-      "icon": "",
       "name": "basic",
       "releaseNotes": "Update README.md",
       "version": "0.1.0"

--- a/integration/update/modify-chart/expected/.ship/state.json
+++ b/integration/update/modify-chart/expected/.ship/state.json
@@ -14,7 +14,6 @@
     },
     "metadata": {
       "applicationType": "helm",
-      "icon": "",
       "name": "modify-chart",
       "releaseNotes": "Update values.yaml",
       "version": "0.1.0"

--- a/integration/update/values-static/expected/.ship/state.json
+++ b/integration/update/values-static/expected/.ship/state.json
@@ -14,7 +14,6 @@
     },
     "metadata": {
       "applicationType": "helm",
-      "icon": "",
       "name": "values-update",
       "releaseNotes": "add static chart (will not be updated)",
       "version": "0.1.0"

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -77,12 +77,12 @@ func (m *MManager) SerializeShipMetadata(metadata api.ShipAppMetadata, applicati
 	}
 
 	versionedState := current.Versioned()
-	versionedState.V1.Metadata = map[string]string{
-		"applicationType": applicationType,
-		"releaseNotes":    metadata.ReleaseNotes,
-		"version":         metadata.Version,
-		"icon":            metadata.Icon,
-		"name":            metadata.Name,
+	versionedState.V1.Metadata = &Metadata{
+		ApplicationType: applicationType,
+		ReleaseNotes:    metadata.ReleaseNotes,
+		Version:         metadata.Version,
+		Icon:            metadata.Icon,
+		Name:            metadata.Name,
 	}
 
 	return m.serializeAndWriteState(versionedState)
@@ -99,12 +99,12 @@ func (m *MManager) SerializeAppMetadata(metadata api.ReleaseMetadata) error {
 	}
 
 	versionedState := current.Versioned()
-	versionedState.V1.Metadata = map[string]string{
-		"applicationType": "replicated.app",
-		"releaseNotes":    metadata.ReleaseNotes,
-		"customerID":      metadata.CustomerID,
-		"installationID":  metadata.InstallationID,
-		"version":         metadata.Semver,
+	versionedState.V1.Metadata = &Metadata{
+		ApplicationType: "replicated.app",
+		ReleaseNotes:    metadata.ReleaseNotes,
+		Version:         metadata.Semver,
+		CustomerID:      metadata.CustomerID,
+		InstallationID:  metadata.InstallationID,
 	}
 
 	return m.serializeAndWriteState(versionedState)

--- a/pkg/state/manager_test.go
+++ b/pkg/state/manager_test.go
@@ -429,12 +429,12 @@ func TestMManager_SerializeShipMetadata(t *testing.T) {
 			},
 			expected: VersionedState{
 				V1: &V1{
-					Metadata: map[string]string{
-						"applicationType": "mock application type",
-						"releaseNotes":    "",
-						"version":         "test version",
-						"icon":            "test icon",
-						"name":            "test name",
+					Metadata: &Metadata{
+						ApplicationType: "mock application type",
+						ReleaseNotes:    "",
+						Version:         "test version",
+						Icon:            "test icon",
+						Name:            "test name",
 					},
 				},
 			},

--- a/pkg/state/models.go
+++ b/pkg/state/models.go
@@ -60,13 +60,23 @@ type V1 struct {
 	HelmValuesDefaults string                 `json:"helmValuesDefaults,omitempty" yaml:"helmValuesDefaults,omitempty" hcl:"helmValuesDefaults,omitempty"`
 	Kustomize          *Kustomize             `json:"kustomize,omitempty" yaml:"kustomize,omitempty" hcl:"kustomize,omitempty"`
 	Upstream           string                 `json:"upstream,omitempty" yaml:"upstream,omitempty" hcl:"upstream,omitempty"`
-	Metadata           map[string]string      `json:"metadata" yaml:"metadata" hcl:"metadata"`
+	Metadata           *Metadata              `json:"metadata" yaml:"metadata" hcl:"metadata"`
 	//deprecated in favor of upstream
 	ChartURL     string    `json:"chartURL,omitempty" yaml:"chartURL,omitempty" hcl:"chartURL,omitempty"`
 	ChartRepoURL string    `json:"ChartRepoURL,omitempty" yaml:"ChartRepoURL,omitempty" hcl:"ChartRepoURL,omitempty"`
 	ChartVersion string    `json:"ChartVersion,omitempty" yaml:"ChartVersion,omitempty" hcl:"ChartVersion,omitempty"`
 	ContentSHA   string    `json:"contentSHA,omitempty" yaml:"contentSHA,omitempty" hcl:"contentSHA,omitempty"`
 	Lifecycle    *Lifeycle `json:"lifecycle,omitempty" yaml:"lifecycle,omitempty" hcl:"lifecycle,omitempty"`
+}
+
+type Metadata struct {
+	ApplicationType string `json:"applicationType" yaml:"applicationType" hcl:"applicationType"`
+	Icon            string `json:"icon,omitempty" yaml:"icon,omitempty" hcl:"icon,omitempty"`
+	Name            string `json:"name,omitempty" yaml:"name,omitempty" hcl:"name,omitempty"`
+	ReleaseNotes    string `json:"releaseNotes" yaml:"releaseNotes" hcl:"releaseNotes"`
+	Version         string `json:"version" yaml:"version" hcl:"version"`
+	CustomerID      string `json:"customerID,omitempty" yaml:"customerID,omitempty" hcl:"customerID,omitempty"`
+	InstallationID  string `json:"installationID,omitempty" yaml:"installationID,omitempty" hcl:"installationID,omitempty"`
 }
 
 type StepsCompleted map[string]interface{}


### PR DESCRIPTION
What I Did
------------
I changed the 'metadata' component of ship state into a struct, instead of a map[string]string. This will make it easier to keep usage consistent across upstreams.

How I Did it
------------
Refactor + fixing the integration tests that expected "" values

How to verify it
------------


Description for the Changelog
------------
Refactored state storage methodology


Picture of a Boat (not required but encouraged)
------------

![USS Aylwin (DD-47)](https://upload.wikimedia.org/wikipedia/commons/9/9a/USS_Aylwin_%28DD-47%29.jpg "USS Aylwin (DD-47)")










<!-- (thanks https://github.com/docker/docker for this template) -->

