### PR TITLE
run the four sets of integration tests in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ jobs:
             - /tmp/go/cache
           key: ship-unit-test-build-cache-{{ epoch }}
 
-  integration:
+  integration_base:
     machine: true
     working_directory: /home/circleci/go/src/github.com/replicatedhq/ship
     environment:
@@ -177,7 +177,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - ship-integration-test-build-cache
+            - ship-integration-test-build-cache-base
       - run: |
           export GO_DOWNLOAD_URL=https://dl.google.com/go/go1.10.4.linux-amd64.tar.gz
           export GOROOT=/usr/local/go
@@ -200,13 +200,134 @@ jobs:
           sudo $GOPATH/bin/registry serve integration/docker-registry.yaml > /dev/null 2>&1 &
           PORT=4569 http-echo-server > /dev/null 2>&1 &
           $GOPATH/bin/ginkgo -p -stream integration/base
-          $GOPATH/bin/ginkgo -p -stream integration/update
-          $GOPATH/bin/ginkgo -p -stream integration/init
-          $GOPATH/bin/ginkgo -p -stream integration/init_app
       - save_cache:
           paths:
             - /tmp/go/cache
-          key: ship-integration-test-build-cache-{{ epoch }}
+          key: ship-integration-test-build-cache-base-{{ epoch }}
+
+  integration_init:
+    machine: true
+    working_directory: /home/circleci/go/src/github.com/replicatedhq/ship
+    environment:
+      GOPATH: /home/circleci/go
+      GO_SHA256SUM: fa04efdb17a275a0c6e137f969a1c4eb878939e91e1da16060ce42f02c2ec5ec
+      GO: /usr/local/go/bin/go
+      GOCACHE: "/tmp/go/cache"
+    steps:
+    - checkout
+    - restore_cache:
+        keys:
+        - ship-integration-test-build-cache-init
+    - run: |
+        export GO_DOWNLOAD_URL=https://dl.google.com/go/go1.10.4.linux-amd64.tar.gz
+        export GOROOT=/usr/local/go
+        export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+        sudo apt update --fix-missing
+        sudo apt install --no-install-recommends -y gcc
+        curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+        sudo apt-get install -y nodejs
+        sudo npm install -g http-echo-server
+        wget "$GO_DOWNLOAD_URL" -O golang.tar.gz
+        echo "${GO_SHA256SUM}  golang.tar.gz" | sha256sum -c -
+        tar -zxvf golang.tar.gz -C /tmp
+        sudo rm -rf ${GOROOT}
+        sudo mv /tmp/go ${GOROOT}
+    - run: $GO get github.com/onsi/ginkgo/ginkgo
+    - run: $GO get github.com/docker/distribution/cmd/registry
+    - run: sudo ./hack/get_run_deps.sh
+    - run: sudo mkdir -p /var/lib/registry
+    - run: |
+        sudo $GOPATH/bin/registry serve integration/docker-registry.yaml > /dev/null 2>&1 &
+        PORT=4569 http-echo-server > /dev/null 2>&1 &
+        $GOPATH/bin/ginkgo -p -stream integration/init
+    - save_cache:
+        paths:
+        - /tmp/go/cache
+        key: ship-integration-test-build-cache-init-{{ epoch }}
+
+
+
+  integration_init_app:
+    machine: true
+    working_directory: /home/circleci/go/src/github.com/replicatedhq/ship
+    environment:
+      GOPATH: /home/circleci/go
+      GO_SHA256SUM: fa04efdb17a275a0c6e137f969a1c4eb878939e91e1da16060ce42f02c2ec5ec
+      GO: /usr/local/go/bin/go
+      GOCACHE: "/tmp/go/cache"
+    steps:
+    - checkout
+    - restore_cache:
+        keys:
+        - ship-integration-test-build-cache-init-app
+    - run: |
+        export GO_DOWNLOAD_URL=https://dl.google.com/go/go1.10.4.linux-amd64.tar.gz
+        export GOROOT=/usr/local/go
+        export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+        sudo apt update --fix-missing
+        sudo apt install --no-install-recommends -y gcc
+        curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+        sudo apt-get install -y nodejs
+        sudo npm install -g http-echo-server
+        wget "$GO_DOWNLOAD_URL" -O golang.tar.gz
+        echo "${GO_SHA256SUM}  golang.tar.gz" | sha256sum -c -
+        tar -zxvf golang.tar.gz -C /tmp
+        sudo rm -rf ${GOROOT}
+        sudo mv /tmp/go ${GOROOT}
+    - run: $GO get github.com/onsi/ginkgo/ginkgo
+    - run: $GO get github.com/docker/distribution/cmd/registry
+    - run: sudo ./hack/get_run_deps.sh
+    - run: sudo mkdir -p /var/lib/registry
+    - run: |
+        sudo $GOPATH/bin/registry serve integration/docker-registry.yaml > /dev/null 2>&1 &
+        PORT=4569 http-echo-server > /dev/null 2>&1 &
+        $GOPATH/bin/ginkgo -p -stream integration/init_app
+    - save_cache:
+        paths:
+        - /tmp/go/cache
+        key: ship-integration-test-build-cache-init-app-{{ epoch }}
+
+
+
+  integration_update:
+    machine: true
+    working_directory: /home/circleci/go/src/github.com/replicatedhq/ship
+    environment:
+      GOPATH: /home/circleci/go
+      GO_SHA256SUM: fa04efdb17a275a0c6e137f969a1c4eb878939e91e1da16060ce42f02c2ec5ec
+      GO: /usr/local/go/bin/go
+      GOCACHE: "/tmp/go/cache"
+    steps:
+    - checkout
+    - restore_cache:
+        keys:
+        - ship-integration-test-build-cache-update
+    - run: |
+        export GO_DOWNLOAD_URL=https://dl.google.com/go/go1.10.4.linux-amd64.tar.gz
+        export GOROOT=/usr/local/go
+        export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+        sudo apt update --fix-missing
+        sudo apt install --no-install-recommends -y gcc
+        curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+        sudo apt-get install -y nodejs
+        sudo npm install -g http-echo-server
+        wget "$GO_DOWNLOAD_URL" -O golang.tar.gz
+        echo "${GO_SHA256SUM}  golang.tar.gz" | sha256sum -c -
+        tar -zxvf golang.tar.gz -C /tmp
+        sudo rm -rf ${GOROOT}
+        sudo mv /tmp/go ${GOROOT}
+    - run: $GO get github.com/onsi/ginkgo/ginkgo
+    - run: $GO get github.com/docker/distribution/cmd/registry
+    - run: sudo ./hack/get_run_deps.sh
+    - run: sudo mkdir -p /var/lib/registry
+    - run: |
+        sudo $GOPATH/bin/registry serve integration/docker-registry.yaml > /dev/null 2>&1 &
+        PORT=4569 http-echo-server > /dev/null 2>&1 &
+        $GOPATH/bin/ginkgo -p -stream integration/update
+    - save_cache:
+        paths:
+        - /tmp/go/cache
+        key: ship-integration-test-build-cache-update-{{ epoch }}
 
   ui:
     docker:
