### PR TITLE
minor homebrew changes suggested by brew audit

### DIFF
--- a/deploy/.goreleaser.unstable.yml
+++ b/deploy/.goreleaser.unstable.yml
@@ -9,9 +9,9 @@ brew:
     name: homebrew-ship
   folder: Formula
   homepage: https://ship.replicated.com/
-  description: Deploy 3rd party applications through modern pipelines.
+  description: Deploy 3rd party applications through modern pipelines
   test: |
-    system "#{bin}/ship version"
+    system "#{bin}/ship", "version"
 builds:
 - goos:
   - linux

--- a/deploy/.goreleaser.yml
+++ b/deploy/.goreleaser.yml
@@ -9,9 +9,9 @@ brew:
     name: homebrew-ship
   folder: Formula
   homepage: https://ship.replicated.com/
-  description: Deploy 3rd party applications through modern pipelines.
+  description: Deploy 3rd party applications through modern pipelines
   test: |
-    system "#{bin}/ship version"
+    system "#{bin}/ship", "version"
 builds:
 - goos:
   - linux


### PR DESCRIPTION
What I Did
------------
I tested the Ship homebrew formula with brew audit, found two minor issues, and addressed them.
* Removed the period at the end of the description
* Separated the test string params

How I Did it
------------

I tested the Ship brew formula (which is deployed by goreleaser into https://github.com/replicatedhq/homebrew-ship/blob/master/Formula/ship.rb) by running `brew audit --new-formula ship`

Brew audit reported:
* C: 2: col 63: Description shouldn't end with a full stop
* Use `system "#{bin}/ship", "version"` instead of `system "#{bin}/ship version"` 


How to verify it
------------
run `brew tap replicatedhq/ship` to point homebrew at the existing formula
run `brew audit --new-formula ship` to test the formula
Find the local copy of the ship formula and make the necessary changes.  I found mine at '/usr/local/Homebrew/Library/Taps/replicatedhq/homebrew-ship/Formula/ship.rb'
run `brew audit --new-formula ship` again to verify that with these changes, no more errors are thrown.

Description for the Changelog
------------
Minor changes to Ship Homebrew formula to address feedback from 'brew audit'


Picture of a Boat (not required but encouraged)
------------
![bilbo-on-barrel-small](https://user-images.githubusercontent.com/1616680/47743403-3b8c5080-dc3c-11e8-8747-a87f75a0a51b.jpg)












<!-- (thanks https://github.com/docker/docker for this template) -->

