### PR TITLE
restore prev circle config to avoid npx-publishing forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,9 +248,11 @@ jobs:
           name: publish
           working_directory: ~/ship/web/init
           command: |
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-            # Run publish npm module, will pull latest
-            npx publish
+            if [ "${CIRCLE_PROJECT_USERNAME}" == "replicatedhq" ]; then
+              echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+              # Run publish npm module, will pull latest
+              npx publish
+            fi
 
   deploy_unstable:
     docker:


### PR DESCRIPTION
What I Did
------------
Restored the prior circleci config

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

