### PR TITLE
GitHub single file with gogetter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ integration/*/_test_*
 /overlays/
 /base/
 web/.state/
-rendered.yaml
+/rendered.yaml

--- a/integration/init/git-single-file-gogetter/expected/.ship/state.json
+++ b/integration/init/git-single-file-gogetter/expected/.ship/state.json
@@ -1,0 +1,9 @@
+{
+  "v1": {
+    "config": {},
+    "upstream": "github.com/replicatedhq/test-charts/blob/3427d6997bd150c60caa00ba0298fdfe17e3ed04/plain-k8s/frontend-deployment.yaml",
+    "metadata": null,
+    "releaseName": "ship",
+    "contentSHA": "9fa025c3fdbcc02c7de8e9c74c8058d16b2aada04917895685504b387563afda"
+  }
+}

--- a/integration/init/git-single-file-gogetter/expected/base/kustomization.yaml
+++ b/integration/init/git-single-file-gogetter/expected/base/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: ""
+apiversion: ""
+resources:
+- plain-k8s/frontend-deployment.yaml

--- a/integration/init/git-single-file-gogetter/expected/base/plain-k8s/frontend-deployment.yaml
+++ b/integration/init/git-single-file-gogetter/expected/base/plain-k8s/frontend-deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  selector:
+    matchLabels:
+      app: guestbook
+      tier: frontend
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: guestbook
+        tier: frontend
+    spec:
+      containers:
+      - name: php-redis
+        image: gcr.io/google-samples/gb-frontend:v4
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: GET_HOSTS_FROM
+          value: dns
+          # If your cluster config does not include a dns service, then to
+          # instead access environment variables to find service host
+          # info, comment out the 'value: dns' line above, and uncomment the
+          # line below:
+          # value: env
+        ports:
+        - containerPort: 80

--- a/integration/init/git-single-file-gogetter/expected/overlays/ship/kustomization.yaml
+++ b/integration/init/git-single-file-gogetter/expected/overlays/ship/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: ""
+apiversion: ""
+bases:
+- ../../base

--- a/integration/init/git-single-file-gogetter/expected/rendered.yaml
+++ b/integration/init/git-single-file-gogetter/expected/rendered.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: guestbook
+      tier: frontend
+  template:
+    metadata:
+      labels:
+        app: guestbook
+        tier: frontend
+    spec:
+      containers:
+      - env:
+        - name: GET_HOSTS_FROM
+          value: dns
+        image: gcr.io/google-samples/gb-frontend:v4
+        name: php-redis
+        ports:
+        - containerPort: 80
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi

--- a/integration/init/git-single-file-gogetter/metadata.yaml
+++ b/integration/init/git-single-file-gogetter/metadata.yaml
@@ -1,0 +1,3 @@
+upstream: "github.com/replicatedhq/test-charts/blob/3427d6997bd150c60caa00ba0298fdfe17e3ed04/plain-k8s/frontend-deployment.yaml"
+args: ["--prefer-git"]
+skip_cleanup: false

--- a/pkg/specs/apptype/determine_type.go
+++ b/pkg/specs/apptype/determine_type.go
@@ -78,10 +78,10 @@ func (r *inspector) DetermineApplicationType(
 		return r.determineTypeFromContents(ctx, upstream, githubClient)
 	}
 
-	upstream, subdir := gogetter.UntreeGithub(upstream)
+	upstream, subdir, isSingleFile := gogetter.UntreeGithub(upstream)
 	if gogetter.IsGoGettable(upstream) {
 		// get with go-getter
-		fetcher := gogetter.GoGetter{Logger: r.logger, FS: r.fs, Subdir: subdir}
+		fetcher := gogetter.GoGetter{Logger: r.logger, FS: r.fs, Subdir: subdir, IsSingleFile: isSingleFile}
 		return r.determineTypeFromContents(ctx, upstream, &fetcher)
 	}
 

--- a/pkg/specs/gogetter/go_getter.go
+++ b/pkg/specs/gogetter/go_getter.go
@@ -3,6 +3,7 @@ package gogetter
 import (
 	"context"
 	"fmt"
+	"os"
 	"path"
 	"path/filepath"
 
@@ -10,21 +11,28 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/hashicorp/go-getter"
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/ship/pkg/constants"
 	"github.com/replicatedhq/ship/pkg/util"
 	errors2 "github.com/replicatedhq/ship/pkg/util/errors"
 	"github.com/spf13/afero"
 )
 
 type GoGetter struct {
-	Logger log.Logger
-	FS     afero.Afero
-	Subdir string
+	Logger       log.Logger
+	FS           afero.Afero
+	Subdir       string
+	IsSingleFile bool
 }
 
 // TODO figure out how to copy files from host into afero filesystem for testing, or how to force go-getter to fetch into afero
 func (g *GoGetter) GetFiles(ctx context.Context, upstream, savePath string) (string, error) {
 	debug := level.Debug(g.Logger)
 	debug.Log("event", "gogetter.GetFiles", "upstream", upstream, "savePath", savePath)
+
+	if g.IsSingleFile {
+		debug.Log("event", "gogetter.GetSingleFile", "upstream", upstream, "savePath", savePath)
+		return g.GetSingleFile(ctx, upstream, savePath)
+	}
 
 	err := getter.GetAny(savePath, upstream)
 	if err != nil {
@@ -47,6 +55,28 @@ func (g *GoGetter) GetFiles(ctx context.Context, upstream, savePath string) (str
 	return filepath.Join(savePath, g.Subdir), nil
 }
 
+func (g *GoGetter) GetSingleFile(ctx context.Context, upstream, savePath string) (string, error) {
+	tmpDir := filepath.Join(constants.ShipPathInternalTmp, "gogetter-file")
+
+	err := getter.GetAny(tmpDir, upstream)
+	if err != nil {
+		return "", errors2.FetchFilesError{Message: err.Error()}
+	}
+	defer g.FS.RemoveAll(tmpDir)
+
+	err = g.FS.MkdirAll(filepath.Dir(filepath.Join(savePath, g.Subdir)), os.FileMode(0777))
+	if err != nil {
+		return "", errors.Wrap(err, "make path to move file to")
+	}
+
+	err = g.FS.Rename(filepath.Join(tmpDir, g.Subdir), filepath.Join(savePath, g.Subdir))
+	if err != nil {
+		return "", errors.Wrap(err, "move downloaded file to destination")
+	}
+
+	return savePath, nil
+}
+
 func IsGoGettable(path string) bool {
 	_, err := getter.Detect(path, "", getter.Detectors)
 	if err != nil {
@@ -58,10 +88,11 @@ func IsGoGettable(path string) bool {
 // if this path is a github path of the form `github.com/OWNER/REPO/tree/REF/SUBDIR` or `github.com/OWNER/REPO/SUBDIR`,
 // change it to the go-getter form of `github.com/OWNER/REPO?ref=REF//` with a default ref of master and return a subdir of SUBDIR
 // otherwise return the unmodified path
-func UntreeGithub(path string) (string, string) {
+// the final param is whether the github URL is a blob (and thus a single file)
+func UntreeGithub(path string) (string, string, bool) {
 	githubURL, err := util.ParseGithubURL(path, "master")
 	if err != nil {
-		return path, ""
+		return path, "", false
 	}
-	return fmt.Sprintf("github.com/%s/%s?ref=%s//", githubURL.Owner, githubURL.Repo, githubURL.Ref), githubURL.Subdir
+	return fmt.Sprintf("github.com/%s/%s?ref=%s//", githubURL.Owner, githubURL.Repo, githubURL.Ref), githubURL.Subdir, githubURL.IsBlob
 }

--- a/pkg/specs/gogetter/go_getter_test.go
+++ b/pkg/specs/gogetter/go_getter_test.go
@@ -47,6 +47,7 @@ func TestUntreeGithub(t *testing.T) {
 		path   string
 		want   string
 		subdir string
+		blob   bool
 	}{
 		{
 			name: "empty",
@@ -124,11 +125,18 @@ func TestUntreeGithub(t *testing.T) {
 			want:   "github.com/replicatedhq/ship?ref=master//",
 			subdir: "pkg/specs",
 		},
+		{
+			name:   "ship repo in pkg/specs dir at hash with www",
+			path:   "https://www.github.com/replicatedhq/ship/blob/atestsha/pkg/specs/chart.go",
+			want:   "github.com/replicatedhq/ship?ref=atestsha//",
+			subdir: "pkg/specs/chart.go",
+			blob:   true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got, subdir := UntreeGithub(tt.path); got != tt.want || subdir != tt.subdir {
-				t.Errorf("untreeGithub(%s) = %v, %v, want %v, %v", tt.path, got, subdir, tt.want, tt.subdir)
+			if got, subdir, blob := UntreeGithub(tt.path); got != tt.want || subdir != tt.subdir || blob != tt.blob {
+				t.Errorf("untreeGithub(%s) = %v, %v, %t want %v, %v, %t", tt.path, got, subdir, blob, tt.want, tt.subdir, tt.blob)
 			}
 		})
 	}

--- a/pkg/util/github.go
+++ b/pkg/util/github.go
@@ -12,9 +12,11 @@ type GithubURL struct {
 	Repo   string
 	Ref    string
 	Subdir string
+	IsBlob bool
 }
 
 var githubTreeRegex = regexp.MustCompile(`^[htps:/]*[w.]*github\.com/([^/?=]+)/([^/?=]+)/tree/([^/?=]+)/?(.*)$`)
+var githubBlobRegex = regexp.MustCompile(`^[htps:/]*[w.]*github\.com/([^/?=]+)/([^/?=]+)/blob/([^/?=]+)/?(.*)$`)
 var githubRegex = regexp.MustCompile(`^[htps:/]*[w.]*github\.com/([^/?=]+)/([^/?=]+)(/(.*))?$`)
 
 func ParseGithubURL(url string, defaultRef string) (GithubURL, error) {
@@ -25,6 +27,12 @@ func ParseGithubURL(url string, defaultRef string) (GithubURL, error) {
 		parsed.Repo = matches[2]
 		parsed.Ref = matches[3]
 		parsed.Subdir = matches[4]
+	} else if matches = githubBlobRegex.FindStringSubmatch(url); matches != nil && len(matches) == 5 {
+		parsed.Owner = matches[1]
+		parsed.Repo = matches[2]
+		parsed.Ref = matches[3]
+		parsed.Subdir = matches[4]
+		parsed.IsBlob = true
 	} else if matches = githubRegex.FindStringSubmatch(url); matches != nil && len(matches) == 5 {
 		parsed.Owner = matches[1]
 		parsed.Repo = matches[2]

--- a/pkg/util/github_test.go
+++ b/pkg/util/github_test.go
@@ -205,6 +205,17 @@ func TestParseGithubURL(t *testing.T) {
 				Subdir: "pkg/specs",
 			},
 		},
+		{
+			name: "ship repo in pkg/specs/chart.go file at hash with www",
+			path: "https://www.github.com/replicatedhq/ship/blob/atestsha/pkg/specs/chart.go",
+			want: GithubURL{
+				Owner:  "replicatedhq",
+				Repo:   "ship",
+				Ref:    "atestsha",
+				Subdir: "pkg/specs/chart.go",
+				IsBlob: true,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
What I Did
------------
Followup to https://github.com/replicatedhq/ship/pull/646
Allow fetching a single file from GitHub (via a 'blob' path) with `ship init` when using the go-getter fetcher (by passing the `--prefer-git` flag)

Also, our `.gitignore` no longer ignores `rendered.yaml` except in the root directory.

How I Did it
------------
When the URL is a GitHub blob url, the repo is cloned via go-getter into a temp directory, and then the single desired file is copied to the destination. The normal ship flow continues from that point.

How to verify it
------------
There are now two integration tests for this behavior - one with `--prefer-git`, one without.
You can also try running ship with a command like this one:
```
ship init --prefer-git https://github.com/replicatedhq/test-charts/blob/master/plain-k8s/redis-master-deployment.yaml
```

Description for the Changelog
------------
Github blob urls now work as upstreams when passing the `--prefer-git` flag.


Picture of a Boat (not required but encouraged)
------------

![USS Wickes (DD-75)](https://upload.wikimedia.org/wikipedia/commons/thumb/d/d6/Wickes_dd75.jpg/1600px-Wickes_dd75.jpg "USS Wickes (DD-75)")










<!-- (thanks https://github.com/docker/docker for this template) -->

