### PR TITLE
Only apply patch on editor marker click vs on key stroke

### DIFF
--- a/web/init/src/components/kustomize/kustomize_overlay/AceEditorHOC.jsx
+++ b/web/init/src/components/kustomize/kustomize_overlay/AceEditorHOC.jsx
@@ -51,13 +51,14 @@ export class AceEditorHOC extends React.Component {
     find(markers, ({ startRow, endRow }) => ( row >= startRow && row <= endRow ))
   )
 
-  addToOverlay = () => {
-    const { handleGeneratePatch } = this.props;
+  addToOverlay = async () => {
+    const { handleGeneratePatch, handleApplyPatch } = this.props;
     const { activeMarker } = this.state;
 
     if (activeMarker.length > 0) {
       const matchingMarker = activeMarker[0];
       const { path } = matchingMarker;
+      await handleApplyPatch().catch();
       handleGeneratePatch(path);
     }
   }

--- a/web/init/src/components/kustomize/kustomize_overlay/KustomizeOverlay.jsx
+++ b/web/init/src/components/kustomize/kustomize_overlay/KustomizeOverlay.jsx
@@ -311,7 +311,6 @@ export default class KustomizeOverlay extends React.Component {
     // React re-rendering the ACE Editor
     if (!isResource) {
       this.state.patch = patch; // eslint-disable-line
-      this.handleApplyPatch();
     }
   };
 
@@ -428,6 +427,7 @@ export default class KustomizeOverlay extends React.Component {
                               <ReactTooltip id="create-overlay-tooltip" effect="solid" className="replicated-tooltip">Create patch</ReactTooltip>
                               <AceEditorHOC
                                 handleGeneratePatch={this.handleGeneratePatch}
+                                handleApplyPatch={this.handleApplyPatch}
                                 fileToView={fileToView}
                                 diffOpen={this.state.viewDiff}
                                 overlayOpen={showOverlay}


### PR DESCRIPTION
What I Did
------------
Changed `KustomizeOverlay.jsx` so that `this.handleApplyPatch` only fires on an ace marker click vs on every keystroke + debounced.

How I Did it
------------
Passed `this.handleApplyPatch` down to `AceEditorHOC.jsx` and call it on `addToOverlay`.

How to verify it
------------
Run `ship init` with a helm chart.

Description for the Changelog
------------
Only apply patch on editor marker click vs on key stroke.


Picture of a Boat (not required but encouraged)
------------
⛵️ 










<!-- (thanks https://github.com/docker/docker for this template) -->

