### PR TITLE
Fixed weird typing issue and clear lastSavedPatch after discarding an overlay

### DIFF
--- a/web/init/package.json
+++ b/web/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replicatedhq/ship-init",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Shared component that contains the Ship Init app",
   "author": "Replicated, Inc.",
   "license": "Apache-2.0",

--- a/web/init/src/components/kustomize/kustomize_overlay/KustomizeOverlay.jsx
+++ b/web/init/src/components/kustomize/kustomize_overlay/KustomizeOverlay.jsx
@@ -165,7 +165,8 @@ export default class KustomizeOverlay extends React.Component {
     await this.deleteOverlay(overlayToDelete);
     this.setState({
       patch: "",
-      displayConfirmModal: false
+      displayConfirmModal: false,
+      lastSavedPatch: null
     });
   }
 
@@ -257,7 +258,7 @@ export default class KustomizeOverlay extends React.Component {
     this.aceEditorOverlay = editor;
   }
 
-  updateModifiedPatch = debounce((patch, isResource) => {
+  updateModifiedPatch = (patch, isResource) => {
     // We already circumvent React's lifecycle state system for updates
     // Set the current patch state to the changed value to avoid
     // React re-rendering the ACE Editor
@@ -265,7 +266,7 @@ export default class KustomizeOverlay extends React.Component {
       this.state.patch = patch; // eslint-disable-line
       this.handleApplyPatch();
     }
-  }, 500);
+  };
 
   handleAddResourceClick = async () => {
     // Ref input won't focus until state has been set
@@ -413,6 +414,7 @@ export default class KustomizeOverlay extends React.Component {
                           useSoftTabs: true,
                           tabSize: 2,
                         }}
+                        debounceChangePeriod={1000}
                         setOptions={{
                           scrollPastEnd: false
                         }}


### PR DESCRIPTION
What I Did
------------
Fixed weird typing issue and clear lastSavedPatch after discarding an overlay. React-ace editor has its own debounce prop that fires events after a person is done typing. We were using another debounce on top of this--so I removed it.

How I Did it
------------
^^

How to verify it
------------
Run ship init and type up a patch reasonably fast.

Description for the Changelog
------------
Fixed weird typing issue and clear lastSavedPatch after discarding an overlay


Picture of a Boat (not required but encouraged)
------------
⛵️ 











<!-- (thanks https://github.com/docker/docker for this template) -->