@@ -338,7 +459,10 @@ workflows:
             - e2e_setup
 
       - test
-      - integration
+      - integration_base
+      - integration_init
+      - integration_init_app
+      - integration_update
       - ui
 
       - deploy_ship_init:
@@ -360,14 +484,20 @@ workflows:
             - e2e_setup
             - e2e_init
             - test
-            - integration
+            - integration_base
+            - integration_init
+            - integration_init_app
+            - integration_update
             - ui
           filters:
             branches:
               only: /master/
       - deploy_integration:
           requires:
-          - integration
+          - integration_base
+          - integration_init
+          - integration_init_app
+          - integration_update
           - deploy_unstable
           filters:
             branches:
@@ -427,12 +557,30 @@ workflows:
               only: /^v[0-9]+(\.[0-9]+)*(-.*)*/
             branches:
               ignore: /.*/
-      - integration:
+      - integration_base:
           filters:
               tags:
                 only: /^v[0-9]+(\.[0-9]+)*(-.*)*/
               branches:
                 ignore: /.*/
+      - integration_init:
+          filters:
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*(-.*)*/
+            branches:
+              ignore: /.*/
+      - integration_init_app:
+          filters:
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*(-.*)*/
+            branches:
+              ignore: /.*/
+      - integration_update:
+          filters:
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*(-.*)*/
+            branches:
+              ignore: /.*/
       - ui:
           filters:
             tags:
@@ -447,7 +595,10 @@ workflows:
             - e2e_setup
             - e2e_init
             - test
-            - integration
+            - integration_base
+            - integration_init
+            - integration_init_app
+            - integration_update
             - ui
           filters:
             tags:


### PR DESCRIPTION
What I Did
------------
Reworked CircleCI jobs to run integration test suites in parallel, reducing integration test runtime from ~6 minutes to ~4.

It may be possible to further speed builds by removing unneeded external dependencies from suites that do not require them.

How I Did it
------------
There are four suites of tests - `base`, `init`, `init_app` and `update`. Instead of running them in series, 4 Circle jobs are created to run them in parallel. 

How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------


![USS Winslow (DD 359)](https://upload.wikimedia.org/wikipedia/commons/7/71/USSWinslowDD359.jpg "USS Winslow (DD 359)")









<!-- (thanks https://github.com/docker/docker for this template) -->

