### PR TITLE
temporarily skip online terraform tests

### DIFF
--- a/integration/base/terraform/metadata.yaml
+++ b/integration/base/terraform/metadata.yaml
@@ -2,3 +2,4 @@ customer_id: "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G"
 installation_id: "lZk73HnLmatQ-s1nk7l3Q3QKA45orDFi"
 release_version: "0.0.4-alpha"
 set_channel_name: "terraform"
+disable_online: true


### PR DESCRIPTION
What I Did
------------

Temporarily skip online terraform tests. This is gonna get an overhaul in #661, and then I'll turn it back on.

How I Did it
------------

add `disable_online` to metadata.yaml

How to verify it
------------

Run the integration tests, they'll pass now.

Description for the Changelog
------------

None

:boat: