### PR TITLE
Allow ship init to be pointed to valid go-getter ship.yaml path

### DIFF
--- a/integration/init/integration_test.go
+++ b/integration/init/integration_test.go
@@ -79,15 +79,18 @@ var _ = Describe("ship init with arbitrary upstream", func() {
 				}, 20)
 
 				It("Should output the expected files", func() {
+					replacements := map[string]string{}
 					absoluteUpstream := testMetadata.Upstream
+
 					if testMetadata.MakeAbsolute {
 						relativePath := testMetadata.Upstream
 						pwdRoot, err := os.Getwd()
 						Expect(err).NotTo(HaveOccurred())
 						pwdRoot, err = filepath.Abs(pwdRoot)
 						Expect(err).NotTo(HaveOccurred())
-						absoluteUpstream = fmt.Sprintf("file::%s", filepath.Join(pwdRoot, "..", relativePath))
-						fmt.Println("absolute upstream", absoluteUpstream)
+						absolutePath := filepath.Join(pwdRoot, "..")
+						absoluteUpstream = fmt.Sprintf("file::%s", filepath.Join(absolutePath, relativePath))
+						replacements["__upstream__"] = absolutePath
 					}
 					cmd := cli.RootCmd()
 					buf := new(bytes.Buffer)
@@ -102,7 +105,7 @@ var _ = Describe("ship init with arbitrary upstream", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					// compare the files in the temporary directory with those in the "expected" directory
-					result, err := integration.CompareDir(path.Join(testPath, "expected"), testOutputPath, map[string]string{})
+					result, err := integration.CompareDir(path.Join(testPath, "expected"), testOutputPath, replacements)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result).To(BeTrue())
 				}, 60)

--- a/integration/init/integration_test.go
+++ b/integration/init/integration_test.go
@@ -90,7 +90,7 @@ var _ = Describe("ship init with arbitrary upstream", func() {
 						Expect(err).NotTo(HaveOccurred())
 						absolutePath := filepath.Join(pwdRoot, "..")
 						absoluteUpstream = fmt.Sprintf("file::%s", filepath.Join(absolutePath, relativePath))
-						replacements["__upstream__"] = absolutePath
+						replacements["__upstream__"] = absoluteUpstream
 					}
 					cmd := cli.RootCmd()
 					buf := new(bytes.Buffer)

--- a/integration/init/local-single-file-gogetter/expected/.ship/state.json
+++ b/integration/init/local-single-file-gogetter/expected/.ship/state.json
@@ -2,7 +2,7 @@
   "v1": {
     "config": null,
     "releaseName": "ship",
-    "upstream": "file::/Users/robert/go/src/github.com/replicatedhq/ship/integration/init/local-single-file-gogetter/input/ship.yaml",
+    "upstream": "file::__upstream__/input/ship.yaml",
     "metadata": null,
     "contentSHA": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   }

--- a/integration/init/local-single-file-gogetter/expected/.ship/state.json
+++ b/integration/init/local-single-file-gogetter/expected/.ship/state.json
@@ -1,0 +1,9 @@
+{
+  "v1": {
+    "config": null,
+    "releaseName": "ship",
+    "upstream": "file::/Users/robert/go/src/github.com/replicatedhq/ship/integration/init/local-single-file-gogetter/input/ship.yaml",
+    "metadata": null,
+    "contentSHA": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  }
+}

--- a/integration/init/local-single-file-gogetter/expected/.ship/state.json
+++ b/integration/init/local-single-file-gogetter/expected/.ship/state.json
@@ -2,7 +2,7 @@
   "v1": {
     "config": null,
     "releaseName": "ship",
-    "upstream": "file::__upstream__/input/ship.yaml",
+    "upstream": "__upstream__",
     "metadata": null,
     "contentSHA": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   }

--- a/integration/init/local-single-file-gogetter/input/ship.yaml
+++ b/integration/init/local-single-file-gogetter/input/ship.yaml
@@ -1,0 +1,4 @@
+lifecycle:
+  v1:
+    - message:
+       contents: "test message"

--- a/integration/init/local-single-file-gogetter/metadata.yaml
+++ b/integration/init/local-single-file-gogetter/metadata.yaml
@@ -1,0 +1,4 @@
+upstream: "input/ship.yaml"
+make_absolute: true
+args: []
+skip_cleanup: false

--- a/pkg/specs/apptype/determine_type.go
+++ b/pkg/specs/apptype/determine_type.go
@@ -79,6 +79,9 @@ func (r *inspector) DetermineApplicationType(
 	}
 
 	upstream, subdir, isSingleFile := gogetter.UntreeGithub(upstream)
+	if !isSingleFile {
+		isSingleFile = gogetter.IsShipYaml(upstream)
+	}
 	if gogetter.IsGoGettable(upstream) {
 		// get with go-getter
 		fetcher := gogetter.GoGetter{Logger: r.logger, FS: r.fs, Subdir: subdir, IsSingleFile: isSingleFile}
@@ -137,10 +140,9 @@ func (r *inspector) determineTypeFromContents(
 		if err != nil {
 			return "", "", errors.Wrapf(err, "check for %s", filename)
 		}
-	}
-
-	if isReplicatedApp {
-		return "inline.replicated.app", finalPath, nil
+		if isReplicatedApp {
+			return "inline.replicated.app", finalPath, nil
+		}
 	}
 
 	// if there's a Chart.yaml, assume its a chart

--- a/pkg/specs/gogetter/go_getter.go
+++ b/pkg/specs/gogetter/go_getter.go
@@ -96,3 +96,8 @@ func UntreeGithub(path string) (string, string, bool) {
 	}
 	return fmt.Sprintf("github.com/%s/%s?ref=%s//", githubURL.Owner, githubURL.Repo, githubURL.Ref), githubURL.Subdir, githubURL.IsBlob
 }
+
+func IsShipYaml(path string) bool {
+	base := filepath.Base(path)
+	return base == "ship.yaml" || base == "ship.yml"
+}


### PR DESCRIPTION
What I Did
------------
- Allow ship init to be pointed to valid go-getter ship.yaml path

How I Did it
------------
- Point ship init to a ship.yaml

How to verify it
------------
Point `ship init` to valid go-getter ship.yaml path

Description for the Changelog
------------
Allow ship init to be pointed to valid go-getter ship.yaml path


Picture of a Boat (not required but encouraged)
------------
🛶 











<!-- (thanks https://github.com/docker/docker for this template) -->

