### PR TITLE
Fix UI for workflows with multiple async lifecycle steps

### DIFF
--- a/fixtures/kubectl/ship.yml
+++ b/fixtures/kubectl/ship.yml
@@ -1,0 +1,68 @@
+assets:
+  v1:
+    - inline:
+        dest: first/nginx.yaml
+        contents: |
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: nginx
+          spec:
+            selector:
+              matchLabels:
+                app: nginx
+            replicas: 2
+            template:
+              metadata:
+                labels:
+                  app: nginx
+              spec:
+                containers:
+                - name: nginx
+                  image: nginx:1.7.9
+                  ports:
+                  - containerPort: 80
+    - inline:
+        dest: second/redis.yaml
+        contents: |
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: redis
+            labels:
+              app: redis
+          spec:
+            selector:
+              matchLabels:
+                app: redis
+                role: master
+                tier: backend
+            replicas: 1
+            template:
+              metadata:
+                labels:
+                  app: redis
+                  role: master
+                  tier: backend
+              spec:
+                containers:
+                - name: master
+                  image: redis
+                  resources:
+                    requests:
+                      cpu: 100m
+                      memory: 100Mi
+                  ports:
+                  - containerPort: 6379
+
+lifecycle:
+  v1:
+    - message:
+        contents: "Hi - The following steps will create a nginx and redis deployment"
+    - render: {}
+    - kubectlApply:
+        path: first
+    - kubectlApply:
+        path: second
+    - message:
+        contents: "Bye"

--- a/web/init/src/components/shared/RouteDecider.jsx
+++ b/web/init/src/components/shared/RouteDecider.jsx
@@ -36,7 +36,7 @@ const ShipRoutesWrapper = ({ routes, headerEnabled, basePath, onCompletion }) =>
                     onCompletion={onCompletion}
                     basePath={basePath}
                     routes={routes}
-                    routeId={route.id}
+                    currentRoute={route}
                   />}
                 />
               ))}

--- a/web/init/src/components/shared/StepBuildingAssets.jsx
+++ b/web/init/src/components/shared/StepBuildingAssets.jsx
@@ -5,12 +5,17 @@ import { Line } from "rc-progress";
 import { Utilities } from "../../utilities/utilities";
 import Loader from "./Loader";
 
