### PR TITLE
Only publish UI module from replicatedhq

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,9 +248,11 @@ jobs:
           name: publish
           working_directory: ~/ship/web/init
           command: |
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-            # Run publish npm module, will pull latest
-            npx publish
+            if [ "${CIRCLE_PROJECT_USERNAME}" == "replicatedhq" ]; then
+              echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+              # Run publish npm module, will pull latest
+              npx publish
+            fi
 
   deploy_unstable:
     docker:


### PR DESCRIPTION
What I Did
------------
Changed the CircleCI config to not attempt to publish the UI module from forks of this repo.

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------



![USS Macdonough (DD-351)](https://upload.wikimedia.org/wikipedia/commons/7/70/USSMacdonoughDD351.jpg "USS Macdonough (DD-351)")








<!-- (thanks https://github.com/docker/docker for this template) -->

