### PR TITLE
Stable sort order for patches

### DIFF
--- a/pkg/lifecycle/kustomize/kustomizer.go
+++ b/pkg/lifecycle/kustomize/kustomizer.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -118,7 +119,15 @@ func (l *Kustomizer) writeResources(fs afero.Afero, shipOverlay state.Overlay, d
 func (l *Kustomizer) writeFileMap(fs afero.Afero, files map[string]string, destDir string) (paths []string, err error) {
 	debug := level.Debug(log.With(l.Logger, "method", "writeResources"))
 
-	for file, contents := range files {
+	var keys []string
+	for k := range files {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, file := range keys {
+		contents := files[file]
+
 		name := path.Join(destDir, file)
 		err := l.writeFile(fs, name, contents)
 		if err != nil {
@@ -132,6 +141,7 @@ func (l *Kustomizer) writeFileMap(fs afero.Afero, files map[string]string, destD
 		}
 		paths = append(paths, relativePatchPath)
 	}
+
 	return paths, nil
 
 }

--- a/pkg/lifecycle/unfork/unforker.go
+++ b/pkg/lifecycle/unfork/unforker.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -182,7 +183,15 @@ func (l *Unforker) writeResources(fs afero.Afero, shipOverlay state.Overlay, des
 func (l *Unforker) writeFileMap(fs afero.Afero, files map[string]string, destDir string) (paths []string, err error) {
 	debug := level.Debug(log.With(l.Logger, "method", "writeResources"))
 
-	for file, contents := range files {
+	var keys []string
+	for k := range files {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, file := range keys {
+		contents := files[file]
+
 		name := path.Join(destDir, file)
 		err := l.writeFile(fs, name, contents)
 		if err != nil {
@@ -196,6 +205,7 @@ func (l *Unforker) writeFileMap(fs afero.Afero, files map[string]string, destDir
 		}
 		paths = append(paths, relativePatchPath)
 	}
+
 	return paths, nil
 
 }


### PR DESCRIPTION
What I Did
------------
Integration tests are unreliable because patches are not written in a stable, deterministic order. I I sorted them to make them predictable.

How I Did it
------------
Used the alphabet and sorted.

How to verify it
------------
Integration tests work when you run them > 1 time.

Description for the Changelog
------------
Stable, deterministic sort order for patches in kustomization.yaml


Picture of a Boat (not required but encouraged)
------------
![51nba epfal _sx466_](https://user-images.githubusercontent.com/173451/49323030-c75afc00-f4ca-11e8-9e2c-fe98ca4b4537.jpg)













<!-- (thanks https://github.com/docker/docker for this template) -->

