### PR TITLE
Allow Helm values editor to be searchable

### DIFF
--- a/web/init/package.json
+++ b/web/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replicatedhq/ship-init",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Shared component that contains the Ship Init app",
   "author": "Replicated, Inc.",
   "license": "Apache-2.0",

--- a/web/init/src/components/kustomize/HelmValuesEditor.jsx
+++ b/web/init/src/components/kustomize/HelmValuesEditor.jsx
@@ -9,6 +9,7 @@ import find from "lodash/find";
 
 import "../../../node_modules/brace/mode/yaml";
 import "../../../node_modules/brace/theme/chrome";
+import "../../../node_modules/brace/ext/searchbox";
 
 export default class HelmValuesEditor extends React.Component {
   constructor(props) {


### PR DESCRIPTION
What I Did
------------
Import Brace extension to make Helm values editor searchable

How I Did it
------------
- Import brace extension

How to verify it
------------
Press CTRL+F while the Helm values editor is highlighted

Description for the Changelog
------------
- Allow Helm values editor to be searchable


Picture of a Boat (not required but encouraged)
------------
🛶 











<!-- (thanks https://github.com/docker/docker for this template) -->

