### PR TITLE
No trailing newline integration test

### DIFF
--- a/integration/init/plain-k8s-no-trailing-newline/expected/.ship/state.json
+++ b/integration/init/plain-k8s-no-trailing-newline/expected/.ship/state.json
@@ -1,0 +1,9 @@
+{
+  "v1": {
+    "config": {},
+    "releaseName": "ship",
+    "upstream": "https://github.com/replicatedhq/test-charts/tree/960955cdcf61891c3b5ff27c25dcde0184926add/plain-k8s-no-trailing-newline",
+    "metadata": null,
+    "contentSHA": "e03f03a48d619be6a9ff2c56c19808b0cfa2cb84615346b1c867eeca20ff92d0"
+  }
+}

--- a/integration/init/plain-k8s-no-trailing-newline/expected/base/frontend-deployment.yaml
+++ b/integration/init/plain-k8s-no-trailing-newline/expected/base/frontend-deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: guestbook
+      tier: frontend
+  template:
+    metadata:
+      labels:
+        app: guestbook
+        tier: frontend
+    spec:
+      containers:
+      - env:
+        - name: GET_HOSTS_FROM
+          value: dns
+        image: gcr.io/google-samples/gb-frontend:v4
+        name: php-redis
+        ports:
+        - containerPort: 80
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi

--- a/integration/init/plain-k8s-no-trailing-newline/expected/base/frontend-service.yaml
+++ b/integration/init/plain-k8s-no-trailing-newline/expected/base/frontend-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: guestbook
+    tier: frontend
+  name: frontend
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: guestbook
+    tier: frontend
+  type: NodePort

--- a/integration/init/plain-k8s-no-trailing-newline/expected/base/kustomization.yaml
+++ b/integration/init/plain-k8s-no-trailing-newline/expected/base/kustomization.yaml
@@ -1,0 +1,9 @@
+kind: ""
+apiversion: ""
+resources:
+- frontend-deployment.yaml
+- frontend-service.yaml
+- redis-master-deployment.yaml
+- redis-master-service.yaml
+- redis-slave-deployment.yaml
+- redis-slave-service.yaml

--- a/integration/init/plain-k8s-no-trailing-newline/expected/base/redis-master-deployment.yaml
+++ b/integration/init/plain-k8s-no-trailing-newline/expected/base/redis-master-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-master
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+      role: master
+      tier: backend
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: master
+        tier: backend
+    spec:
+      containers:
+      - image: k8s.gcr.io/redis:e2e
+        name: master
+        ports:
+        - containerPort: 6379
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi

--- a/integration/init/plain-k8s-no-trailing-newline/expected/base/redis-master-service.yaml
+++ b/integration/init/plain-k8s-no-trailing-newline/expected/base/redis-master-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: redis
+    role: master
+    tier: backend
+  name: redis-master
+spec:
+  ports:
+  - port: 6379
+    targetPort: 6379
+  selector:
+    app: redis
+    role: master
+    tier: backend

--- a/integration/init/plain-k8s-no-trailing-newline/expected/base/redis-slave-deployment.yaml
+++ b/integration/init/plain-k8s-no-trailing-newline/expected/base/redis-slave-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-slave
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: redis
+      role: slave
+      tier: backend
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: slave
+        tier: backend
+    spec:
+      containers:
+      - env:
+        - name: GET_HOSTS_FROM
+          value: dns
+        image: gcr.io/google_samples/gb-redisslave:v1
+        name: slave
+        ports:
+        - containerPort: 6379
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi

--- a/integration/init/plain-k8s-no-trailing-newline/expected/base/redis-slave-service.yaml
+++ b/integration/init/plain-k8s-no-trailing-newline/expected/base/redis-slave-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: redis
+    role: slave
+    tier: backend
+  name: redis-slave
+spec:
+  ports:
+  - port: 6379
+  selector:
+    app: redis
+    role: slave
+    tier: backend
+    zquotenum: "123"

--- a/integration/init/plain-k8s-no-trailing-newline/expected/overlays/ship/kustomization.yaml
+++ b/integration/init/plain-k8s-no-trailing-newline/expected/overlays/ship/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: ""
+apiversion: ""
+bases:
+- ../../base

--- a/integration/init/plain-k8s-no-trailing-newline/expected/rendered.yaml
+++ b/integration/init/plain-k8s-no-trailing-newline/expected/rendered.yaml
@@ -1,0 +1,136 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: guestbook
+    tier: frontend
+  name: frontend
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: guestbook
+    tier: frontend
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: redis
+    role: master
+    tier: backend
+  name: redis-master
+spec:
+  ports:
+  - port: 6379
+    targetPort: 6379
+  selector:
+    app: redis
+    role: master
+    tier: backend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: redis
+    role: slave
+    tier: backend
+  name: redis-slave
+spec:
+  ports:
+  - port: 6379
+  selector:
+    app: redis
+    role: slave
+    tier: backend
+    zquotenum: "123"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: guestbook
+      tier: frontend
+  template:
+    metadata:
+      labels:
+        app: guestbook
+        tier: frontend
+    spec:
+      containers:
+      - env:
+        - name: GET_HOSTS_FROM
+          value: dns
+        image: gcr.io/google-samples/gb-frontend:v4
+        name: php-redis
+        ports:
+        - containerPort: 80
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-master
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+      role: master
+      tier: backend
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: master
+        tier: backend
+    spec:
+      containers:
+      - image: k8s.gcr.io/redis:e2e
+        name: master
+        ports:
+        - containerPort: 6379
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-slave
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: redis
+      role: slave
+      tier: backend
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: slave
+        tier: backend
+    spec:
+      containers:
+      - env:
+        - name: GET_HOSTS_FROM
+          value: dns
+        image: gcr.io/google_samples/gb-redisslave:v1
+        name: slave
+        ports:
+        - containerPort: 6379
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi

--- a/integration/init/plain-k8s-no-trailing-newline/metadata.yaml
+++ b/integration/init/plain-k8s-no-trailing-newline/metadata.yaml
@@ -1,0 +1,3 @@
+upstream: "https://github.com/replicatedhq/test-charts/tree/960955cdcf61891c3b5ff27c25dcde0184926add/plain-k8s-no-trailing-newline"
+args: ["--prefer-git"]
+skip_cleanup: false

--- a/integration/update/k8s-no-trailing-newline/expected/.ship/state.json
+++ b/integration/update/k8s-no-trailing-newline/expected/.ship/state.json
@@ -1,0 +1,19 @@
+{
+  "v1": {
+    "config": {},
+    "releaseName": "ship",
+    "kustomize": {
+      "overlays": {
+        "ship": {
+          "patches": {
+            "/redis-master-service.yaml": "apiVersion: v1\nkind: Service\nmetadata:\n  labels:\n    app: redis\n    role: master\n    tier: backend\n  name: redis-master\nspec:\n  selector:\n    zquotenum: \"456\"\n",
+            "/redis-slave-service.yaml": "apiVersion: v1\nkind: Service\nmetadata:\n  labels:\n    app: redis\n    role: slave\n    tier: backend\n  name: redis-slave\nspec:\n  selector:\n    zquotenum: \"987\"\n"
+          }
+        }
+      }
+    },
+    "upstream": "https://github.com/replicatedhq/test-charts/tree/960955cdcf61891c3b5ff27c25dcde0184926add/plain-k8s-no-trailing-newline",
+    "metadata": null,
+    "contentSHA": "e03f03a48d619be6a9ff2c56c19808b0cfa2cb84615346b1c867eeca20ff92d0"
+  }
+}

--- a/integration/update/k8s-no-trailing-newline/expected/base/frontend-deployment.yaml
+++ b/integration/update/k8s-no-trailing-newline/expected/base/frontend-deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: guestbook
+      tier: frontend
+  template:
+    metadata:
+      labels:
+        app: guestbook
+        tier: frontend
+    spec:
+      containers:
+      - env:
+        - name: GET_HOSTS_FROM
+          value: dns
+        image: gcr.io/google-samples/gb-frontend:v4
+        name: php-redis
+        ports:
+        - containerPort: 80
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi

--- a/integration/update/k8s-no-trailing-newline/expected/base/frontend-service.yaml
+++ b/integration/update/k8s-no-trailing-newline/expected/base/frontend-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: guestbook
+    tier: frontend
+  name: frontend
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: guestbook
+    tier: frontend
+  type: NodePort

--- a/integration/update/k8s-no-trailing-newline/expected/base/kustomization.yaml
+++ b/integration/update/k8s-no-trailing-newline/expected/base/kustomization.yaml
@@ -1,0 +1,9 @@
+kind: ""
+apiversion: ""
+resources:
+- frontend-deployment.yaml
+- frontend-service.yaml
+- redis-master-deployment.yaml
+- redis-master-service.yaml
+- redis-slave-deployment.yaml
+- redis-slave-service.yaml

--- a/integration/update/k8s-no-trailing-newline/expected/base/redis-master-deployment.yaml
+++ b/integration/update/k8s-no-trailing-newline/expected/base/redis-master-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-master
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+      role: master
+      tier: backend
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: master
+        tier: backend
+    spec:
+      containers:
+      - image: k8s.gcr.io/redis:e2e
+        name: master
+        ports:
+        - containerPort: 6379
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi

--- a/integration/update/k8s-no-trailing-newline/expected/base/redis-master-service.yaml
+++ b/integration/update/k8s-no-trailing-newline/expected/base/redis-master-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: redis
+    role: master
+    tier: backend
+  name: redis-master
+spec:
+  ports:
+  - port: 6379
+    targetPort: 6379
+  selector:
+    app: redis
+    role: master
+    tier: backend

--- a/integration/update/k8s-no-trailing-newline/expected/base/redis-slave-deployment.yaml
+++ b/integration/update/k8s-no-trailing-newline/expected/base/redis-slave-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-slave
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: redis
+      role: slave
+      tier: backend
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: slave
+        tier: backend
+    spec:
+      containers:
+      - env:
+        - name: GET_HOSTS_FROM
+          value: dns
+        image: gcr.io/google_samples/gb-redisslave:v1
+        name: slave
+        ports:
+        - containerPort: 6379
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi

--- a/integration/update/k8s-no-trailing-newline/expected/base/redis-slave-service.yaml
+++ b/integration/update/k8s-no-trailing-newline/expected/base/redis-slave-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: redis
+    role: slave
+    tier: backend
+  name: redis-slave
+spec:
+  ports:
+  - port: 6379
+  selector:
+    app: redis
+    role: slave
+    tier: backend
+    zquotenum: "123"

--- a/integration/update/k8s-no-trailing-newline/expected/overlays/ship/kustomization.yaml
+++ b/integration/update/k8s-no-trailing-newline/expected/overlays/ship/kustomization.yaml
@@ -1,0 +1,7 @@
+kind: ""
+apiversion: ""
+bases:
+- ../../base
+patchesStrategicMerge:
+- redis-master-service.yaml
+- redis-slave-service.yaml

--- a/integration/update/k8s-no-trailing-newline/expected/overlays/ship/redis-master-service.yaml
+++ b/integration/update/k8s-no-trailing-newline/expected/overlays/ship/redis-master-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: redis
+    role: master
+    tier: backend
+  name: redis-master
+spec:
+  selector:
+    zquotenum: "456"

--- a/integration/update/k8s-no-trailing-newline/expected/overlays/ship/redis-slave-service.yaml
+++ b/integration/update/k8s-no-trailing-newline/expected/overlays/ship/redis-slave-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: redis
+    role: slave
+    tier: backend
+  name: redis-slave
+spec:
+  selector:
+    zquotenum: "987"

