### PR TITLE
add GOPATH/bin to path explicitly for go-bindata-assetfs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,7 +291,7 @@ build_ship_integration_test:
 	docker build -t $(DOCKER_REPO)/ship-e2e-test:latest -f ./integration/Dockerfile .
 
 pkg/lifecycle/daemon/ui.bindatafs.go: .state/mark-ui-gitignored .state/build-deps web/app/.state/built-ui
-	go-bindata-assetfs -pkg daemon \
+	export PATH=$(GOPATH)/bin:$$PATH; go-bindata-assetfs -pkg daemon \
 	  -o pkg/lifecycle/daemon/ui.bindatafs.go \
 	  -prefix web/app \
 	  web/app/build/...
@@ -337,7 +337,7 @@ cypress: build cypress_base
 # rather than folks just getting an old version of the UI
 dev-embed-ui:
 	mkdir -p .state/tmp/dist
-	go-bindata-assetfs -pkg daemon \
+	export PATH=$(GOPATH)/bin:$$PATH; go-bindata-assetfs -pkg daemon \
 	  -o pkg/lifecycle/daemon/ui.bindatafs.go \
 	  -prefix .state/tmp/ \
 	  -debug \


### PR DESCRIPTION
What I Did
------------
Updated ship Makefile to enable building even if GOPATH/bin isn't present in user's path. With this change, we can remove some path-fiddling from the Ship Homebrew formula (which is one of the issues preventing our PR from getting merged).

How I Did it
------------
explicitly push GOPATH/bin into PATH before invoking go-bindata-assetfs

How to verify it
------------
remove GOPATH/bin from your path & 'make build'

Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

