### PR TITLE
add build-minimal target and env options to enable git-free builds for homebrew

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,9 +261,9 @@ build: fmt embed-ui-dev test bin/ship
 
 build-ci: ci-embed-ui bin/ship
 
-build-ci-cypress: mark-ui-gitignored pkg/lifeycle/daemon/ui.bindatafs.go bin/ship
+build-ci-cypress: mark-ui-gitignored pkg/lifecycle/daemon/ui.bindatafs.go bin/ship
 
-build-minimal: bin/ship build-ui pkg/lifeycle/daemon/ui.bindatafs.go
+build-minimal: bin/ship build-ui pkg/lifecycle/daemon/ui.bindatafs.go
 
 bin/ship: $(FULLSRC)
 	go build \
@@ -290,7 +290,7 @@ run: build
 build_ship_integration_test:
 	docker build -t $(DOCKER_REPO)/ship-e2e-test:latest -f ./integration/Dockerfile .
 
-pkg/lifeycle/daemon/ui.bindatafs.go: .state/build-deps
+pkg/lifecycle/daemon/ui.bindatafs.go: .state/build-deps
 	go-bindata-assetfs -pkg daemon \
 	  -o pkg/lifecycle/daemon/ui.bindatafs.go \
 	  -prefix web/app \
@@ -300,11 +300,11 @@ mark-ui-gitignored:
 	cd pkg/lifecycle/daemon/; git update-index --assume-unchanged ui.bindatafs.go
 
 
-embed-ui: mark-ui-gitignored build-ui pkg/lifeycle/daemon/ui.bindatafs.go
+embed-ui: mark-ui-gitignored build-ui pkg/lifecycle/daemon/ui.bindatafs.go
 
-embed-ui-dev: mark-ui-gitignored build-ui-dev pkg/lifeycle/daemon/ui.bindatafs.go
+embed-ui-dev: mark-ui-gitignored build-ui-dev pkg/lifecycle/daemon/ui.bindatafs.go
 
-ci-embed-ui: mark-ui-gitignored pkg/lifeycle/daemon/ui.bindatafs.go
+ci-embed-ui: mark-ui-gitignored pkg/lifecycle/daemon/ui.bindatafs.go
 build-ui:
 	$(MAKE) -C web/app build_ship
 

--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ build-ci: ci-embed-ui bin/ship
 
 build-ci-cypress: mark-ui-gitignored pkg/lifecycle/daemon/ui.bindatafs.go bin/ship
 
-build-minimal: bin/ship build-ui pkg/lifecycle/daemon/ui.bindatafs.go
+build-minimal: build-ui pkg/lifecycle/daemon/ui.bindatafs.go bin/ship
 
 bin/ship: $(FULLSRC)
 	go build \


### PR DESCRIPTION
What I Did
------------
* Added a `build-minimal` make target (which builds the complete go binaries & skips some git-related hygiene steps)
* Added env-variable options for specifying VERSION and GIT_SHA when invoking make, so the homebrew build-from-source will work fine in a tarball that's not a git repo

How I Did it
------------


How to verify it
------------
make VERSION="0.21.0.testing" GIT_SHA="" build-minimal
make VERSION="0.21.0.testing" build-minimal
make build-minimal
etc...

Description for the Changelog
------------
add build-minimal target and env options to enable git-free builds for homebrew


Picture of a Boat (not required but encouraged)
------------
![concreteboatplans](https://user-images.githubusercontent.com/1616680/47880858-a925b180-dde1-11e8-9f78-11fc94f0726d.JPG)












<!-- (thanks https://github.com/docker/docker for this template) -->

