### PR TITLE
Hide ship app command

### DIFF
--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -11,11 +11,10 @@ import (
 
 func App() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:        "app",
-		Short:      "Download and configure a licensed third party application",
-		Long:       `Download and configure a third party application using a supplied customer id.`,
-		Hidden:     true,
-		Deprecated: "use \"ship init /path/to/ship.yaml\" instead.",
+		Use:    "app",
+		Short:  "Download and configure a licensed third party application",
+		Long:   `Download and configure a third party application using a supplied customer id.`,
+		Hidden: true,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			viper.BindPFlags(cmd.Flags())
 			viper.BindPFlags(cmd.PersistentFlags())

--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -11,9 +11,11 @@ import (
 
 func App() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "app",
-		Short: "Download and configure a licensed third party application",
-		Long:  `Download and configure a third party application using a supplied customer id.`,
+		Use:        "app",
+		Short:      "Download and configure a licensed third party application",
+		Long:       `Download and configure a third party application using a supplied customer id.`,
+		Hidden:     true,
+		Deprecated: "use \"ship init /path/to/ship.yaml\" instead.",
 		PreRun: func(cmd *cobra.Command, args []string) {
 			viper.BindPFlags(cmd.Flags())
 			viper.BindPFlags(cmd.PersistentFlags())


### PR DESCRIPTION
What I Did
------------
```
$ bin/ship --help
ship allows for configuring and updating third party application in modern pipelines (gitops).

Usage:
  ship [flags]
  ship [command]

Available Commands:
  help        Help about any command
  init        Build and deploy kubernetes applications with kustomize.
  update      Pull an updated helm chart
  version     Print the current version and exit
  watch       Watch an upstream for updates
...
```

Description for the Changelog
------------
Covered in #725 


Picture of a Boat (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

