### PR TITLE
updates for add resources workflow

### DIFF
--- a/pkg/filetree/loader.go
+++ b/pkg/filetree/loader.go
@@ -98,6 +98,10 @@ func (a *aferoLoader) LoadTree(root string) (*Node, error) {
 	}
 
 	populatedBase, err := a.loadTree(fs, rootNode, files)
+	if err != nil {
+		return nil, errors.Wrap(err, "load tree")
+	}
+
 	populatedPatches := a.loadOverlayTree(patchesRootNode, a.patches)
 	populatedResources := a.loadOverlayTree(resourceRootNode, a.resources)
 
@@ -115,7 +119,7 @@ func (a *aferoLoader) LoadTree(root string) (*Node, error) {
 		Path:     "/",
 		Name:     "/",
 		Children: children,
-	}, errors.Wrap(err, "load tree")
+	}, nil
 }
 
 // todo move this to a new struct or something

--- a/pkg/filetree/loader.go
+++ b/pkg/filetree/loader.go
@@ -19,7 +19,8 @@ import (
 
 const (
 	CustomResourceDefinition = "CustomResourceDefinition"
-	OverlaysFolder           = "overlays"
+	PatchesFolder            = "overlays"
+	ResourcesFolder          = "resources"
 )
 
 // A Loader returns a struct representation
@@ -85,18 +86,29 @@ func (a *aferoLoader) LoadTree(root string) (*Node, error) {
 		Name:     "/",
 		Children: []Node{},
 	}
-	overlayRootNode := Node{
+	patchesRootNode := Node{
 		Path:     "/",
-		Name:     OverlaysFolder,
+		Name:     PatchesFolder,
+		Children: []Node{},
+	}
+	resourceRootNode := Node{
+		Path:     "/",
+		Name:     ResourcesFolder,
 		Children: []Node{},
 	}
 
-	populatedKustomization := a.loadOverlayTree(overlayRootNode)
-	populated, err := a.loadTree(fs, rootNode, files)
-	children := []Node{populated}
+	populatedBase, err := a.loadTree(fs, rootNode, files)
+	populatedPatches := a.loadOverlayTree(patchesRootNode, a.patches)
+	populatedResources := a.loadOverlayTree(resourceRootNode, a.resources)
 
-	if len(populatedKustomization.Children) != 0 {
-		children = append(children, populatedKustomization)
+	children := []Node{populatedBase}
+
+	if len(populatedPatches.Children) != 0 {
+		children = append(children, populatedPatches)
+	}
+
+	if len(populatedResources.Children) != 0 {
+		children = append(children, populatedResources)
 	}
 
 	return &Node{
@@ -201,14 +213,10 @@ func (n Node) withChild(child Node) Node {
 	}
 }
 
-func (a *aferoLoader) loadOverlayTree(kustomizationNode Node) Node {
+func (a *aferoLoader) loadOverlayTree(kustomizationNode Node, files map[string]string) Node {
 	filledTree := &kustomizationNode
-	for patchPath := range a.patches {
+	for patchPath := range files {
 		splitPatchPath := strings.Split(patchPath, "/")[1:]
-		filledTree = a.createOverlayNode(filledTree, splitPatchPath)
-	}
-	for resourcePath := range a.resources {
-		splitPatchPath := strings.Split(resourcePath, "/")[1:]
 		filledTree = a.createOverlayNode(filledTree, splitPatchPath)
 	}
 	return *filledTree

--- a/pkg/filetree/loader_test.go
+++ b/pkg/filetree/loader_test.go
@@ -1,6 +1,7 @@
 package filetree
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"path"
 	"testing"
@@ -74,7 +75,7 @@ func TestAferoLoader(t *testing.T) {
 
 			testResources := make(map[string]string)
 			for _, resource := range test.Resources {
-				testPatches[resource.Key.(string)] = resource.Value.(string)
+				testResources[resource.Key.(string)] = resource.Value.(string)
 			}
 
 			mockState.EXPECT().TryLoad().Return(state.VersionedState{
@@ -97,8 +98,11 @@ func TestAferoLoader(t *testing.T) {
 				req.Regexp(test.ExpectErr, err.Error())
 				return
 			}
+			eq := EqualTrees(*tree, *test.Expect)
 
-			req.True(EqualTrees(*tree, *test.Expect))
+			expectTree, err := json.Marshal(test.Expect)
+			actualTree, err := json.Marshal(tree)
+			req.True(eq, "%s\n%s", string(expectTree), string(actualTree))
 		})
 	}
 }

--- a/pkg/filetree/test-cases/tests.yml
+++ b/pkg/filetree/test-cases/tests.yml
@@ -132,6 +132,22 @@
             - name: foo.txt
               path: /k/foo.txt
 
+- name: has a resource
+  resources:
+    /foo.txt: bar
+  expect:
+    name: /
+    path: /
+    children:
+    - name: /
+      path: /
+      children: []
+    - name: resources
+      path: /
+      children:
+      - name: foo.txt
+        path: /foo.txt
+
 - name: has an overlay
   touch:
     - foo.txt
@@ -248,5 +264,11 @@
         children:
         - name: foo.txt
           path: /bar/foo.txt
+    - name: resources
+      path: /
+      children:
+      - name: bar
+        path: /bar
+        children:
         - name: spam.txt
           path: /bar/spam.txt

--- a/pkg/lifecycle/daemon/routes_navcycle.go
+++ b/pkg/lifecycle/daemon/routes_navcycle.go
@@ -67,6 +67,7 @@ func (d *NavcycleRoutes) Register(group *gin.RouterGroup, release *api.Release) 
 	kustom.POST("finalize", d.kustomizeFinalize)
 	kustom.POST("patch", d.createOrMergePatch)
 	kustom.DELETE("patch", d.deletePatch)
+	kustom.DELETE("resource", d.deleteResource)
 	kustom.POST("apply", d.applyPatch)
 
 	conf := v1.Group("/config")

--- a/pkg/lifecycle/daemon/routes_navcycle_kustomize.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_kustomize.go
@@ -339,7 +339,7 @@ func (d *NavcycleRoutes) deletePatch(c *gin.Context) {
 	c.JSON(200, map[string]string{"status": "success"})
 }
 
-func (d *NavcycleRoutes) deleteFile(pathQueryParam string, filesMap func(overlay state.Overlay) map[string]string) error {
+func (d *NavcycleRoutes) deleteFile(pathQueryParam string, getFiles func(overlay state.Overlay) map[string]string) error {
 	debug := level.Debug(log.With(d.Logger, "struct", "daemon", "handler", "deleteFile"))
 	debug.Log("event", "state.load")
 	currentState, err := d.StateManager.TryLoad()
@@ -353,7 +353,7 @@ func (d *NavcycleRoutes) deleteFile(pathQueryParam string, filesMap func(overlay
 	}
 
 	shipOverlay := kustomize.Ship()
-	files := filesMap(shipOverlay)
+	files := getFiles(shipOverlay)
 
 	if len(files) == 0 {
 		return errors.New("no patches to delete")


### PR DESCRIPTION
What I Did
------------

Improvements for managing non-patch resources during Kustomize step.

How I Did it
------------

- In addition to `/` (base) and `overlays` (patches), include another `filetree.Node` in the return from `GET /api/v1/navcyle/step/kustomize`, called `resources`
- Include all added `resources` from state.json in this node.
- Add endpoint to delete a resource, refactoring out core delete logic into helper


How to verify it
------------

With ship running, add `resources` to `state.json`, try out `curl`s to `GET /api/v1/navcycle/step/kustomize` and `DELETE /api/v1/kustomize/resource/<filename>`

Description for the Changelog
------------

Improved API support for deleting resources.


:canoe: