### PR TITLE
Add better debug output on proxied github pull failure.

### DIFF
--- a/pkg/api/spec.go
+++ b/pkg/api/spec.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -31,6 +32,19 @@ type GithubContent struct {
 	Files []GithubFile `json:"files" yaml:"files" hcl:"files" meta:"files"`
 }
 
+// Not using json.Marshal because I want to omit the file data, and don't feel like
+// writing a custom marshaller
+func (g GithubContent) String() string {
+
+	fileStr := "["
+	for _, file := range g.Files {
+		fileStr += fmt.Sprintf("%s, ", file.String())
+	}
+	fileStr += "]"
+
+	return fmt.Sprintf("GithubContent{ repo:%s path:%s ref:%s files:%s }", g.Repo, g.Path, g.Ref, fileStr)
+}
+
 // GithubFile
 type GithubFile struct {
 	Name string `json:"name" yaml:"name" hcl:"name" meta:"name"`
@@ -38,6 +52,12 @@ type GithubFile struct {
 	Sha  string `json:"sha" yaml:"sha" hcl:"sha" meta:"sha"`
 	Size int64  `json:"size" yaml:"size" hcl:"size" meta:"size"`
 	Data string `json:"data" yaml:"data" hcl:"data" meta:"data"`
+}
+
+func (file GithubFile) String() string {
+	return fmt.Sprintf("GitHubFile{ name:%s path:%s sha:%s size:%d dataLen:%d }",
+		file.Name, file.Path, file.Sha, file.Size, len(file.Data))
+
 }
 
 type ShipAppMetadata struct {

--- a/pkg/lifecycle/render/github/render.go
+++ b/pkg/lifecycle/render/github/render.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -90,7 +91,8 @@ func (r *LocalRenderer) Execute(
 		debug.Log("event", "resolveProxyGithubAssets")
 		files := filterGithubContents(meta.GithubContents, asset)
 		if len(files) == 0 {
-			level.Info(r.Logger).Log("msg", "no files for asset", "repo", asset.Repo, "path", asset.Path)
+			level.Info(r.Logger).Log("msg", "no proxy files for asset", "repo", asset.Repo, "path", asset.Path)
+			r.debugDumpKnownGithubFiles(meta, asset)
 
 			if asset.Source == "public" || !asset.Proxy {
 				debug.Log("event", "resolveNoProxyGithubAssets")
@@ -105,6 +107,22 @@ func (r *LocalRenderer) Execute(
 
 		return r.resolveProxyGithubAssets(asset, builder, rootFs, files)
 	}
+}
+
+func (r *LocalRenderer) debugDumpKnownGithubFiles(meta api.ReleaseMetadata, asset api.GitHubAsset) {
+	debugStr := "["
+	for _, content := range meta.GithubContents {
+		debugStr += fmt.Sprintf("%s, ", content.String())
+
+	}
+	debugStr += "]"
+
+	level.Debug(r.Logger).Log(
+		"msg", "github contents",
+		"repo", asset.Repo,
+		"path", asset.Path,
+		"releaseMeta", debugStr,
+	)
 }
 
 func filterGithubContents(githubContents []api.GithubContent, asset api.GitHubAsset) []api.GithubFile {

--- a/pkg/lifecycle/render/local/render.go
+++ b/pkg/lifecycle/render/local/render.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"path/filepath"
 
-	"github.com/pkg/errors"
-
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-
+	"github.com/pkg/errors"
 	"github.com/replicatedhq/libyaml"
 	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/spf13/afero"

--- a/pkg/lifecycle/unfork/unforker.go
+++ b/pkg/lifecycle/unfork/unforker.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/replicatedhq/ship/pkg/util"
-
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
@@ -20,6 +18,7 @@ import (
 	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 	"github.com/replicatedhq/ship/pkg/patch"
 	"github.com/replicatedhq/ship/pkg/state"
+	"github.com/replicatedhq/ship/pkg/util"
 	"github.com/spf13/afero"
 	yaml "gopkg.in/yaml.v2"
 	"k8s.io/client-go/kubernetes/scheme"

--- a/pkg/patch/patcher.go
+++ b/pkg/patch/patcher.go
@@ -8,14 +8,13 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/replicatedhq/ship/pkg/util"
-
 	"github.com/ghodss/yaml"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/constants"
+	"github.com/replicatedhq/ship/pkg/util"
 	"github.com/spf13/afero"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes/scheme"

--- a/pkg/specs/interface.go
+++ b/pkg/specs/interface.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"gopkg.in/yaml.v2"
-
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
@@ -17,6 +15,7 @@ import (
 	"github.com/replicatedhq/ship/pkg/constants"
 	"github.com/replicatedhq/ship/pkg/specs/replicatedapp"
 	"github.com/replicatedhq/ship/pkg/util"
+	"gopkg.in/yaml.v2"
 )
 
 func (r *Resolver) ResolveUnforkRelease(ctx context.Context, upstream string, forked string) (*api.Release, error) {

--- a/pkg/util/kubernetes_resource.go
+++ b/pkg/util/kubernetes_resource.go
@@ -3,10 +3,9 @@ package util
 import (
 	"bytes"
 
-	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
-
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/kustomize/pkg/resource"
 )
 


### PR DESCRIPTION
What I Did
------------

Add better debug output on proxied github pull failure.

How I Did it
------------

Dump all the files we got in ReleaseMetadata into a debug log. Not using
JSON.Marshal because we want to explicitly exclude the contents and
writing a custom marshaller seems overkill.

How to verify it
------------

Run a ship.yaml with 2 github assets in it, one valid and one that doesn't match up to actual
files in the repo. See a debug log line about what we *did* know about.

Description for the Changelog
------------

Add better debug output on proxied github pull failure.


:canoe: