### PR TITLE
Create new resource via UI + version bump

### DIFF
--- a/web/init/package.json
+++ b/web/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replicatedhq/ship-init",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Shared component that contains the Ship Init app",
   "author": "Replicated, Inc.",
   "license": "Apache-2.0",

--- a/web/init/src/components/kustomize/kustomize_overlay/FileTree.jsx
+++ b/web/init/src/components/kustomize/kustomize_overlay/FileTree.jsx
@@ -14,7 +14,7 @@ export default class FileTree extends React.Component {
   render() {
     const { files, basePath, isRoot, selectedFile, handleFileSelect, handleDeleteOverlay, isOverlayTree, isResourceTree } = this.props;
     return (
-      <ul className={`${isRoot ? "FileTree-wrapper" : "u-marginLeft--normal"}`}>
+      <ul className={`${isRoot ? "FileTree-wrapper" : "u-marginLeft--normal"} u-position--relative`}>
         {files && files.map((file, i) => ( file.children && file.children.length ?
           <li key={`${file.path}-Directory-${i}`} className={`u-position--relative u-userSelect--none ${file.hasOverlay && "edited"}`}>
             <input type="checkbox" name={`sub-dir-${file.name}-${file.children.length}-${file.path}-${basePath}-${i}`} id={`sub-dir-${file.name}-${file.children.length}-${file.path}-${basePath}-${i}`} defaultChecked={true} />

--- a/web/init/src/scss/components/kustomize/KustomizeOverlay.scss
+++ b/web/init/src/scss/components/kustomize/KustomizeOverlay.scss
@@ -174,6 +174,34 @@
   }
 }
 
+.add-new-resource {
+  top: -10px;
+  .Input {
+    margin: 0 0 0 30px;
+    height: 20px;
+    font-size: 12px;
+    line-height: 2em;
+    background: #193B5B;
+    border: 0;
+    color: #fff;
+    width: 100%;
+    border: solid 1px;
+    border-radius: 2px;
+    border-color: rgba(255, 255, 255, 0.2);
+    &::placeholder {
+      color: rgba(255, 255, 255, 0.7);
+    }
+  }
+}
+
+.add-resource-link {
+  padding-left: 20px;
+  color: white;
+  &.hidden {
+    visibility: hidden;
+  }
+}
+
 
 /* ≥ 768px */
 @media screen and (min-width: 48em) {


### PR DESCRIPTION
What I Did
------------
Updated UI to included ability add a resource from the file tree vs just in state.json.
Bumped the version to include new delete + add resource feature on Kustomize step.

How I Did it
------------
Add "+ Resource" button to the sidebar, and saving new resource from path name provided.
Changed version in` package.json` to `1.4.1`.

How to verify it
------------
Run ship init, and go through the flow. At the kustomize step, add a new resource.
Look at `package.json`, or NPM.

Description for the Changelog
------------
Create new resource via UI.
Bumped ship init version.


Picture of a Boat (not required but encouraged)
------------
⛵️ 











<!-- (thanks https://github.com/docker/docker for this template) -->

