### PR TITLE
Fixed broken patch for multiple YAML docs

### DIFF
--- a/web/init/src/components/kustomize/kustomize_overlay/KustomizeOverlay.jsx
+++ b/web/init/src/components/kustomize/kustomize_overlay/KustomizeOverlay.jsx
@@ -8,6 +8,7 @@ import sortBy from "lodash/sortBy";
 import pick from "lodash/pick";
 import keyBy from "lodash/keyBy";
 import find from "lodash/find";
+import map from "lodash/map";
 import defaultTo from "lodash/defaultTo";
 import debounce from "lodash/debounce";
 
@@ -105,14 +106,15 @@ export default class KustomizeOverlay extends React.Component {
     const { selectedFile } = this.state;
     let file = find(this.props.fileContents, ["key", selectedFile]);
     if (!file) return;
-    file = yaml.safeLoad(file.baseContent)
-    const overlayFields = pick(file, "apiVersion", "kind", "metadata.name");
+    const files = yaml.safeLoadAll(file.baseContent);
+    const overlayFields = map(files, (file) => {
+      return pick(file, "apiVersion", "kind", "metadata.name")
+    });
     const overlay = yaml.safeDump(overlayFields);
     this.setState({ patch: `--- \n${overlay}` });
   }
 
   setSelectedFile = async (path) => {
-    console.log(path);
     this.setState({ selectedFile: path });
     await this.props.getFileContent(path).then(() => {
       // set state with new file content

--- a/web/init/src/scss/variables/variables.scss
+++ b/web/init/src/scss/variables/variables.scss
@@ -11,7 +11,7 @@ $navbar-background:        #ffffff;
 $navbar-label-color:       #323232;
 
 /* Sidebar */
-$sidebar-background:        #193B5B;
+$sidebar-background:        #124B71;
 $sidebar-label-color:       #ffffff;
 
 /* Buttons */


### PR DESCRIPTION
What I Did
------------
Fixed the bug where multiple YAML docs in a file were breaking patch creation. Updated config  sidebar color to match kustomize sidebar color.

How I Did it
------------
Used `safeLoadAll` in `createOverlay` method instead of `safeLoad` which assumes a single YAML doc.

How to verify it
------------
Run `ship init https://github.com/DivvyCloud/k8s-helm-chart/tree/master/divvycloud` and navigate to kustomize view. Create a patch using `services.yaml`.

Description for the Changelog
------------
Fixed broken patch creation for multiple YAML docs


Picture of a Boat (not required but encouraged)
------------
⛵️ 











<!-- (thanks https://github.com/docker/docker for this template) -->

