### PR TITLE
Remove render requirement

### DIFF
--- a/pkg/specs/chart.go
+++ b/pkg/specs/chart.go
@@ -131,8 +131,7 @@ func (r *Resolver) DefaultRawRelease(basePath string) api.Spec {
 				{
 					Render: &api.Render{
 						StepShared: api.StepShared{
-							ID:       "render",
-							Requires: []string{"values"},
+							ID: "render",
 						},
 						Root: ".",
 					},


### PR DESCRIPTION
What I Did
------------
- Remove render requirement for k8s upstream

How I Did it
------------
- Remove render requirement for k8s upstream

How to verify it
------------
- Point `ship init` at k8s upstream

Description for the Changelog
------------
- Remove render requirement for k8s upstream


Picture of a Boat (not required but encouraged)
------------
🛶 











<!-- (thanks https://github.com/docker/docker for this template) -->

