### PR TITLE
reduce the number of integration tests using the github API

### DIFF
--- a/integration/init/lists/metadata.yaml
+++ b/integration/init/lists/metadata.yaml
@@ -1,3 +1,3 @@
 upstream: "github.com/replicatedhq/test-charts/multiple-list-yamls"
-args: []
+args: ["--prefer-git"]
 skip_cleanup: false

--- a/integration/update/app_basic/metadata.yaml
+++ b/integration/update/app_basic/metadata.yaml
@@ -1,3 +1,3 @@
-args: []
+args: ["--prefer-git"]
 
 skip_cleanup: false

--- a/integration/update/modify-chart/metadata.yaml
+++ b/integration/update/modify-chart/metadata.yaml
@@ -1,3 +1,3 @@
-args: []
+args: ["--prefer-git"]
 
 skip_cleanup: false

--- a/integration/update/values-static/metadata.yaml
+++ b/integration/update/values-static/metadata.yaml
@@ -1,3 +1,3 @@
-args: []
+args: ["--prefer-git"]
 
 skip_cleanup: false

--- a/integration/update/values-update/metadata.yaml
+++ b/integration/update/values-update/metadata.yaml
@@ -1,3 +1,3 @@
-args: []
+args: ["--prefer-git"]
 skip: true
 


### PR DESCRIPTION
What I Did
------------
Updated old integration tests to use go-getter when that does not reduce coverage of the integrated github client.

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------


![USS Worden (DD-352)](https://upload.wikimedia.org/wikipedia/commons/7/7a/USSWordenDD352.jpg "USS Worden (DD-352)")









<!-- (thanks https://github.com/docker/docker for this template) -->

