### PR TITLE
Fixed typing bug on app settings page

### DIFF
--- a/web/init/src/components/config_render/ConfigRender.jsx
+++ b/web/init/src/components/config_render/ConfigRender.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import keyBy from "lodash/keyBy";
+import debounce from "lodash/debounce";
 import _ from "lodash";
 
 import ConfigGroups from "./ConfigGroups";
@@ -12,6 +13,7 @@ export default class ConfigRender extends React.Component {
     this.state= {
       groups: this.props.fields
     }
+    this.triggerChange = debounce(this.triggerChange, 300);
   }
 
   triggerChange = (data) => {


### PR DESCRIPTION
What I Did
------------
Fixed the issue where typing fast in a field on the app settings page caused weird behavior. Whatever you typed would be overwritten by what you last typed. This was caused by the `triggerChange` method in the `ConfigRender.jsx` component, it was being called repeatedly on each keystroke.

How I Did it
------------
Debounced the `triggerChange` method by `300` milliseconds.

How to verify it
------------
Run the ship init flow with custom lifecycle settings, type in any field quickly (or hold down a key).

Description for the Changelog
------------
Fixed typing bug on app settings page fields.


Picture of a Boat (not required but encouraged)
------------
![dino doing a cool flip](https://media.giphy.com/media/iVqXV4vE4DDYk/giphy-downsized.gif)











<!-- (thanks https://github.com/docker/docker for this template) -->

