### PR TITLE
removing continue to next step from top

### DIFF
--- a/web/init/src/components/config_only/ConfigOnly.jsx
+++ b/web/init/src/components/config_only/ConfigOnly.jsx
@@ -218,7 +218,8 @@ export default class ConfigOnly extends React.Component {
                 }
               </div>
               <div className="flex-auto flex justifyContent--flexEnd layout-footer-actions">
-                <button type="button" disabled={dataLoading.saveAppSettingsLoading} onClick={this.handleConfigSave} className="btn primary">{dataLoading.saveAppSettingsLoading ? "Saving" : "Save changes"}</button>
+                <button type="button" disabled={dataLoading.saveAppSettingsLoading} onClick={this.handleConfigSave} className="btn primary u-marginRight--10">{dataLoading.saveAppSettingsLoading ? "Saving" : "Save changes"}</button>
+                <button type="button" disabled={!toastDetails.showToast} onClick={toastDetails.opts.confirmAction} className="btn primary">Continue to next step</button>
               </div>
             </div>
           </div>

--- a/web/init/src/components/shared/Toast.jsx
+++ b/web/init/src/components/shared/Toast.jsx
@@ -15,11 +15,6 @@ export default class Toast extends React.Component {
             {toast.subText && <div className="Toast-sub">{toast.subText}</div>}
           </div>
         </div>
-        <div className="flex-auto flex-column flex-verticalCenter">
-          <div className="flex">
-            <button onClick={toast.opts.confirmAction} className="btn primary">{toast.opts.confirmButtonText}</button>
-          </div>
-        </div>
       </div>
     );
   }


### PR DESCRIPTION
What I Did
------------
Removing "Continue to next step" button from the top of Config screen.

How I Did it
------------
Added "Continue to next step" to the bottom. Next to "Save changes" button.

How to verify it
------------
Run `./bin/ship init "replicated.app/travis?customer_id=<customer_id>&installation_id=<installation_id>"` and navigate to config screen. Both buttons should be at the bottom.

Description for the Changelog
------------
Removing "Continue to next step" button from the top.


Picture of a Boat (not required but encouraged)
------------

⛵️ 










<!-- (thanks https://github.com/docker/docker for this template) -->

