### PR TITLE
Remove watch dir after checking content sha

### DIFF
--- a/pkg/specs/interface.go
+++ b/pkg/specs/interface.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"net/url"
-	"os"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -90,7 +89,7 @@ func (r *Resolver) ReadContentSHAForWatch(ctx context.Context, upstream string) 
 	debug.Log("event", "apptype.inspect", "type", appType, "localPath", localPath)
 
 	defer func() {
-		if err := os.RemoveAll(localPath); err != nil {
+		if err := r.FS.RemoveAll(localPath); err != nil {
 			level.Error(r.Logger).Log("event", "remove watch dir", "err", err)
 		}
 	}()

--- a/pkg/specs/interface_test.go
+++ b/pkg/specs/interface_test.go
@@ -280,6 +280,7 @@ func TestResolver_ReadContentSHAForWatch(t *testing.T) {
 				appTypeInspector: inspector,
 				AppResolver:      resolver,
 				shaSummer:        test.shaSummer,
+				FS:               afero.Afero{Fs: afero.NewMemMapFs()},
 			}
 
 			sha, err := r.ReadContentSHAForWatch(ctx, test.upstream)


### PR DESCRIPTION
What I Did
------------
When `ship watch` sleeps, it should start with a clean filesystem each time. Currently, this was failing on the second pass if it was a go-getter url because there was no .git directory.

How I Did it
------------
Delete the directory immediately after checking the content sha in the watch command.

How to verify it
------------
Run watch on a ship app with a go-getter url and let the interval expire twice. There should be no more error.

Description for the Changelog
------------
- Fix a bug that would cause `watch` to crash on the second loop.


Picture of a Boat (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

