### PR TITLE
add parameter to allow for setting the path to terraform executable

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -64,6 +64,8 @@ func RootCmd() *cobra.Command {
 
 	cmd.PersistentFlags().String("upload-assets-to", "", "URL to upload assets to via HTTP PUT request. NOTE: this will cause the entire working directory to be uploaded to the specified URL, use with caution.")
 
+	cmd.PersistentFlags().String("terraform-exec-path", "terraform", "Path to a terraform executable on the system.")
+
 	cmd.PersistentFlags().String("resource-type", "", "upstream application resource type")
 	cmd.PersistentFlags().BoolP("prefer-git", "", false, "prefer the git protocol instead of using http apis")
 

--- a/pkg/lifecycle/terraform/daemonless.go
+++ b/pkg/lifecycle/terraform/daemonless.go
@@ -34,11 +34,12 @@ func NewDaemonlessTerraformer(
 	planner tfplan.PlanConfirmer,
 	viper *viper.Viper,
 ) lifecycle.Terraformer {
+	terraformPath := viper.GetString("terraform-exec-path")
 	return &DaemonlessTerraformer{
 		Logger:        logger,
 		PlanConfirmer: planner,
 		Terraform: func(cmdPath string) *exec.Cmd {
-			cmd := exec.Command("terraform")
+			cmd := exec.Command(terraformPath)
 			cmd.Dir = path.Join(constants.InstallerPrefixPath, cmdPath)
 			return cmd
 		},

--- a/pkg/lifecycle/terraform/terraformer.go
+++ b/pkg/lifecycle/terraform/terraformer.go
@@ -39,12 +39,13 @@ func NewTerraformer(
 	planner tfplan.PlanConfirmer,
 	viper *viper.Viper,
 ) lifecycle.Terraformer {
+	terraformPath := viper.GetString("terraform-exec-path")
 	return &ForkTerraformer{
 		Logger:        logger,
 		Daemon:        daemon,
 		PlanConfirmer: planner,
 		Terraform: func(cmdPath string) *exec.Cmd {
-			cmd := exec.Command("terraform")
+			cmd := exec.Command(terraformPath)
 			cmd.Dir = path.Join(constants.InstallerPrefixPath, cmdPath)
 			return cmd
 		},


### PR DESCRIPTION
What I Did
------------

add parameter to allow for setting the path to terraform executable

How I Did it
------------

Viper/pflags, updated default constructors

How to verify it
------------


```
sudo mv /usr/local/bin/terraform ~/Documents/terraform
ship app --runbook path/to/ship.yaml --terraform-exec-path=~/Documents/terraform
```

Description for the Changelog
------------

add parameter to allow for setting the path to terraform executable

:canoe: