### PR TITLE
Allow saving after reaching error state on helm values step in UI

### DIFF
--- a/web/init/src/components/kustomize/HelmValuesEditor.jsx
+++ b/web/init/src/components/kustomize/HelmValuesEditor.jsx
@@ -43,7 +43,7 @@ export default class HelmValuesEditor extends React.Component {
     }
   }
 
-  
+
 
   getLinterErrors = (specContents) => {
     if (specContents === "") return;
@@ -120,7 +120,8 @@ export default class HelmValuesEditor extends React.Component {
           if (errors) {
             return this.setState({
               saving: false,
-              helmLintErrors: errors
+              helmLintErrors: errors,
+              saveFinal: false,
             });
           }
           this.setState({ saving: false, savedYaml: true });

--- a/web/init/src/components/kustomize/HelmValuesEditor.spec.js
+++ b/web/init/src/components/kustomize/HelmValuesEditor.spec.js
@@ -1,0 +1,66 @@
+import React from "react";
+import { shallow } from "enzyme";
+import HelmValuesEditor from "./HelmValuesEditor";
+
+const mockShipAppMetadata = {
+  values: "some: values",
+  readme: "a readme",
+  name: "test",
+}
+
+const mockGetStep = {};
+
+describe("HelmValuesEditor", () => {
+  describe("with invalid helm values", () => {
+    describe("saved and finalized", () => {
+      it("allows for the save button to be clicked after an error", async() => {
+        const mockSaveValues = jest.fn();
+        mockSaveValues.mockImplementation(() => Promise.resolve({ errors: ["Test error"]}));
+
+        const mockSpecValue = "some: different values";
+        const wrapper = shallow(
+          <HelmValuesEditor
+            shipAppMetadata={mockShipAppMetadata}
+            saveValues={mockSaveValues}
+            getStep={mockGetStep}
+          />
+        );
+
+        wrapper.setState({ specValue: mockSpecValue });
+        await wrapper.instance().handleSaveValues(true);
+
+        expect(mockSaveValues.mock.calls).toHaveLength(1);
+        const elements = wrapper.find("button");
+        expect(elements).toHaveLength(2);
+        elements.forEach((element) => {
+          expect(element.prop("disabled")).toEqual(false);
+        });
+      });
+    });
+    describe("saved", () => {
+      it("allows for the save button to be clicked after an error", async() => {
+        const mockSaveValues = jest.fn();
+        mockSaveValues.mockImplementation(() => Promise.resolve({ errors: ["Test error"]}));
+
+        const mockSpecValue = "some: different values";
+        const wrapper = shallow(
+          <HelmValuesEditor
+            shipAppMetadata={mockShipAppMetadata}
+            saveValues={mockSaveValues}
+            getStep={mockGetStep}
+          />
+        );
+
+        wrapper.setState({ specValue: mockSpecValue });
+        await wrapper.instance().handleSaveValues(false);
+
+        expect(mockSaveValues.mock.calls).toHaveLength(1);
+        const elements = wrapper.find("button");
+        expect(elements).toHaveLength(2);
+        elements.forEach((element) => {
+          expect(element.prop("disabled")).toEqual(false);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
What I Did
------------
- Allow saving after reaching error state on helm values step in UI

How I Did it
------------
- Booleans

How to verify it
------------
- Tests, Run `ship init`, provide invalid yaml to helm values step - saving will be allowed 

Description for the Changelog
------------
- Allow saving after reaching error state on helm values step in UI


Picture of a Boat (not required but encouraged)
------------
🛶 











<!-- (thanks https://github.com/docker/docker for this template) -->

