### PR TITLE
designate Makefile NOTPARALLEL until we can make it parallellable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.NOTPARALLEL:
+
 .PHONY: build-deps dep-deps docker shell githooks dep e2e run citest ci-upload-coverage goreleaser integration-test build_ship_integration_test build-ui build-ui-dev mark-ui-gitignored fmt lint vet test build embed-ui clean-ship clean clean-integration
 
 


### PR DESCRIPTION
What I Did
------------
designated the top-level Makefile 'NOTPARALLEL' so that it will still build serially even if invoked with 'make -j' (which is how Homebrew likes to build)

How I Did it
------------
Added a ".NOTPARALLEL:' target to the top of the makefile.  This is a temporary step.  I plan to dig in and add appropriate dependencies so that we can actually build parallel.

How to verify it
------------
'make build' various targets to verify that serial builds still work fine
and 'make -j build' various targets to verify that parallel builds work fine (because they're now serialized)

Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

