### PR TITLE
Auto focus TO_BE_MODIFIED in patch editor, fixed "add resource" button positioning

### DIFF
--- a/web/app/cypress/integration/init/testchart.spec.js
+++ b/web/app/cypress/integration/init/testchart.spec.js
@@ -55,9 +55,8 @@ describe("Ship Init test-charts/modify-chart", () => {
       });
 
       it("allows the stubbed overlay to be edited", () => {
-        const backspacesToRemoveToBeModified = buildRepeatKeyString("{backspace}", 14);
         cy.get(".ace_text-input").last().type(
-          `${backspacesToRemoveToBeModified}10`,
+          `10`,
           { force: true }
         )
       });

--- a/web/init/src/components/kustomize/kustomize_overlay/KustomizeOverlay.jsx
+++ b/web/init/src/components/kustomize/kustomize_overlay/KustomizeOverlay.jsx
@@ -288,7 +288,13 @@ export default class KustomizeOverlay extends React.Component {
       resource: `${fileTreeBasePath}${selectedFile}`,
     };
     await this.props.generatePatch(payload);
-    this.aceEditorOverlay.editor.find(PATCH_TOKEN);
+    
+    const position = this.aceEditorOverlay.editor.find(PATCH_TOKEN); // Find text for position
+    if(position) {
+      this.aceEditorOverlay.editor.focus();
+      this.aceEditorOverlay.editor.gotoLine(position.start.row + 1, position.start.column);
+      this.aceEditorOverlay.editor.find(PATCH_TOKEN); // Have to find text again to auto focus text
+    }
   }
 
   rebuildTooltip = () => {

--- a/web/init/src/scss/components/kustomize/KustomizeOverlay.scss
+++ b/web/init/src/scss/components/kustomize/KustomizeOverlay.scss
@@ -176,6 +176,7 @@
 
 .add-new-resource {
   top: -10px;
+  padding-top: 10px;
   .Input {
     margin: 0 0 0 30px;
     height: 20px;

--- a/web/init/src/scss/components/shared/FileTree.scss
+++ b/web/init/src/scss/components/shared/FileTree.scss
@@ -1,5 +1,6 @@
 .dirtree-wrapper {
   background-color: #124B71;
+  padding-bottom: 30px;
 }
 
 .dirtree {


### PR DESCRIPTION
What I Did
------------
Fixed the "Add Resource" button positioning on large file trees. It was hidden before, even if you scrolled down. Also updated the `handleGeneratePatch` in `KustomizeOverlay.jsx` to focus and go to the patch line being edited.

How I Did it
------------
Add Resource fix: Updated CSS properties of `.add-new-resource` and `..dirtree-wrapper`.
Auto focus fix: Use the `find` and `goToLine` methods on Ace `Editor` to get the position of the text being edited and then focus on it.

How to verify it
------------
Run ship init and go to the kustomize view. You can simulate a large file tree by adding more `<li>` elements to the file tree. Click on a base line and type something in the patch.

Description for the Changelog
------------
Auto focus TO_BE_MODIFIED in patch editor.
Fixed "add resource" button positioning on large file trees.


Picture of a Boat (not required but encouraged)
------------
⛵️ 











<!-- (thanks https://github.com/docker/docker for this template) -->

