### PR TITLE
update terraform-aws-eks to 1.7.0

### DIFF
--- a/integration/base/amazon-eks/expected/installer/empty/empty.tf
+++ b/integration/base/amazon-eks/expected/installer/empty/empty.tf
@@ -28,7 +28,7 @@ variable "eks-cluster-name" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "1.4.0"
+  version = "1.7.0"
 
   cluster_name = "${var.eks-cluster-name}"
 

--- a/integration/base/amazon-eks/expected/installer/existing/existing_vpc.tf
+++ b/integration/base/amazon-eks/expected/installer/existing/existing_vpc.tf
@@ -41,7 +41,7 @@ variable "eks-cluster-name" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "1.4.0"
+  version = "1.7.0"
 
   cluster_name = "${var.eks-cluster-name}"
 

--- a/integration/base/amazon-eks/expected/installer/new/new_vpc.tf
+++ b/integration/base/amazon-eks/expected/installer/new/new_vpc.tf
@@ -87,7 +87,7 @@ variable "eks-cluster-name" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "1.4.0"
+  version = "1.7.0"
 
   cluster_name = "${var.eks-cluster-name}"
 

--- a/integration/init_app/amazon-eks-template/expected/installer/new/new_vpc.tf
+++ b/integration/init_app/amazon-eks-template/expected/installer/new/new_vpc.tf
@@ -87,7 +87,7 @@ variable "eks-cluster-name" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "1.4.0"
+  version = "1.7.0"
 
   cluster_name = "${var.eks-cluster-name}"
 

--- a/pkg/lifecycle/render/amazoneks/render_templates.go
+++ b/pkg/lifecycle/render/amazoneks/render_templates.go
@@ -91,7 +91,7 @@ variable "eks-cluster-name" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "1.4.0"
+  version = "1.7.0"
 
   cluster_name = "${var.eks-cluster-name}"
 

--- a/pkg/lifecycle/render/amazoneks/render_test.go
+++ b/pkg/lifecycle/render/amazoneks/render_test.go
@@ -180,7 +180,7 @@ variable "eks-cluster-name" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "1.4.0"
+  version = "1.7.0"
 
   cluster_name = "${var.eks-cluster-name}"
 
@@ -237,7 +237,7 @@ variable "eks-cluster-name" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "1.4.0"
+  version = "1.7.0"
 
   cluster_name = "${var.eks-cluster-name}"
 
@@ -308,7 +308,7 @@ variable "eks-cluster-name" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "1.4.0"
+  version = "1.7.0"
 
   cluster_name = "${var.eks-cluster-name}"
 
@@ -615,7 +615,7 @@ variable "eks-cluster-name" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "1.4.0"
+  version = "1.7.0"
 
   cluster_name = "${var.eks-cluster-name}"
 
@@ -689,7 +689,7 @@ variable "eks-cluster-name" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "1.4.0"
+  version = "1.7.0"
 
   cluster_name = "${var.eks-cluster-name}"
 
@@ -821,7 +821,7 @@ variable "eks-cluster-name" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "1.4.0"
+  version = "1.7.0"
 
   cluster_name = "${var.eks-cluster-name}"
 


### PR DESCRIPTION
What I Did
------------
Changed the EKS terraform module version from `1.4.0` to `1.7.0`.

How I Did it
------------
```
sed -i 's/1\.4\.0/1.7.0/g' `ag '1\.4\.0' pkg/ -l`
sed -i 's/1\.4\.0/1.7.0/g' `ag '1\.4\.0' integration/ -l`
```
How to verify it
------------


Description for the Changelog
------------
Updated terraform-aws-eks module to 1.7.0


Picture of a Boat (not required but encouraged)
------------


![USS Rowan (DD-64)](https://upload.wikimedia.org/wikipedia/commons/8/89/USSRowanDD64.jpg "USS Rowan (DD-64)")









<!-- (thanks https://github.com/docker/docker for this template) -->

