### PR TITLE
revert to last working circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,11 +248,9 @@ jobs:
           name: publish
           working_directory: ~/ship/web/init
           command: |
-            if [ "${CIRCLE_PROJECT_USERNAME}" == "replicatedhq" ]; then
-              echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-              # Run publish npm module, will pull latest
-              npx publish
-            fi
+            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+            # Run publish npm module, will pull latest
+            npx publish
 
   deploy_unstable:
     docker:


### PR DESCRIPTION
What I Did
------------
Reverted circleci config to the 5bc6745 version, that prevents publishing UI module from forks

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

