### PR TITLE
update mutations.json to no longer require deprecated github property 'source'

### DIFF
--- a/hack/docs/mutations.json
+++ b/hack/docs/mutations.json
@@ -181,7 +181,7 @@
             "repo": "github.com/replicatedhq/superbigtool-k8s",
             "ref": "8fcaebe55af67fe6789fa678faaa76fa867fbc",
             "path": "k8s-yamls/",
-            "source": "private"
+            "proxy": true
           },
           "dest": "charts/rendered/"
         },
@@ -424,7 +424,7 @@
           "ref": "8fcaebe55af67fe6789fa678faaa76fa867fbc",
           "path": "k8s-yamls/",
           "dest": "./k8s/",
-          "source": "private",
+          "proxy": true,
           "strip_path": ""
         },
         {
@@ -432,7 +432,7 @@
           "ref": "master",
           "path": "hack/docs/",
           "dest": "./docs{{repl Add 1 1}}/",
-          "source": "public",
+          "proxy": false,
           "mode": 644,
           "strip_path": "{{repl ParseBool \"true\"}}"
         }
@@ -442,8 +442,7 @@
       "required": [
         "repo",
         "path",
-        "dest",
-        "source"
+        "dest"
       ]
     }
   },

--- a/hack/docs/schema.json
+++ b/hack/docs/schema.json
@@ -406,7 +406,7 @@
                     "ref": "8fcaebe55af67fe6789fa678faaa76fa867fbc",
                     "path": "k8s-yamls/",
                     "dest": "./k8s/",
-                    "source": "private",
+                    "proxy": true,
                     "strip_path": ""
                   },
                   {
@@ -414,7 +414,7 @@
                     "ref": "master",
                     "path": "hack/docs/",
                     "dest": "./docs{{repl Add 1 1}}/",
-                    "source": "public",
+                    "proxy": false,
                     "mode": 644,
                     "strip_path": "{{repl ParseBool \"true\"}}"
                   }
@@ -464,8 +464,7 @@
                 "required": [
                   "repo",
                   "path",
-                  "dest",
-                  "source"
+                  "dest"
                 ]
               },
               "google_gke": {
@@ -550,7 +549,7 @@
                       "repo": "github.com/replicatedhq/superbigtool-k8s",
                       "ref": "8fcaebe55af67fe6789fa678faaa76fa867fbc",
                       "path": "k8s-yamls/",
-                      "source": "private"
+                      "proxy": true
                     },
                     "dest": "charts/rendered/"
                   },
@@ -674,11 +673,7 @@
                   "values_from": {
                     "description": "values_from",
                     "type": "object",
-                    "properties": {
-                      "lifecycle": {
-                        "type": "object"
-                      }
-                    }
+                    "properties": {}
                   },
                   "when": {
                     "description": "This asset will be included when 'when' is omitted or true",


### PR DESCRIPTION

What I Did
------------
`mutations.json` and `schema.json` updates

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------


![USS Conyngham (DD-371)](https://upload.wikimedia.org/wikipedia/commons/thumb/e/ee/USS_Conyngham_%28DD-371%29_off_the_Mare_Island_Navy_Yard_on_22_January_1942_%2819-N-27127%29.jpg/2560px-USS_Conyngham_%28DD-371%29_off_the_Mare_Island_Navy_Yard_on_22_January_1942_%2819-N-27127%29.jpg "USS Conyngham (DD-371)")









<!-- (thanks https://github.com/docker/docker for this template) -->

