### PR TITLE
16604 key commands

### DIFF
--- a/web/init/package.json
+++ b/web/init/package.json
@@ -20,7 +20,7 @@
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.11",
     "rc-progress": "^2.2.5",
-    "react-ace": "^6.1.4",
+    "react-ace": "^6.2.0",
     "react-document-title": "^2.0.3",
     "react-modal": "^3.5.1",
     "react-monaco-editor": "^0.18.0",

--- a/web/init/src/components/kustomize/HelmValuesEditor.jsx
+++ b/web/init/src/components/kustomize/HelmValuesEditor.jsx
@@ -31,7 +31,8 @@ export default class HelmValuesEditor extends React.Component {
   }
 
   componentDidMount() {
-    if(this.props.getStep.values) {
+    window.addEventListener("keydown", this.handleKeyboardSave);
+    if (this.props.getStep.values) {
       this.setState({
         initialSpecValue: this.props.getStep.values,
         specValue: this.props.getStep.values,
@@ -40,6 +41,8 @@ export default class HelmValuesEditor extends React.Component {
       });
     }
   }
+
+  
 
   getLinterErrors = (specContents) => {
     if (specContents === "") return;
@@ -136,6 +139,18 @@ export default class HelmValuesEditor extends React.Component {
           console.log(err);
         })
     }
+  }
+
+  handleKeyboardSave = (e) => {
+    if (e.keyCode == 83 && (e.ctrlKey || e.metaKey)) {
+      e.preventDefault();
+      e.stopPropagation();
+      this.handleSaveValues(false);
+    }
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("keydown", this.handleKeyboardSave);
   }
 
   handleOnChangehelmReleaseName = (helmReleaseName) => this.setState({ helmReleaseName })

--- a/web/init/src/components/kustomize/HelmValuesEditor.jsx
+++ b/web/init/src/components/kustomize/HelmValuesEditor.jsx
@@ -39,6 +39,7 @@ export default class HelmValuesEditor extends React.Component {
         initialHelmReleaseName: this.props.getStep.helmName,
         helmReleaseName: this.props.getStep.helmName,
       });
+      this.helmEditor.editor.getSession().setValue(this.props.getStep.values); // this resets the UndoManager and prevents the editor from being able to be wiped out by too many CMD+Z's
     }
   }
 

--- a/web/init/src/components/kustomize/HelmValuesEditor.jsx
+++ b/web/init/src/components/kustomize/HelmValuesEditor.jsx
@@ -47,7 +47,6 @@ export default class HelmValuesEditor extends React.Component {
 
   getLinterErrors = (specContents) => {
     if (specContents === "") return;
-
     const errors = new linter.Linter(specContents).lint();
     let markers = [];
     for (let error of errors) {

--- a/web/init/src/components/kustomize/HelmValuesEditor.jsx
+++ b/web/init/src/components/kustomize/HelmValuesEditor.jsx
@@ -143,7 +143,8 @@ export default class HelmValuesEditor extends React.Component {
   }
 
   handleKeyboardSave = (e) => {
-    if (e.keyCode == 83 && (e.ctrlKey || e.metaKey)) {
+    const sKey = e.keyCode === 83;
+    if (sKey && (e.ctrlKey || e.metaKey)) {
       e.preventDefault();
       e.stopPropagation();
       this.handleSaveValues(false);

--- a/web/init/yarn.lock
+++ b/web/init/yarn.lock
@@ -2234,7 +2234,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-brace@^0.11.0, brace@^0.11.1:
+brace@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/brace/-/brace-0.11.1.tgz#4896fcc9d544eef45f4bb7660db320d3b379fe58"
   integrity sha1-SJb8ydVE7vRfS7dmDbMg07N5/lg=
@@ -3469,7 +3469,7 @@ dezalgo@^1.0.0, dezalgo@^1.0.1, dezalgo@^1.0.2, dezalgo@~1.0.3:
     asap "^2.0.0"
     wrappy "1"
 
-diff-match-patch@^1.0.0:
+diff-match-patch@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/diff-match-patch/-/diff-match-patch-1.0.4.tgz#6ac4b55237463761c4daf0dc603eb869124744b1"
   integrity sha512-Uv3SW8bmH9nAtHKaKSanOQmj2DnlH65fUpcrMdfdaOxUG02QQ4YGZ8AE7kKOMisF7UqvOlGKVYWRvezdncW9lg==
@@ -6339,7 +6339,7 @@ lodash.isequal@^3.0:
     lodash._baseisequal "^3.0.0"
     lodash._bindcallback "^3.0.0"
 
-lodash.isequal@^4.1.1, lodash.isequal@^4.5.0:
+lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
@@ -8347,16 +8347,16 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-ace@^6.1.4:
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/react-ace/-/react-ace-6.1.4.tgz#33d93a83ae46c61f23b1801df79b71837a328b75"
-  integrity sha512-a8/lAsy2bfi7Ho+3Kaj8hBPR+PEiCTG9xFG9LIjCJrv5WQFYFpeFTiPWA96M3t+LgIDFFltwfVTwD2pmdAVOxQ==
+react-ace@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/react-ace/-/react-ace-6.2.0.tgz#9ab0fd88cd1ef6712fec4b243b61431964481c11"
+  integrity sha512-Cr27xFNZV2wlQi+mFjgUWfd3yPZV84Sf7XVrEXkDBZmQ5I/oY3x4KvtBjX6ImN7SCWu3sU6z9F3Zh6jH3/jtzw==
   dependencies:
-    brace "^0.11.0"
-    diff-match-patch "^1.0.0"
+    brace "^0.11.1"
+    diff-match-patch "^1.0.4"
     lodash.get "^4.4.2"
-    lodash.isequal "^4.1.1"
-    prop-types "^15.5.8"
+    lodash.isequal "^4.5.0"
+    prop-types "^15.6.2"
 
 react-docgen@^2.7.0:
   version "2.21.0"


### PR DESCRIPTION
What I Did
------------
- Add handler for `cmd+s/ctl+s` keystrokes to save `values.yaml`
- Set initial value of editor through ace instead of just state to reset the UndoManager and prevent `cmd+z/ctl+z` from wiping out the entire editor.

How to verify it
------------
- On the values.yaml editor, make a change and do `cmd+s`. Your changes should be saved.
- Make additional changes and then hit `cmd+z` and bunch of times. It should undo your changes to the beginning but it should not ever wipe out the entire contents of the editor.

Description for the Changelog
------------
Support `CMD+S/CTL+S` to save your values.yaml
Bug fix for to many undo's wiping out entire editor.

Picture of a Boat (not required but encouraged)
------------
![300px-uss_strong_ dd-758 _underway_off_oahu_in_1968](https://user-images.githubusercontent.com/4110866/49839535-4e7a6080-fd64-11e8-81fb-3ce166ea8c42.jpg)

