### PR TITLE
Ship Init file::./ship.yaml

### DIFF
--- a/integration/init/just-ship-yaml/expected/.ship/state.json
+++ b/integration/init/just-ship-yaml/expected/.ship/state.json
@@ -1,0 +1,9 @@
+{
+  "v1": {
+    "config": {},
+    "releaseName": "ship",
+    "upstream": "https://github.com/replicatedhq/test-charts/tree/ebebc9e692db3caeadb308ddeec37e9565acba1e/just-ship-yaml",
+    "metadata": null,
+    "contentSHA": "b2234e03feee0754ad02d0a8542c467829da12d13407e268926771f6b560ac83"
+  }
+}

--- a/integration/init/just-ship-yaml/expected/installer/jasper_values.yaml
+++ b/integration/init/just-ship-yaml/expected/installer/jasper_values.yaml
@@ -1,0 +1,2 @@
+two_plus_two: 5
+service_type: 

--- a/integration/init/just-ship-yaml/metadata.yaml
+++ b/integration/init/just-ship-yaml/metadata.yaml
@@ -1,0 +1,3 @@
+upstream: "https://github.com/replicatedhq/test-charts/tree/ebebc9e692db3caeadb308ddeec37e9565acba1e/just-ship-yaml"
+args: []
+skip_cleanup: true

--- a/integration/init/just-ship-yaml/metadata.yaml
+++ b/integration/init/just-ship-yaml/metadata.yaml
@@ -1,3 +1,3 @@
 upstream: "https://github.com/replicatedhq/test-charts/tree/ebebc9e692db3caeadb308ddeec37e9565acba1e/just-ship-yaml"
-args: []
+args: ["--prefer-git"]
 skip_cleanup: true

--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -44,7 +44,7 @@ func App() *cobra.Command {
 	cmd.Flags().String("runbook", "", developerFlagUsage)
 	cmd.Flags().String("set-channel-name", "", developerFlagUsage)
 	cmd.Flags().String("set-channel-icon", "", developerFlagUsage)
-	cmd.Flags().String("set-github-contents", "", fmt.Sprintf("Specify a REPO:REPO_PATH:REF:LOCAL_PATH to override github checkouts to use a local path on the filesystem. %s. ", developerFlagUsage))
+	cmd.Flags().StringSlice("set-github-contents", []string{}, fmt.Sprintf("Specify a REPO:REPO_PATH:REF:LOCAL_PATH to override github checkouts to use a local path on the filesystem. %s. ", developerFlagUsage))
 
 	// Deprecated developer flags
 	cmd.Flags().String("studio-file", "", developerFlagUsage)

--- a/pkg/specs/apptype/determine_type.go
+++ b/pkg/specs/apptype/determine_type.go
@@ -130,6 +130,19 @@ func (r *inspector) determineTypeFromContents(
 		}
 	}
 
+	// if there's a ship.yaml, assume its a replicated.app
+	var isReplicatedApp bool
+	for _, filename := range []string{"ship.yaml", "ship.yml"} {
+		isReplicatedApp, err = r.fs.Exists(path.Join(finalPath, filename))
+		if err != nil {
+			return "", "", errors.Wrapf(err, "check for %s", filename)
+		}
+	}
+
+	if isReplicatedApp {
+		return "inline.replicated.app", finalPath, nil
+	}
+
 	// if there's a Chart.yaml, assume its a chart
 	isChart, err := r.fs.Exists(path.Join(finalPath, "Chart.yaml"))
 	if err != nil {


### PR DESCRIPTION
What I Did
------------

Support `ship init`-ing a file, directory or github URL that contains just a
ship YAML. We'll read the release from the `ship.yaml` instead of a
default release. We'll also skip the "copy the upstream into `./base`"
step for these apps.

How I Did it
------------

- Add new app type `inline.replicated.app`
- Check for `ship.yaml` in `apptype.Inspector`
- Add switch blocks for `inline.replicated.app`

How to verify it
------------

There's an integration test, but also you can now

```
ship init github.com/replicatedhq/test-charts/tree/master/just-ship-yaml
```

Description for the Changelog
------------

Add support for ship init file::./ship.yaml

:ship: