### PR TITLE
Split full/slim docker builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -485,7 +485,7 @@ jobs:
                curl -sL https://git.io/goreleaser | bash -s -- --config deploy/.goreleaser.yml
 
                # build terraform/eks enabled version.  TODO semver, for now just expose latest
-               docker pull replicated/ship:latest # this should be a no-op since we just built it, but just in case
+               docker pull replicated/ship:slim # this should be a no-op since we just built it, but just in case
                docker build -t replicated/ship:full -f deploy/Dockerfile-full deploy
                docker push replicated/ship:full
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -444,6 +444,10 @@ jobs:
               curl -sL https://git.io/goreleaser | bash -s -- --snapshot --config deploy/.goreleaser.unstable.yml
               docker login -u="$DOCKERHUB_DOCKER_USER" -p="$DOCKERHUB_DOCKER_PASS"
               docker push replicated/ship:alpha
+
+              # build terraform/eks enabled version
+              docker build --build-arg=source_tag=alpha-slim -t replicated/ship:alpha-full -f deploy/Dockerfile-full deploy
+              docker push replicated/ship:alpha-full
             fi
 
   deploy_integration:
@@ -478,7 +482,13 @@ jobs:
           command: |
             if [ "${CIRCLE_PROJECT_USERNAME}" == "replicatedhq" ]; then
                docker login -u="$DOCKERHUB_DOCKER_USER" -p="$DOCKERHUB_DOCKER_PASS"
-              curl -sL https://git.io/goreleaser | bash -s -- --config deploy/.goreleaser.yml
+               curl -sL https://git.io/goreleaser | bash -s -- --config deploy/.goreleaser.yml
+
+               # build terraform/eks enabled version.  TODO semver, for now just expose latest
+               docker pull replicated/ship:latest # this should be a no-op since we just built it, but just in case
+               docker build -t replicated/ship:full -f deploy/Dockerfile-full deploy
+               docker push replicated/ship:full
+
             fi
       # todo drop a release-api message to bump a version in the DB
 

--- a/deploy/.goreleaser.unstable.yml
+++ b/deploy/.goreleaser.unstable.yml
@@ -48,5 +48,6 @@ dockers:
     dockerfile: deploy/Dockerfile
     tag_templates:
       - "alpha"
+      - "alpha-slim"
 snapshot:
   name_template: SNAPSHOT-{{ .Commit }}

--- a/deploy/.goreleaser.yml
+++ b/deploy/.goreleaser.yml
@@ -51,5 +51,9 @@ dockers:
       - "{{ .Major }}"
       - "{{ .Major }}.{{ .Minor }}"
       - "{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+      - "slim"
+      - "{{ .Major }}-slim"
+      - "{{ .Major }}.{{ .Minor }}-slim"
+      - "{{ .Major }}.{{ .Minor }}.{{ .Patch }}-slim"
 snapshot:
   name_template: SNAPSHOT-{{ .Commit }}

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -3,23 +3,6 @@ RUN apk add --no-cache ca-certificates curl git && update-ca-certificates
 COPY ship /ship
 ENV IN_CONTAINER 1
 ENV NO_OPEN 1
-
-ENV TERRAFORM_VERSION=0.11.10
-ENV TERRAFORM_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
-ENV TERRAFORM_ZIP="terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
-ENV TERRAFORM_SHA256SUM=43543a0e56e31b0952ea3623521917e060f2718ab06fe2b2d506cfaa14d54527
-
-
-ENV KUBECTL_VERSION=v1.11.1
-ENV KUBECTL_URL=https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
-ENV KUBECTL_SHA256SUM=d16a4e7bfe0033ea5f56f8d11e74f7a2dec5ff8832a046a643c8355b79b4ba5c
-
-RUN curl -fsSLO "${KUBECTL_URL}" \
-	&& echo "${KUBECTL_SHA256SUM}  kubectl" | sha256sum -c - \
-	&& chmod +x kubectl \
-	&& mv kubectl "/usr/local/bin/kubectl-${KUBECTL_VERSION}" \
-	&& ln -s "/usr/local/bin/kubectl-${KUBECTL_VERSION}" /usr/local/bin/kubectl
-
 LABEL "com.replicated.ship"="true"
 WORKDIR /out
 ENTRYPOINT [ "/ship" ]

--- a/deploy/Dockerfile-full
+++ b/deploy/Dockerfile-full
@@ -1,0 +1,34 @@
+ARG source_tag=slim
+FROM replicated/ship:${source_tag}
+
+ENV TERRAFORM_VERSION=0.11.10
+ENV TERRAFORM_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
+ENV TERRAFORM_ZIP="terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
+ENV TERRAFORM_SHA256SUM=43543a0e56e31b0952ea3623521917e060f2718ab06fe2b2d506cfaa14d54527
+
+RUN curl -fsSLO "$TERRAFORM_URL" \
+	&& echo "${TERRAFORM_SHA256SUM}  ${TERRAFORM_ZIP}" | sha256sum -c - \
+	&& unzip "$TERRAFORM_ZIP" \
+	&& mv "terraform" "/usr/local/bin/terraform-${TERRAFORM_VERSION}" \
+	&& ln -s "/usr/local/bin/terraform-${TERRAFORM_VERSION}" /usr/local/bin/terraform \
+	&& rm $TERRAFORM_ZIP
+
+ENV AWS_IAM_AUTHENTICATOR_VERSION=1.11.5
+ENV AWS_IAM_AUTHENTICATOR_URL=https://amazon-eks.s3-us-west-2.amazonaws.com/1.11.5/2018-12-06/bin/linux/amd64/aws-iam-authenticator
+ENV AWS_IAM_AUTHENTICATOR_SHA256SUM=a46c66eb14ad08204f2f588b32dc50b10e9a8a0cc48ddf0966596d3c07abe059
+RUN curl -o aws-iam-authenticator -fsSLO  "$AWS_IAM_AUTHENTICATOR_URL" \
+	&& echo "${AWS_IAM_AUTHENTICATOR_SHA256SUM}  aws-iam-authenticator" | sha256sum -c - \
+	&& chmod +x aws-iam-authenticator \
+	&& mv "aws-iam-authenticator" "/usr/local/bin/aws-iam-authenticator"
+
+
+ENV KUBECTL_VERSION=v1.11.1
+ENV KUBECTL_URL=https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
+ENV KUBECTL_SHA256SUM=d16a4e7bfe0033ea5f56f8d11e74f7a2dec5ff8832a046a643c8355b79b4ba5c
+
+RUN curl -fsSLO "${KUBECTL_URL}" \
+	&& echo "${KUBECTL_SHA256SUM}  kubectl" | sha256sum -c - \
+	&& chmod +x kubectl \
+	&& mv kubectl "/usr/local/bin/kubectl-${KUBECTL_VERSION}" \
+	&& ln -s "/usr/local/bin/kubectl-${KUBECTL_VERSION}" /usr/local/bin/kubectl
+

--- a/integration/init/jaeger-helm/expected/base/charts/cassandra/templates/service.yaml
+++ b/integration/init/jaeger-helm/expected/base/charts/cassandra/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     app: cassandra
-    chart: cassandra-0.9.4
+    chart: cassandra-0.9.5
     heritage: Tiller
     release: jaeger
   name: jaeger-cassandra

--- a/integration/init/jaeger-helm/expected/base/charts/cassandra/templates/statefulset.yaml
+++ b/integration/init/jaeger-helm/expected/base/charts/cassandra/templates/statefulset.yaml
@@ -3,7 +3,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: cassandra
-    chart: cassandra-0.9.4
+    chart: cassandra-0.9.5
     heritage: Tiller
     release: jaeger
   name: jaeger-cassandra

--- a/integration/init/jaeger-helm/expected/rendered.yaml
+++ b/integration/init/jaeger-helm/expected/rendered.yaml
@@ -69,7 +69,7 @@ kind: Service
 metadata:
   labels:
     app: cassandra
-    chart: cassandra-0.9.4
+    chart: cassandra-0.9.5
     heritage: Tiller
     release: jaeger
   name: jaeger-cassandra
@@ -157,7 +157,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: cassandra
-    chart: cassandra-0.9.4
+    chart: cassandra-0.9.5
     heritage: Tiller
     release: jaeger
   name: jaeger-cassandra


### PR DESCRIPTION
What I Did
------------

Split full/slim docker builds into a `slim` tag, that has the ship
binary and not much else, and a `full` tag, that has `kubectl`,
`terraform`, `aws-iam-authenticator`, and whatever else we might end up
wanting to add in. `latest` remains the same minus `kubectl`, it is the same as `slim`
 
How I Did it
------------

- new Dockerfile in `deploy/Dockerfile-full`
        - pulls from `replicated/ship:latest` by default, customizable via build tag
        - adds in all the tools we need for doing fancy terraform appliance setups
- remove `kubectl` install from `deploy/Dockerfile`
- update goreleaser to add a copy of build with `-slim` suffix, so now
for a tag `0.22.0` we create
    - `latest`
    - `slim`
    - `0`
    - `0-slim`
    - `0.22`
    - `0.22-slim`
    - `0.22.0`
    - `0.22.0-slim`

- add to stable `deploy` circle job to also build/publish a `full` tag.  I'd like to add as well `0-full`, `0.22-full`, `0.22.0-full`, etc. But want to get initial feedback on this first.

- add to unstable `deploy_unstable` circle job to also build/publish a `alpha-full` tag.

The `-full` builds get built in the circle script rather than goreleaser, because goreleaser was giving me a weird error when trying to do multiple `dockers`.

How to verify it
------------

I've pushed the results to `dexhorthy/ship:latest` and `dexhorthy/ship:full`, so you can try any terraform-powered app yaml using either of those images.

Description for the Changelog
------------

Publish an official version of the `ship` image that includes `terraform`, `kubectl`, and `aws-iam-authenticator` bundled in. The latest version will be available under the `replicatedh/ship:full` tag in docker hub. Tagged versions will be available with the `-full` suffix, e.g. `0.30.0-full`.

:ship: