### PR TITLE
Allow ship to be pointed to git file paths

### DIFF
--- a/integration/init/git-single-file/expected/.ship/state.json
+++ b/integration/init/git-single-file/expected/.ship/state.json
@@ -1,0 +1,8 @@
+{
+  "v1": {
+    "config": {},
+    "upstream": "github.com/replicatedhq/test-charts/blob/3427d6997bd150c60caa00ba0298fdfe17e3ed04/plain-k8s/frontend-deployment.yaml",
+    "metadata": null,
+    "contentSHA": "9fa025c3fdbcc02c7de8e9c74c8058d16b2aada04917895685504b387563afda"
+  }
+}

--- a/integration/init/git-single-file/expected/base/kustomization.yaml
+++ b/integration/init/git-single-file/expected/base/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: ""
+apiversion: ""
+resources:
+- plain-k8s/frontend-deployment.yaml

--- a/integration/init/git-single-file/expected/base/plain-k8s/frontend-deployment.yaml
+++ b/integration/init/git-single-file/expected/base/plain-k8s/frontend-deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  selector:
+    matchLabels:
+      app: guestbook
+      tier: frontend
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: guestbook
+        tier: frontend
+    spec:
+      containers:
+      - name: php-redis
+        image: gcr.io/google-samples/gb-frontend:v4
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: GET_HOSTS_FROM
+          value: dns
+          # If your cluster config does not include a dns service, then to
+          # instead access environment variables to find service host
+          # info, comment out the 'value: dns' line above, and uncomment the
+          # line below:
+          # value: env
+        ports:
+        - containerPort: 80

--- a/integration/init/git-single-file/expected/overlays/ship/kustomization.yaml
+++ b/integration/init/git-single-file/expected/overlays/ship/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: ""
+apiversion: ""
+bases:
+- ../../base

--- a/integration/init/git-single-file/expected/rendered.yaml
+++ b/integration/init/git-single-file/expected/rendered.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: guestbook
+      tier: frontend
+  template:
+    metadata:
+      labels:
+        app: guestbook
+        tier: frontend
+    spec:
+      containers:
+      - env:
+        - name: GET_HOSTS_FROM
+          value: dns
+        image: gcr.io/google-samples/gb-frontend:v4
+        name: php-redis
+        ports:
+        - containerPort: 80
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi

--- a/integration/init/git-single-file/metadata.yaml
+++ b/integration/init/git-single-file/metadata.yaml
@@ -1,0 +1,3 @@
+upstream: "github.com/replicatedhq/test-charts/blob/3427d6997bd150c60caa00ba0298fdfe17e3ed04/plain-k8s/frontend-deployment.yaml"
+args: []
+skip_cleanup: false

--- a/pkg/specs/githubclient/client.go
+++ b/pkg/specs/githubclient/client.go
@@ -145,7 +145,9 @@ func (g *GithubClient) downloadAndExtractFiles(
 				}
 				basePathFound = true
 
-				fileName = strings.TrimPrefix(fileName, basePath)
+				if fileName != basePath {
+					fileName = strings.TrimPrefix(fileName, basePath)
+				}
 				outFile, err := g.fs.Create(filepath.Join(filePath, fileName))
 				if err != nil {
 					return errors.Wrapf(err, "extract tar gz, create")
@@ -177,7 +179,7 @@ func decodeGitHubURL(chartPath string) (owner string, repo string, branch string
 	branch = ""
 	path = ""
 	if len(splitPath) > 3 {
-		if splitPath[3] == "tree" {
+		if splitPath[3] == "tree" || splitPath[3] == "blob" {
 			branch = splitPath[4]
 			path = strings.Join(splitPath[5:], "/")
 		} else {

--- a/pkg/specs/githubclient/client_test.go
+++ b/pkg/specs/githubclient/client_test.go
@@ -3,7 +3,6 @@ package githubclient
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -144,12 +143,28 @@ var _ = Describe("GithubClient", func() {
 
 				err := gitClient.GetFiles(context.Background(), validGithubURLSingle, constants.HelmChartPath)
 
-				files, _ := gitClient.fs.ReadDir(path.Join(constants.HelmChartPath))
-				fmt.Println("files", files)
 				chart, err := gitClient.fs.ReadFile(path.Join(constants.HelmChartPath, "Chart.yaml"))
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(string(chart)).To(Equal("bar"))
+			})
+		})
+
+		Context("With a url path to a single nested file", func() {
+			It("should fetch and persist the file", func() {
+				validGithubURLSingle := "github.com/o/r/blob/master/templates/service.yml"
+				mockFs := afero.Afero{Fs: afero.NewMemMapFs()}
+				gitClient := &GithubClient{
+					client: client,
+					fs:     mockFs,
+					logger: log.NewNopLogger(),
+				}
+
+				err := gitClient.GetFiles(context.Background(), validGithubURLSingle, constants.HelmChartPath)
+				chart, err := gitClient.fs.ReadFile(path.Join(constants.HelmChartPath, "templates", "service.yml"))
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(string(chart)).To(Equal("service"))
 			})
 		})
 	})


### PR DESCRIPTION
What I Did
------------
- Allow ship to be pointed to git file paths

How I Did it
------------
- Add additional logic for how files are determined to be included from the tar

How to verify it
------------
- Tests
- `ship init github.com/scalyr/scalyr-agent-2/blob/master/k8s/scalyr-agent-2.yaml`

Description for the Changelog
------------
- Allow ship to be pointed to git file paths


Picture of a Boat (not required but encouraged)
------------
🛶 











<!-- (thanks https://github.com/docker/docker for this template) -->

