### PR TITLE
Update README.md to refer to 0.22.0 not 0.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ There are two ways you can get started with Ship:
 Ship is packaged as a single binary, and Linux and MacOS versions are distributed:
 - To download the latest Linux build, run:
 ```shell
-curl -sSL https://github.com/replicatedhq/ship/releases/download/v0.16.0/ship_0.16.0_linux_amd64.tar.gz | tar xv && sudo mv ship /usr/local/bin
+curl -sSL https://github.com/replicatedhq/ship/releases/download/v0.22.0/ship_0.22.0_linux_amd64.tar.gz | tar xv && sudo mv ship /usr/local/bin
 ```
 
 - To download the latest MacOS build, run:
 ```shell
-curl -sSL https://github.com/replicatedhq/ship/releases/download/v0.16.0/ship_0.16.0_darwin_amd64.tar.gz | tar xv && sudo mv ship /usr/local/bin
+curl -sSL https://github.com/replicatedhq/ship/releases/download/v0.22.0/ship_0.22.0_darwin_amd64.tar.gz | tar xv && sudo mv ship /usr/local/bin
 ```
 
 Ship is also available through [Homebrew](https://brew.sh/):


### PR DESCRIPTION
What I Did
------------
Updated the readme's download links

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------


![USS Hull (DD-350)](https://upload.wikimedia.org/wikipedia/commons/7/72/USSHullDD350.jpg "USS Hull (DD-350)")









<!-- (thanks https://github.com/docker/docker for this template) -->