--- a/integration/update/k8s-no-trailing-newline/expected/rendered.yaml
+++ b/integration/update/k8s-no-trailing-newline/expected/rendered.yaml
@@ -1,0 +1,137 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: guestbook
+    tier: frontend
+  name: frontend
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: guestbook
+    tier: frontend
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: redis
+    role: master
+    tier: backend
+  name: redis-master
+spec:
+  ports:
+  - port: 6379
+    targetPort: 6379
+  selector:
+    app: redis
+    role: master
+    tier: backend
+    zquotenum: "456"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: redis
+    role: slave
+    tier: backend
+  name: redis-slave
+spec:
+  ports:
+  - port: 6379
+  selector:
+    app: redis
+    role: slave
+    tier: backend
+    zquotenum: "987"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: guestbook
+      tier: frontend
+  template:
+    metadata:
+      labels:
+        app: guestbook
+        tier: frontend
+    spec:
+      containers:
+      - env:
+        - name: GET_HOSTS_FROM
+          value: dns
+        image: gcr.io/google-samples/gb-frontend:v4
+        name: php-redis
+        ports:
+        - containerPort: 80
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-master
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+      role: master
+      tier: backend
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: master
+        tier: backend
+    spec:
+      containers:
+      - image: k8s.gcr.io/redis:e2e
+        name: master
+        ports:
+        - containerPort: 6379
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-slave
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: redis
+      role: slave
+      tier: backend
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: slave
+        tier: backend
+    spec:
+      containers:
+      - env:
+        - name: GET_HOSTS_FROM
+          value: dns
+        image: gcr.io/google_samples/gb-redisslave:v1
+        name: slave
+        ports:
+        - containerPort: 6379
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi

--- a/integration/update/k8s-no-trailing-newline/input/.ship/state.json
+++ b/integration/update/k8s-no-trailing-newline/input/.ship/state.json
@@ -1,0 +1,27 @@
+{
+  "v1": {
+    "config": null,
+    "releaseName": "ship",
+    "kustomize": {
+      "overlays": {
+        "ship": {
+          "patches": {
+            "/redis-master-service.yaml": "apiVersion: v1\nkind: Service\nmetadata:\n  labels:\n    app: redis\n    role: master\n    tier: backend\n  name: redis-master\nspec:\n  selector:\n    zquotenum: \"456\"\n",
+            "/redis-slave-service.yaml": "apiVersion: v1\nkind: Service\nmetadata:\n  labels:\n    app: redis\n    role: slave\n    tier: backend\n  name: redis-slave\nspec:\n  selector:\n    zquotenum: \"987\"\n"
+          }
+        }
+      }
+    },
+    "upstream": "https://github.com/replicatedhq/test-charts/tree/960955cdcf61891c3b5ff27c25dcde0184926add/plain-k8s-no-trailing-newline",
+    "metadata": null,
+    "contentSHA": "e03f03a48d619be6a9ff2c56c19808b0cfa2cb84615346b1c867eeca20ff92d0",
+    "lifecycle": {
+      "stepsCompleted": {
+        "kustomize": true,
+        "kustomize-intro": true,
+        "outro": true,
+        "render": true
+      }
+    }
+  }
+}

--- a/integration/update/k8s-no-trailing-newline/metadata.yaml
+++ b/integration/update/k8s-no-trailing-newline/metadata.yaml
@@ -1,0 +1,3 @@
+args: ["--prefer-git"]
+
+skip_cleanup: false


### PR DESCRIPTION
What I Did
------------
Added integration tests based on the upstream here: https://github.com/replicatedhq/test-charts/tree/960955cdcf61891c3b5ff27c25dcde0184926add/plain-k8s-no-trailing-newline

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------




![USS Cassin (DD-372)](https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/USS_Cassin_%28DD-372%29.png/2560px-USS_Cassin_%28DD-372%29.png "USS Cassin (DD-372)")







<!-- (thanks https://github.com/docker/docker for this template) -->

