### PR TITLE
use the dynamic render root for the kubectl apply step

### DIFF
--- a/pkg/lifecycle/kubectl/daemonless.go
+++ b/pkg/lifecycle/kubectl/daemonless.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/ship/pkg/api"
-	"github.com/replicatedhq/ship/pkg/constants"
 	"github.com/replicatedhq/ship/pkg/lifecycle"
 	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 	"github.com/replicatedhq/ship/pkg/templates"
@@ -58,7 +57,7 @@ func (d *DaemonlessKubectl) Execute(ctx context.Context, release api.Release, st
 	}
 
 	cmd := exec.Command("kubectl")
-	cmd.Dir = constants.InstallerPrefixPath
+	cmd.Dir = release.FindRenderRoot()
 	cmd.Args = append(cmd.Args, "apply", "-f", step.Path)
 	if step.Kubeconfig != "" {
 		cmd.Args = append(cmd.Args, "--kubeconfig", builtKubePath)

--- a/pkg/lifecycle/kubectl/kubectl.go
+++ b/pkg/lifecycle/kubectl/kubectl.go
@@ -13,7 +13,6 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/ship/pkg/api"
-	"github.com/replicatedhq/ship/pkg/constants"
 	"github.com/replicatedhq/ship/pkg/lifecycle"
 	"github.com/replicatedhq/ship/pkg/lifecycle/daemon"
 	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
@@ -63,7 +62,7 @@ func (k *ForkKubectl) Execute(ctx context.Context, release api.Release, step api
 	}
 
 	cmd := exec.Command("kubectl")
-	cmd.Dir = constants.InstallerPrefixPath
+	cmd.Dir = release.FindRenderRoot()
 	cmd.Args = append(cmd.Args, "apply", "-f", step.Path)
 	if step.Kubeconfig != "" {
 		cmd.Args = append(cmd.Args, "--kubeconfig", builtKubePath)


### PR DESCRIPTION
What I Did
------------
Instead of using `constants.InstallerPrefixPath`, the root of the kubectl command will instead be the render root.

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------
fix running `kubectl apply` when the render root is not 'installer'


Picture of a Boat (not required but encouraged)
------------


![USS Dewey (DD-349)](https://upload.wikimedia.org/wikipedia/commons/0/0f/USSDeweyDD349.jpg "USS Dewey (DD-349)")









<!-- (thanks https://github.com/docker/docker for this template) -->

