### PR TITLE
fix yarn concurrency issues

### DIFF
--- a/web/app/Makefile
+++ b/web/app/Makefile
@@ -8,7 +8,7 @@ $SRC = $(shell find . -path "./node_modules" -prune -o -path "./build" -prune -o
 	@mkdir -p .state
 	@touch .state/package
 
-.state/package-init: ../init/package.json ../init/yarn.lock
+.state/package-init: ../init/package.json ../init/yarn.lock .state/package
 	cd ../init && \
 		yarn --pure-lockfile && \
 		yarn build && \
@@ -17,7 +17,7 @@ $SRC = $(shell find . -path "./node_modules" -prune -o -path "./build" -prune -o
 	@mkdir -p .state
 	@touch .state/package-init
 
-.state/package-init-dev: ../init/package.json ../init/yarn.lock
+.state/package-init-dev: ../init/package.json ../init/yarn.lock .state/package
 	cd ../init && \
 		yarn --pure-lockfile && \
 		yarn build-dev && \


### PR DESCRIPTION
What I Did
------------
Updated Makefile dependencies to correctly serialize dependent steps, and prevent yarn concurrency problems seen with parallel Homebrew builds.

How I Did it
------------
Add a 'package' dependency to the 'package-init' targets, which forces yarn build steps to wait for completion of yarn install step.

How to verify it
------------
`rm -rf ~/Library/Caches/Yarn/v4/`
`make -j build_ship`

This will clear the yarn cache, forcing the yarn install stuff to run and take a while, and the '-j' option to make will cause build steps to be executed in parallel.  This used to lead to multiple errors, which are fixed with this change.

Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

