### PR TITLE
makefile improvements and typo fix

### DIFF
--- a/pkg/lifecycle/daemon/ui.go
+++ b/pkg/lifecycle/daemon/ui.go
@@ -29,7 +29,7 @@ func (b *binaryFileSystem) Exists(prefix string, filepath string) bool {
 			debug.Log("event", "file.open.err", "err", err)
 			return false
 		}
-		debug.Log("event", "file.open.sucess")
+		debug.Log("event", "file.open.success")
 		return true
 	}
 	debug.Log("event", "file.prefix.miss")

--- a/web/app/Makefile
+++ b/web/app/Makefile
@@ -47,11 +47,13 @@ serve_ship:
 	yarn build
 	@mkdir -p .state
 	@touch .state/build_ship
+	@touch .state/built-ui
 
 .state/build_ship_dev: deps-dev
 	yarn build
 	@mkdir -p .state
 	@touch .state/build_ship_dev
+	@touch .state/built-ui
 
 build_ship: .state/build_ship
 


### PR DESCRIPTION
What I Did
------------
Improved the makefile to actually regenerate `ui.bindatafs.go` when the web content changes.

How I Did it
------------
Both the prod and dev UI build steps now touch a file that the `ui.bindatafs.go` makefile step depends on.

How to verify it
------------

Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------
![USS Cummings (DD-365)](https://upload.wikimedia.org/wikipedia/commons/7/75/USS_Cummings_%28DD-365%29_underway_in_San_Diego_harbor%2C_circa_1938_%28NH_61868%29.jpg "USS Cummings (DD-365)")











<!-- (thanks https://github.com/docker/docker for this template) -->

