### PR TITLE
Add markdown formatting to outro screen

### DIFF
--- a/pkg/specs/chart.go
+++ b/pkg/specs/chart.go
@@ -99,7 +99,7 @@ func (r *Resolver) DefaultHelmRelease(chartPath string) api.Spec {
 				Contents: `
 Assets are ready to deploy. You can run
 
-kubectl apply -f rendered.yaml
+    kubectl apply -f rendered.yaml
 
 to deploy the overlaid assets to your cluster.
 `},
@@ -150,7 +150,7 @@ func (r *Resolver) DefaultRawRelease(basePath string) api.Spec {
 				Contents: `
 Assets are ready to deploy. You can run
 
-kubectl apply -f rendered.yaml
+    kubectl apply -f rendered.yaml
 
 to deploy the overlaid assets to your cluster.
 `},


### PR DESCRIPTION
What I Did
------------
Add the markdown formatting back to the outro step.

How I Did it
------------
Added some spaces.

How to verify it
------------
Look at the rendered ui.

Description for the Changelog
------------
- Fix: markdown formatting was missing on the outro step.


Picture of a Boat (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

