### PR TITLE
Update cassandra to match generated files

### DIFF
--- a/integration/init/jaeger-helm/expected/base/charts/cassandra/templates/service.yaml
+++ b/integration/init/jaeger-helm/expected/base/charts/cassandra/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     app: cassandra
-    chart: cassandra-0.9.3
+    chart: cassandra-0.9.4
     heritage: Tiller
     release: jaeger
   name: jaeger-cassandra

--- a/integration/init/jaeger-helm/expected/base/charts/cassandra/templates/statefulset.yaml
+++ b/integration/init/jaeger-helm/expected/base/charts/cassandra/templates/statefulset.yaml
@@ -3,7 +3,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: cassandra
-    chart: cassandra-0.9.3
+    chart: cassandra-0.9.4
     heritage: Tiller
     release: jaeger
   name: jaeger-cassandra

--- a/integration/init/jaeger-helm/expected/rendered.yaml
+++ b/integration/init/jaeger-helm/expected/rendered.yaml
@@ -69,7 +69,7 @@ kind: Service
 metadata:
   labels:
     app: cassandra
-    chart: cassandra-0.9.3
+    chart: cassandra-0.9.4
     heritage: Tiller
     release: jaeger
   name: jaeger-cassandra
@@ -157,7 +157,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: cassandra
-    chart: cassandra-0.9.3
+    chart: cassandra-0.9.4
     heritage: Tiller
     release: jaeger
   name: jaeger-cassandra


### PR DESCRIPTION
I think jaeger is using latest cassandra here or something similar

What I Did
------------
Updated the version of Cassandra that the jaeger-helm integration test expected

How I Did it
------------


How to verify it
------------
Integration tests pass

Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------
![USS Reid (DD 369)](https://upload.wikimedia.org/wikipedia/commons/6/6a/USS_Reid_%28DD_369%29.jpg "USS Reid (DD 369)")











<!-- (thanks https://github.com/docker/docker for this template) -->

