### PR TITLE
Return after abort, dont abort on bind, vet fixes

### DIFF
--- a/pkg/lifecycle/daemon/routes_navcycle_config.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_config.go
@@ -129,6 +129,7 @@ func (d *NavcycleRoutes) putAppConfig(release *api.Release) gin.HandlerFunc {
 		if err := d.StateManager.SerializeConfig(nil, api.ReleaseMetadata{}, templateContext); err != nil {
 			level.Error(d.Logger).Log("msg", "serialize state failed", "err", err)
 			c.AbortWithStatus(500)
+			return
 		}
 
 		d.CurrentConfig = templateContext

--- a/pkg/lifecycle/daemon/routes_navcycle_kustomize.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_kustomize.go
@@ -28,7 +28,6 @@ func (d *NavcycleRoutes) kustomizeSaveOverlay(c *gin.Context) {
 	var request SaveOverlayRequest
 	if err := c.BindJSON(&request); err != nil {
 		level.Error(d.Logger).Log("event", "unmarshal request failed", "err", err)
-		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
 
@@ -137,7 +136,6 @@ func (d *NavcycleRoutes) kustomizeGetFile(c *gin.Context) {
 	var request Request
 	if err := c.BindJSON(&request); err != nil {
 		level.Error(d.Logger).Log("event", "unmarshal request failed", "err", err)
-		c.AbortWithError(500, err)
 		return
 	}
 
@@ -207,7 +205,6 @@ func (d *NavcycleRoutes) applyPatch(c *gin.Context) {
 	debug.Log("event", "request.bind")
 	if err := c.BindJSON(&request); err != nil {
 		level.Error(d.Logger).Log("event", "unmarshal request body failed", "err", err)
-		c.AbortWithError(500, errors.New("internal_server_error"))
 		return
 	}
 
@@ -243,7 +240,6 @@ func (d *NavcycleRoutes) createOrMergePatch(c *gin.Context) {
 	debug.Log("event", "request.bind")
 	if err := c.BindJSON(&request); err != nil {
 		level.Error(d.Logger).Log("event", "unmarshal request body failed", "err", err)
-		c.AbortWithError(500, errors.New("internal_server_error"))
 		return
 	}
 

--- a/pkg/lifecycle/daemon/routes_v1.go
+++ b/pkg/lifecycle/daemon/routes_v1.go
@@ -109,6 +109,7 @@ func (d *V1Routes) saveHelmValues(c *gin.Context) {
 	debug.Log("event", "request.bind")
 	if err := c.BindJSON(&request); err != nil {
 		level.Error(d.Logger).Log("event", "unmarshal request body failed", "err", err)
+		return
 	}
 
 	debug.Log("event", "validate")
@@ -121,12 +122,14 @@ func (d *V1Routes) saveHelmValues(c *gin.Context) {
 
 		level.Error(d.Logger).Log("event", "values.readDefault.fail")
 		c.AbortWithError(http.StatusInternalServerError, errors.Wrap(err, "read file values.yaml"))
+		return
 	}
 
 	debug.Log("event", "serialize.helmValues")
 	if err := d.StateManager.SerializeHelmValues(request.Values, string(chartDefaultValues)); err != nil {
 		debug.Log("event", "seralize.helmValues.fail", "err", err)
 		c.AbortWithError(http.StatusInternalServerError, errors.New("internal_server_error"))
+		return
 	}
 
 	debug.Log("event", "serialize.helmReleaseName")
@@ -134,6 +137,7 @@ func (d *V1Routes) saveHelmValues(c *gin.Context) {
 		if err := d.StateManager.SerializeReleaseName(request.ReleaseName); err != nil {
 			debug.Log("event", "serialize.helmReleaseName.fail", "err", err)
 			c.AbortWithError(http.StatusInternalServerError, errors.New("internal_server_error"))
+			return
 		}
 	}
 	c.String(http.StatusOK, "")

--- a/pkg/lifecycle/daemon/routes_v1_kustomize.go
+++ b/pkg/lifecycle/daemon/routes_v1_kustomize.go
@@ -17,6 +17,7 @@ func (d *V1Routes) requireKustomize() gin.HandlerFunc {
 				400,
 				errors.Errorf("bad request: expected phase kustomize, was %q", d.currentStepName),
 			)
+			return
 		}
 		c.Next()
 

--- a/pkg/lifecycle/render/config/resolve/api.go
+++ b/pkg/lifecycle/render/config/resolve/api.go
@@ -71,11 +71,10 @@ func (r *APIConfigRenderer) shouldOverrideValueWithDefault(item *libyaml.ConfigI
 	// non-empty defaults
 	if firstPass {
 		return item.Hidden && item.Value == "" && item.Default != ""
-	} else {
-		// vendor can't override a default with "" in interactive mode
-		_, ok := savedState[item.Name]
-		return !ok && item.Value == "" && item.Default != ""
 	}
+	// vendor can't override a default with "" in interactive mode
+	_, ok := savedState[item.Name]
+	return !ok && item.Value == "" && item.Default != ""
 }
 
 func isRequired(item *libyaml.ConfigItem) bool {

--- a/pkg/util/github_test.go
+++ b/pkg/util/github_test.go
@@ -223,9 +223,8 @@ func TestParseGithubURL(t *testing.T) {
 			if err != nil {
 				if tt.wanterr {
 					return
-				} else {
-					t.Errorf("got unexpected error %s parsing %q", err.Error(), tt.path)
 				}
+				t.Errorf("got unexpected error %s parsing %q", err.Error(), tt.path)
 			}
 
 			if got != tt.want {


### PR DESCRIPTION
What I Did
------------
- Added missing returns after aborts in gin routes
- No longer abort 500 after bind errors
- Vet fixes

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

