### PR TITLE
fix nil pointer panic

### DIFF
--- a/pkg/specs/replicatedapp/local.go
+++ b/pkg/specs/replicatedapp/local.go
@@ -81,7 +81,7 @@ func (r *resolver) loadLocalGithubFiles(localpath string, repoPath string) ([]Gi
 	var files []GithubFile
 	err := r.FS.Walk(localpath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return errors.Wrapf(err, "walk %s from %s", info, path)
+			return errors.Wrapf(err, "walk %+v from %s", info, path)
 		}
 
 		if info.IsDir() {

--- a/pkg/specs/replicatedapp/local.go
+++ b/pkg/specs/replicatedapp/local.go
@@ -81,7 +81,7 @@ func (r *resolver) loadLocalGithubFiles(localpath string, repoPath string) ([]Gi
 	var files []GithubFile
 	err := r.FS.Walk(localpath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return errors.Wrapf(err, "walk %s from %s", info.Name(), path)
+			return errors.Wrapf(err, "walk %s from %s", info, path)
 		}
 
 		if info.IsDir() {


### PR DESCRIPTION
What I Did
------------

Fix a nil pointer panic when walking local FS with `set-github-contents`

How I Did it
------------

Don't call `info.Name()`, it might be nil, just use `info`, and hope `path` has what we need.

How to verify it
------------

--set-github-contents with a non-existent base path

Description for the Changelog
------------

Fix a nil pointer panic when walking local FS with `set-github-contents`


:boat: