### PR TITLE
Add Customer and installation ID to template context for replicated.app

### DIFF
--- a/integration/init_app/basic/expected/.ship/release.yml
+++ b/integration/init_app/basic/expected/.ship/release.yml
@@ -12,6 +12,8 @@ assets:
         contents: |
           #!/bin/bash
           echo "tested nothing"
+          echo "customer {{repl Installation "customer_id" }}"
+          echo "install {{repl Installation "installation_id" }}"
         dest: ./scripts/test.sh
         mode: 0777
 config:

--- a/integration/init_app/basic/expected/.ship/state.json
+++ b/integration/init_app/basic/expected/.ship/state.json
@@ -2,13 +2,13 @@
   "v1": {
     "config": {},
     "upstream": "__upstream__",
-    "contentSHA": "2260e2110304496fc8544b8bf51c95352cdf9300270fe7c7fa9f6e1b76855d1c",
+    "contentSHA": "6faeec976f37e880c5e70cf578412a57fbfda3b35bf8e6f73221fe5fe88f1058",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "__customerID__",
       "installationID": "__installationID__",
       "releaseNotes": "integration tests",
-      "version": "1.0.0-SNAPSHOT"
+      "version": "1.0.2"
     },
     "releaseName": "integration-replicated-app-basic"
   }

--- a/integration/init_app/basic/expected/installer/scripts/test.sh
+++ b/integration/init_app/basic/expected/installer/scripts/test.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
 echo "tested nothing"
+echo "customer -Am-_6i5pw0u4AbspOwKN4lZUCn49u_G"
+echo "install 3Z6uuPbVz6jTxRuXHn_l6UlYQz3hWz6-"

--- a/integration/init_app/basic/input/.ship/release.yml
+++ b/integration/init_app/basic/input/.ship/release.yml
@@ -12,6 +12,8 @@ assets:
         contents: |
           #!/bin/bash
           echo "tested nothing"
+          echo "customer {{repl Installation "customer_id" }}"
+          echo "install {{repl Installation "installation_id" }}"
         dest: ./scripts/test.sh
         mode: 0777
 config:

--- a/integration/init_app/basic/metadata.yaml
+++ b/integration/init_app/basic/metadata.yaml
@@ -1,3 +1,3 @@
 customer_id: "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G"
 installation_id: "3Z6uuPbVz6jTxRuXHn_l6UlYQz3hWz6-"
-release_version: "1.0.0-SNAPSHOT"
+release_version: "1.0.2"

--- a/integration/update/app_basic/expected/.ship/release.yml
+++ b/integration/update/app_basic/expected/.ship/release.yml
@@ -12,6 +12,8 @@ assets:
         contents: |
           #!/bin/bash
           echo "tested nothing"
+          echo "customer {{repl Installation "customer_id" }}"
+          echo "install {{repl Installation "installation_id" }}"
         dest: ./scripts/test.sh
         mode: 0777
 config:

--- a/integration/update/app_basic/expected/.ship/state.json
+++ b/integration/update/app_basic/expected/.ship/state.json
@@ -2,13 +2,13 @@
   "v1": {
     "config": {},
     "upstream": "staging.replicated.app/some-cool-ci-tool?installation_id=3Z6uuPbVz6jTxRuXHn_l6UlYQz3hWz6-&customer_id=-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
-    "contentSHA": "2260e2110304496fc8544b8bf51c95352cdf9300270fe7c7fa9f6e1b76855d1c",
+    "contentSHA": "6faeec976f37e880c5e70cf578412a57fbfda3b35bf8e6f73221fe5fe88f1058",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
       "installationID": "3Z6uuPbVz6jTxRuXHn_l6UlYQz3hWz6-",
       "releaseNotes": "integration tests",
-      "version": "1.0.0-SNAPSHOT"
+      "version": "1.0.2"
     },
     "releaseName": "integration-replicated-app-basic"
   }

--- a/integration/update/app_basic/expected/installer/scripts/test.sh
+++ b/integration/update/app_basic/expected/installer/scripts/test.sh
@@ -1,2 +1,5 @@
 #!/bin/bash
 echo "tested nothing"
+echo "customer -Am-_6i5pw0u4AbspOwKN4lZUCn49u_G"
+echo "install 3Z6uuPbVz6jTxRuXHn_l6UlYQz3hWz6-"
+

--- a/pkg/helm/repo_add.go
+++ b/pkg/helm/repo_add.go
@@ -26,11 +26,9 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-
-	"github.com/pkg/errors"
-
 	"syscall"
 
+	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh/terminal"
 	"k8s.io/helm/pkg/getter"
 	"k8s.io/helm/pkg/helm/helmpath"

--- a/pkg/lifecycle/render/helm/template.go
+++ b/pkg/lifecycle/render/helm/template.go
@@ -10,8 +10,6 @@ import (
 	"regexp"
 	"strings"
 
-	"k8s.io/helm/pkg/chartutil"
-
 	"github.com/emosbaugh/yaml"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -26,6 +24,7 @@ import (
 	"github.com/replicatedhq/ship/pkg/util"
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
+	"k8s.io/helm/pkg/chartutil"
 )
 
 const (

--- a/pkg/lifecycle/render/helm/template_test.go
+++ b/pkg/lifecycle/render/helm/template_test.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"k8s.io/helm/pkg/chartutil"
-
 	"github.com/golang/mock/gomock"
 	"github.com/replicatedhq/libyaml"
 	"github.com/replicatedhq/ship/pkg/api"
@@ -24,6 +22,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
+	"k8s.io/helm/pkg/chartutil"
 )
 
 func TestLocalTemplater(t *testing.T) {

--- a/pkg/specs/upstream_test.go
+++ b/pkg/specs/upstream_test.go
@@ -8,11 +8,9 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/replicatedhq/ship/pkg/specs/githubclient"
-
-	"github.com/replicatedhq/ship/pkg/state"
-
 	"github.com/google/go-github/github"
+	"github.com/replicatedhq/ship/pkg/specs/githubclient"
+	"github.com/replicatedhq/ship/pkg/state"
 	"github.com/replicatedhq/ship/pkg/testing/logger"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/templates/installation_context.go
+++ b/pkg/templates/installation_context.go
@@ -39,7 +39,7 @@ func (ctx *InstallationContext) FuncMap() template.FuncMap {
 			case "state_file_path":
 				return constants.StatePath
 			case "customer_id":
-				return ctx.Viper.GetString("customer-id")
+				return ctx.Meta.CustomerID
 			case "semver":
 				return ctx.Meta.Semver
 			case "channel_name":
@@ -49,7 +49,7 @@ func (ctx *InstallationContext) FuncMap() template.FuncMap {
 			case "release_id":
 				return ctx.Meta.ReleaseID
 			case "installation_id":
-				return ctx.Viper.GetString("installation-id")
+				return ctx.Meta.InstallationID
 			case "release_notes":
 				return ctx.Meta.ReleaseNotes
 			}

--- a/pkg/templates/installation_context_test.go
+++ b/pkg/templates/installation_context_test.go
@@ -98,14 +98,18 @@ func testCases() []TestInstallation {
 			Expected: "It's " + constants.StatePath,
 		},
 		{
-			Name:     "customer_id",
-			Meta:     api.ReleaseMetadata{},
+			Name: "customer_id",
+			Meta: api.ReleaseMetadata{
+				CustomerID: "abc",
+			},
 			Tpl:      `It's {{repl Installation "customer_id" }}`,
 			Expected: `It's abc`,
 		},
 		{
-			Name:     "installation_id",
-			Meta:     api.ReleaseMetadata{},
+			Name: "installation_id",
+			Meta: api.ReleaseMetadata{
+				InstallationID: "xyz",
+			},
 			Tpl:      `It's {{repl Installation "installation_id" }}`,
 			Expected: `It's xyz`,
 		},


### PR DESCRIPTION
What I Did
------------

Add Customer and installation ID to template context for replicated.app,

This means the following now resolve for `ship init replicated.app/...`:

```
{{repl Installation "customer_id"}}
{{repl Installation "installation_id"}}
```

How I Did it
------------

Use the ReleaseMeta for ShipCtx resolution instead of using viper.Get

How to verify it
------------

Include the Installation template functions in an app. This example from
the integration test:

in:

```
    - inline:
        contents: |
          #!/bin/bash
          echo "tested nothing"
          echo "customer {{repl Installation "customer_id" }}"
          echo "install {{repl Installation "installation_id" }}"
        dest: ./scripts/test.sh
        mode: 0777
```

out:

```
echo "tested nothing"
echo "customer 4AbspOwKN4lZUCn49u_G"
echo "install z6jTxRuXHn_l6UlYQz3hWz6-"
```

Description for the Changelog
------------

Fix template context injection of release metadata for replicated.app -style applications in ship.

:boat:


What I Did
------------


How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->