-export default class StepBuildingAssets extends React.Component {
+export const RENDER_PHASE = "render";
+
+export class StepBuildingAssets extends React.Component {
   static propTypes = {
     location: PropTypes.shape({
       pathname: PropTypes.string,
     }).isRequired,
-    routeId: PropTypes.string.isRequired,
+    currentRoute: PropTypes.shape({
+      id: PropTypes.string,
+      phase: PropTypes.string,
+    }).isRequired,
     startPollingStep: PropTypes.func.isRequired,
     status: PropTypes.shape({
       type: PropTypes.string,
@@ -19,8 +24,10 @@ export default class StepBuildingAssets extends React.Component {
   }
 
   componentDidMount() {
-    const { startPollingStep, location, routeId } = this.props;
-    startPollingStep(location, routeId);
+    const { startPollingStep, currentRoute } = this.props;
+    if (currentRoute.phase === RENDER_PHASE) {
+      startPollingStep(currentRoute.id);
+    }
   }
 
   render() {

--- a/web/init/src/components/shared/StepKubectlApply.jsx
+++ b/web/init/src/components/shared/StepKubectlApply.jsx
@@ -7,12 +7,17 @@ import { Utilities } from "../../utilities/utilities";
 import Loader from "./Loader";
 import StepMessage from "./StepMessage";
 
-export default class StepKubectlApply extends React.Component {
+export const KUBECTL_PHASE = "kubectl";
+
+export class StepKubectlApply extends React.Component {
   static propTypes = {
     location: PropTypes.shape({
       pathname: PropTypes.string,
     }).isRequired,
-    routeId: PropTypes.string.isRequired,
+    currentRoute: PropTypes.shape({
+      id: PropTypes.string,
+      phase: PropTypes.string,
+    }).isRequired,
     startPoll: PropTypes.func.isRequired,
     gotoRoute: PropTypes.func.isRequired,
     initializeStep: PropTypes.func.isRequired,
@@ -30,12 +35,13 @@ export default class StepKubectlApply extends React.Component {
 
   componentDidMount() {
     const {
-      routeId,
-      location,
+      currentRoute,
       startPollingStep,
     } = this.props;
 
-    startPollingStep(location, routeId);
+    if (currentRoute.phase === KUBECTL_PHASE) {
+      startPollingStep(currentRoute.id);
+    }
   }
 
   parseStatus = () => {
@@ -86,11 +92,11 @@ export default class StepKubectlApply extends React.Component {
     const {
       handleAction,
       startPoll,
-      routeId,
+      currentRoute,
       gotoRoute,
     } = this.props;
     handleAction(action, false);
-    startPoll(routeId, gotoRoute);
+    startPoll(currentRoute.id, gotoRoute);
   }
 
   render() {

--- a/web/init/src/components/shared/StepKubectlApply.jsx
+++ b/web/init/src/components/shared/StepKubectlApply.jsx
@@ -80,7 +80,7 @@ export class StepKubectlApply extends React.Component {
       const clampedPercent = clamp(percent, 0, 100);
       return {
         isJSON,
-        status: parsedDetailStatus,
+        status: "working",
         percent: clampedPercent,
         progressDetail,
         message,
@@ -128,7 +128,7 @@ export class StepKubectlApply extends React.Component {
                 }
               </div>
               :
-              <p className="u-fontSizer--larger u-color--tundora u-fontWeight--bold u-marginTop--normal u-textAlign--center">{status}</p>
+              null
             }
           </div>: null
         }

--- a/web/init/src/components/shared/StepTerraform.jsx
+++ b/web/init/src/components/shared/StepTerraform.jsx
@@ -8,12 +8,17 @@ import { Utilities } from "../../utilities/utilities";
 import Loader from "./Loader";
 import StepMessage from "./StepMessage";
 
-export default class StepPreparingTerraform extends React.Component {
+export const TERRAFORM_PHASE = "terraform";
+
+export class StepTerraform extends React.Component {
   static propTypes = {
     location: PropTypes.shape({
       pathname: PropTypes.string,
     }).isRequired,
-    routeId: PropTypes.string.isRequired,
+    currentRoute: PropTypes.shape({
+      id: PropTypes.string,
+      phase: PropTypes.string,
+    }).isRequired,
     startPoll: PropTypes.func.isRequired,
     gotoRoute: PropTypes.func.isRequired,
     initializeStep: PropTypes.func.isRequired,
@@ -27,12 +32,13 @@ export default class StepPreparingTerraform extends React.Component {
 
   componentDidMount() {
     const {
-      routeId,
-      location,
       startPollingStep,
+      currentRoute,
     } = this.props;
 
-    startPollingStep(location, routeId);
+    if (currentRoute.phase === TERRAFORM_PHASE) {
+      startPollingStep(currentRoute.id);
+    }
   }
 
   componentDidUpdate() {
@@ -87,11 +93,11 @@ export default class StepPreparingTerraform extends React.Component {
     const {
       handleAction,
       startPoll,
-      routeId,
+      currentRoute,
       gotoRoute,
     } = this.props;
     handleAction(action, false);
-    startPoll(routeId, gotoRoute);
+    startPoll(currentRoute.id, gotoRoute);
   }
 
   scrollToLogsBottom = (elm) => {
@@ -153,7 +159,7 @@ export default class StepPreparingTerraform extends React.Component {
           : null
         }
         {status === "error" ?
-          <div className="Error--wrapper flex flex-column alignItems--center"> 
+          <div className="Error--wrapper flex flex-column alignItems--center">
             <div className="icon progress-detail-error"></div>
             <p className="u-fontSizer--larger u-color--tundora u-lineHeight--normal u-fontWeight--bold u-marginTop--normal u-textAlign--center">{message}</p>
           </div>

--- a/web/init/src/components/shared/StepTerraform.spec.js
+++ b/web/init/src/components/shared/StepTerraform.spec.js
@@ -1,13 +1,16 @@
 import React from "react";
 
-import StepTerraform from "./StepTerraform";
+import { TERRAFORM_PHASE, StepTerraform } from "./StepTerraform";
 import renderer from "react-test-renderer";
 
 const mockProps = {
   location: {
     pathname: "",
   },
-  routeId: "",
+  currentRoute: {
+    phase: TERRAFORM_PHASE,
+    id: "hotdog",
+  },
   startPoll: jest.fn(),
   gotoRoute: jest.fn(),
   initializeStep: jest.fn(),


### PR DESCRIPTION
What I Did
------------
- Fix UI for workflows with multiple async lifecycle steps

How I Did it
------------
- Previously, we were finding routes via the current `phase` that we are in (e.g. `kubectl`, `terraform`, etc.) Route phases are not unique as multiple `kubectl` steps will have the same `phase`. In order to reconcile this, the route `id` is now being used as it is unique to the each step.

How to verify it
------------
- Run `ship init fixtures/kubectl/ship.yml` to observe fixed functionality
- Previous functionality can be verified via `ship init fixtures/terraform/ship.yaml` and `ship init ${helm_chart}`

Description for the Changelog
------------
- Fix UI for workflows with multiple async lifecycle steps


Picture of a Boat (not required but encouraged)
------------
🛶 











<!-- (thanks https://github.com/docker/docker for this template) -->

