### PR TITLE
Unravel patch yaml on FE unless multi doc

### DIFF
--- a/web/init/src/components/kustomize/kustomize_overlay/KustomizeOverlay.jsx
+++ b/web/init/src/components/kustomize/kustomize_overlay/KustomizeOverlay.jsx
@@ -111,9 +111,12 @@ export default class KustomizeOverlay extends React.Component {
     let file = find(this.props.fileContents, ["key", selectedFile]);
     if (!file) return;
     const files = yaml.safeLoadAll(file.baseContent);
-    const overlayFields = map(files, (file) => {
+    let overlayFields = map(files, (file) => {
       return pick(file, "apiVersion", "kind", "metadata.name")
     });
+    if (files.length === 1) {
+      overlayFields = overlayFields[0];
+    }
     const overlay = yaml.safeDump(overlayFields);
     this.setState({ patch: `--- \n${overlay}` });
   }


### PR DESCRIPTION
What I Did
------------
- Unravel patch yaml unless multi doc

How I Did it
------------
- Check if multiple files are returned from loading all yaml
- If not, multiple - only return the first item

How to verify it
------------
- Run `ship init` patches will no longer display as lists

Description for the Changelog
------------
- Unravel patch yaml on FE unless multi doc


Picture of a Boat (not required but encouraged)
------------
🛶 











<!-- (thanks https://github.com/docker/docker for this template) -->

