### PR TITLE
Stop pinning ship-init to specific version

### DIFF
--- a/web/app/Makefile
+++ b/web/app/Makefile
@@ -13,6 +13,7 @@ $SRC = $(shell find . -path "./node_modules" -prune -o -path "./build" -prune -o
 		yarn --pure-lockfile && \
 		yarn build && \
 		yarn link
+		yarn link @replicatedhq/ship-init
 	@mkdir -p .state
 	@touch .state/package-init
 
@@ -21,6 +22,7 @@ $SRC = $(shell find . -path "./node_modules" -prune -o -path "./build" -prune -o
 		yarn --pure-lockfile && \
 		yarn build-dev && \
 		yarn link
+		yarn link @replicatedhq/ship-init
 	@mkdir -p .state
 	@touch .state/package-init-dev
 

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@replicatedhq/react-scripts": "1.0.1",
-    "@replicatedhq/ship-init": "1.4.1",
+    "@replicatedhq/ship-init": "link:../init",
     "monaco-editor": "^0.14.3",
     "react": "^16.5.0",
     "react-dom": "^16.5.0"

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -167,30 +167,9 @@
   optionalDependencies:
     fsevents "^1.1.3"
 
-"@replicatedhq/ship-init@1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@replicatedhq/ship-init/-/ship-init-1.4.1.tgz#96f0d4cd3cd17f66cc508d2a3b0bc6fab39d513c"
-  integrity sha512-dNHj5OL1kknzxRdPBatnVDBXGlZTwCrH06QFAf3QIeorfBLu6VluWTNYBskES4R90B0I7U4uTxcySlyEg1uwdg==
-  dependencies:
-    brace "^0.11.1"
-    history "^4.7.2"
-    isomorphic-fetch "^2.2.1"
-    lodash "^4.17.11"
-    rc-progress "^2.2.5"
-    react-ace "^6.1.4"
-    react-document-title "^2.0.3"
-    react-modal "^3.5.1"
-    react-monaco-editor "^0.18.0"
-    react-redux "^5.0.7"
-    react-remarkable "^1.1.3"
-    react-router-dom "^4.2.2"
-    react-router-hash-link "^1.2.0"
-    react-tooltip "^3.6.1"
-    redux "^3.7.2"
-    redux-segment "^1.6.2"
-    redux-thunk "2.2.0"
-    replicated-lint "^0.12.12"
-    yaml-ast-parser "^0.0.41"
+"@replicatedhq/ship-init@link:../init":
+  version "0.0.0"
+  uid ""
 
 "@types/blob-util@1.3.3":
   version "1.3.3"


### PR DESCRIPTION
What I Did
------------
Reverted web/app Makefile, package.json, yarn.lock changes, which were modified in attempting to fix standalone/Homebrew build issues by pinning a specific ship-init version.

How I Did it
------------


How to verify it
------------
Check that appropriate UI resources are included in local & circleci builds.

Description for the Changelog
------------
Restore embedded ship-init component to use latest code, rather than pinning to explicit version


Picture of a Boat (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

