### PR TITLE
Further improvements to helm template mangling

### DIFF
--- a/pkg/lifecycle/render/helm/template.go
+++ b/pkg/lifecycle/render/helm/template.go
@@ -65,6 +65,8 @@ var arrayLineRegex = regexp.MustCompile(`^\s*(args|volumes):\s*$`)
 var envLineRegex = regexp.MustCompile(`^\s*env:\s*$`)
 var valueLineRegex = regexp.MustCompile(`^\s*value:\s*$`)
 
+var nullValueLineRegex = regexp.MustCompile(`^(\s*value:)\s*null\s*$`)
+
 // LocalTemplater implements Templater by using the Commands interface
 // from pkg/helm and creating the chart in place
 type LocalTemplater struct {
@@ -449,6 +451,13 @@ func fixLines(lines []string) []string {
 			if !checkIsChild(line, nextLine(idx, lines)) {
 				// next line is not a child, so value has no contents, add an empty string
 				lines[idx] = line + ` ""`
+			}
+		} else if nullValueLineRegex.MatchString(line) {
+			// line has `value: null`
+			matches := nullValueLineRegex.FindStringSubmatch(line)
+
+			if len(matches) >= 2 && matches[0] == line {
+				lines[idx] = matches[1] + ` ""`
 			}
 		}
 	}

--- a/pkg/lifecycle/render/helm/template.go
+++ b/pkg/lifecycle/render/helm/template.go
@@ -61,7 +61,7 @@ func NewTemplater(
 
 var releaseNameRegex = regexp.MustCompile("[^a-zA-Z0-9\\-]")
 
-var argsLineRegex = regexp.MustCompile(`^\s*args:\s*$`)
+var arrayLineRegex = regexp.MustCompile(`^\s*(args|volumes):\s*$`)
 var envLineRegex = regexp.MustCompile(`^\s*env:\s*$`)
 var valueLineRegex = regexp.MustCompile(`^\s*value:\s*$`)
 
@@ -432,10 +432,10 @@ func fixFile(fs afero.Afero, thisPath string, mode os.FileMode) error {
 // applies all fixes to all lines provided
 func fixLines(lines []string) []string {
 	for idx, line := range lines {
-		if argsLineRegex.MatchString(line) {
-			// line has `args:` and nothing else but whitespace
+		if arrayLineRegex.MatchString(line) {
+			// line has `key:` and nothing else but whitespace
 			if !checkIsChild(line, nextLine(idx, lines)) {
-				// next line is not a child, so args has no contents, add an empty array
+				// next line is not a child, so this key has no contents, add an empty array
 				lines[idx] = line + " []"
 			}
 		} else if envLineRegex.MatchString(line) {

--- a/pkg/lifecycle/render/helm/template_test.go
+++ b/pkg/lifecycle/render/helm/template_test.go
@@ -551,7 +551,7 @@ func Test_validateGeneratedFiles(t *testing.T) {
 			dir:  "test",
 			inputFiles: []file{
 				{
-					path: "test/blank_line_env.yaml",
+					path: "test/comment_line_env.yaml",
 					contents: `
   env:
     #item
@@ -562,7 +562,7 @@ func Test_validateGeneratedFiles(t *testing.T) {
 `,
 				},
 				{
-					path: "test/blank_line_args.yaml",
+					path: "test/comment_line_args.yaml",
 					contents: `
   args:
     #item
@@ -575,7 +575,7 @@ func Test_validateGeneratedFiles(t *testing.T) {
 			},
 			outputFiles: []file{
 				{
-					path: "test/blank_line_env.yaml",
+					path: "test/comment_line_env.yaml",
 					contents: `
   env: {}
     #item
@@ -586,7 +586,7 @@ func Test_validateGeneratedFiles(t *testing.T) {
 `,
 				},
 				{
-					path: "test/blank_line_args.yaml",
+					path: "test/comment_line_args.yaml",
 					contents: `
   args: []
     #item
@@ -594,6 +594,68 @@ func Test_validateGeneratedFiles(t *testing.T) {
   args:
   #item
     item2
+`,
+				},
+			},
+		},
+		{
+			name: "null values",
+			dir:  "test",
+			inputFiles: []file{
+				{
+					path: "test/null_values.yaml",
+					contents: `
+  value: null
+    #item
+
+  value:
+    null
+
+  value:
+    value: null
+`,
+				},
+			},
+			outputFiles: []file{
+				{
+					path: "test/null_values.yaml",
+					contents: `
+  value: ""
+    #item
+
+  value:
+    null
+
+  value:
+    value: ""
+`,
+				},
+			},
+		},
+		{
+			name: "everything",
+			dir:  "test",
+			inputFiles: []file{
+				{
+					path: "test/everything.yaml",
+					contents: `
+  args:
+  env:
+  volumes:
+  value:
+  value: null
+`,
+				},
+			},
+			outputFiles: []file{
+				{
+					path: "test/everything.yaml",
+					contents: `
+  args: []
+  env: {}
+  volumes: []
+  value: ""
+  value: ""
 `,
 				},
 			},


### PR DESCRIPTION
What I Did
------------
Improved mangling of helm template output to allow kustomize to work on more repos, reducing the set of broken repos (not all of which are 'broken' so much as 'are not provided required values during test script')

Original:
```
stable/artifactory
stable/dask
stable/distribution
stable/elasticsearch-exporter
stable/external-dns
stable/filebeat
stable/gocd
stable/horovod
stable/janusgraph
stable/kong
stable/mission-control
stable/oauth2-proxy
stable/prometheus-node-exporter
stable/sentry
stable/spark
stable/spinnaker
stable/stolon
```
updated:
```
stable/dask 
stable/distribution 
stable/filebeat 
stable/gocd 
stable/horovod 
stable/janusgraph 
stable/kong 
stable/mission-control 
stable/prometheus-node-exporter 
stable/stolon 
```

This continues the work of https://github.com/replicatedhq/ship/pull/636

How I Did it
------------


How to verify it
------------
Run ship with the fixed helm charts

Description for the Changelog
------------
Patch more helm charts to not produce output that kustomize will not accept



Picture of a Boat (not required but encouraged)
------------


![USS O'brien DD-51](https://upload.wikimedia.org/wikipedia/commons/2/2d/USS_O%27brien_DD-51.jpg "USS O'brien DD-51")









<!-- (thanks https://github.com/docker/docker for this template) -->

