### PR TITLE
use a fork of kustomize that fixes gvk sorting

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1922,7 +1922,7 @@
   revision = "045dc31ee5c40e8240241ce28dc24d7b56130373"
 
 [[projects]]
-  digest = "1:fbbfb3bb08bd57bcfc4e3d6b7ead630e442343a46ac544cf965b5ce80070e2a5"
+  digest = "1:0b765e5515d191f0a74f7ebbb5e5c9cf66a3623b5b72cb6316aaa56092e6a0fc"
   name = "sigs.k8s.io/kustomize"
   packages = [
     "pkg/app",
@@ -1942,8 +1942,8 @@
     "pkg/types",
   ]
   pruneopts = "UT"
-  revision = "58492e2d83c59ed63881311f46ad6251f77dabc3"
-  version = "v1.0.8"
+  revision = "747fc669ce76213f980d6542951962142b8d0b1d"
+  source = "https://github.com/laverya/kustomize.git"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -82,7 +82,9 @@ ignored = [
 
 [[constraint]]
   name = "sigs.k8s.io/kustomize"
-  version = "1.0.8"
+  #1.0.8 but includes a GVK sorting patch
+  revision = "747fc669ce76213f980d6542951962142b8d0b1d"
+  source = "https://github.com/laverya/kustomize.git"
 
 [[override]]
   name = "k8s.io/kubernetes"

--- a/vendor/sigs.k8s.io/kustomize/pkg/resmap/idslice.go
+++ b/vendor/sigs.k8s.io/kustomize/pkg/resmap/idslice.go
@@ -51,7 +51,9 @@ func gvkLess(i, j schema.GroupVersionKind) bool {
 	indexi, foundi := typeOrders[i.Kind]
 	indexj, foundj := typeOrders[j.Kind]
 	if foundi && foundj {
-		return indexi < indexj
+		if indexi != indexj {
+			return indexi < indexj
+		}
 	}
 	if foundi && !foundj {
 		return true


### PR DESCRIPTION
What I Did
------------
Set the kustomize version to be from a fork that has a fix to the GVK comparison function
until kustomize merges that patch and we can update to the latest kustomize version

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------
Improve ordering of Kustomize output


Picture of a Boat (not required but encouraged)
------------

![USS Farragut (DD-348)](https://upload.wikimedia.org/wikipedia/commons/e/ef/USS_Farragut_%28DD-348%29_underway_at_sea_on_14_September_1936.jpg "USS Farragut (DD-348)")










<!-- (thanks https://github.com/docker/docker for this template) -->

