### PR TITLE
Omit metadata from state file when it's nil

### DIFF
--- a/integration/init/cockroach/expected/.ship/state.json
+++ b/integration/init/cockroach/expected/.ship/state.json
@@ -3,7 +3,6 @@
     "config": {},
     "releaseName": "ship",
     "upstream": "https://raw.githubusercontent.com/cockroachdb/cockroach/v2.0.6/cloud/kubernetes/cockroachdb-statefulset-secure.yaml",
-    "metadata": null,
     "contentSHA": "4e8ef4ad3601ea5b1970b22010af6b21bc6f16d849cb3af0e973cf2447f79009"
   }
 }

--- a/integration/init/git-single-file-gogetter/expected/.ship/state.json
+++ b/integration/init/git-single-file-gogetter/expected/.ship/state.json
@@ -3,7 +3,6 @@
     "config": {},
     "releaseName": "ship",
     "upstream": "github.com/replicatedhq/test-charts/blob/3427d6997bd150c60caa00ba0298fdfe17e3ed04/plain-k8s/frontend-deployment.yaml",
-    "metadata": null,
     "contentSHA": "9fa025c3fdbcc02c7de8e9c74c8058d16b2aada04917895685504b387563afda"
   }
 }

--- a/integration/init/git-single-file/expected/.ship/state.json
+++ b/integration/init/git-single-file/expected/.ship/state.json
@@ -3,7 +3,6 @@
     "config": {},
     "releaseName": "ship",
     "upstream": "github.com/replicatedhq/test-charts/blob/3427d6997bd150c60caa00ba0298fdfe17e3ed04/plain-k8s/frontend-deployment.yaml",
-    "metadata": null,
     "contentSHA": "9fa025c3fdbcc02c7de8e9c74c8058d16b2aada04917895685504b387563afda"
   }
 }

--- a/integration/init/github-no-proxy-gogetter/expected/.ship/state.json
+++ b/integration/init/github-no-proxy-gogetter/expected/.ship/state.json
@@ -3,7 +3,6 @@
     "config": {},
     "releaseName": "ship",
     "upstream": "__upstream__",
-    "metadata": null,
     "contentSHA": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   }
 }

--- a/integration/init/github-no-proxy/expected/.ship/state.json
+++ b/integration/init/github-no-proxy/expected/.ship/state.json
@@ -3,7 +3,6 @@
     "config": {},
     "releaseName": "ship",
     "upstream": "__upstream__",
-    "metadata": null,
     "contentSHA": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   }
 }

--- a/integration/init/just-ship-yaml/expected/.ship/state.json
+++ b/integration/init/just-ship-yaml/expected/.ship/state.json
@@ -3,7 +3,6 @@
     "config": {},
     "releaseName": "ship",
     "upstream": "https://github.com/replicatedhq/test-charts/tree/ebebc9e692db3caeadb308ddeec37e9565acba1e/just-ship-yaml",
-    "metadata": null,
     "contentSHA": "b2234e03feee0754ad02d0a8542c467829da12d13407e268926771f6b560ac83"
   }
 }

--- a/integration/init/local-single-file-gogetter/expected/.ship/state.json
+++ b/integration/init/local-single-file-gogetter/expected/.ship/state.json
@@ -3,7 +3,6 @@
     "config": null,
     "releaseName": "ship",
     "upstream": "__upstream__",
-    "metadata": null,
     "contentSHA": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   }
 }

--- a/integration/init/plain-k8s-gogetter/expected/.ship/state.json
+++ b/integration/init/plain-k8s-gogetter/expected/.ship/state.json
@@ -3,7 +3,6 @@
     "config": {},
     "releaseName": "ship",
     "upstream": "github.com/replicatedhq/test-charts?ref=3427d6997bd150c60caa00ba0298fdfe17e3ed04//plain-k8s",
-    "metadata": null,
     "contentSHA": "7d52a28c5b78539223c3548c2ee677b8b9d624f178e3aac1a15c0097f4e7cb62"
   }
 }

--- a/integration/init/plain-k8s-no-trailing-newline/expected/.ship/state.json
+++ b/integration/init/plain-k8s-no-trailing-newline/expected/.ship/state.json
@@ -3,7 +3,6 @@
     "config": {},
     "releaseName": "ship",
     "upstream": "https://github.com/replicatedhq/test-charts/tree/960955cdcf61891c3b5ff27c25dcde0184926add/plain-k8s-no-trailing-newline",
-    "metadata": null,
     "contentSHA": "e03f03a48d619be6a9ff2c56c19808b0cfa2cb84615346b1c867eeca20ff92d0"
   }
 }

--- a/integration/init/plain-k8s-withref/expected/.ship/state.json
+++ b/integration/init/plain-k8s-withref/expected/.ship/state.json
@@ -3,7 +3,6 @@
     "config": {},
     "releaseName": "ship",
     "upstream": "https://github.com/replicatedhq/test-charts/tree/3427d6997bd150c60caa00ba0298fdfe17e3ed04/plain-k8s",
-    "metadata": null,
     "contentSHA": "7d52a28c5b78539223c3548c2ee677b8b9d624f178e3aac1a15c0097f4e7cb62"
   }
 }

--- a/integration/init/plain-k8s/expected/.ship/state.json
+++ b/integration/init/plain-k8s/expected/.ship/state.json
@@ -3,7 +3,6 @@
     "config": {},
     "releaseName": "ship",
     "upstream": "github.com/replicatedhq/test-charts/plain-k8s",
-    "metadata": null,
     "contentSHA": "7d52a28c5b78539223c3548c2ee677b8b9d624f178e3aac1a15c0097f4e7cb62"
   }
 }

--- a/integration/update/certs/expected/.ship/state.json
+++ b/integration/update/certs/expected/.ship/state.json
@@ -3,7 +3,6 @@
     "config": {},
     "releaseName": "ship",
     "upstream": "https://github.com/replicatedhq/test-charts/tree/565a3003a45e369ec66035a899e36061da9a0fc4/cert-generation",
-    "metadata": null,
     "contentSHA": "a23a4f2e28da5bd6534057d3bd89ecaf43de832d7ad42707141d372dc7938b8a",
     "cas": {
       "ca1": {

--- a/integration/update/certs/input/.ship/state.json
+++ b/integration/update/certs/input/.ship/state.json
@@ -3,7 +3,6 @@
     "config": {},
     "releaseName": "ship",
     "upstream": "https://github.com/replicatedhq/test-charts/tree/565a3003a45e369ec66035a899e36061da9a0fc4/cert-generation",
-    "metadata": null,
     "contentSHA": "a23a4f2e28da5bd6534057d3bd89ecaf43de832d7ad42707141d372dc7938b8a",
     "cas": {
       "ca1": {

--- a/integration/update/k8s-no-trailing-newline/expected/.ship/state.json
+++ b/integration/update/k8s-no-trailing-newline/expected/.ship/state.json
@@ -13,7 +13,6 @@
       }
     },
     "upstream": "https://github.com/replicatedhq/test-charts/tree/960955cdcf61891c3b5ff27c25dcde0184926add/plain-k8s-no-trailing-newline",
-    "metadata": null,
     "contentSHA": "e03f03a48d619be6a9ff2c56c19808b0cfa2cb84615346b1c867eeca20ff92d0"
   }
 }

--- a/integration/update/k8s-no-trailing-newline/input/.ship/state.json
+++ b/integration/update/k8s-no-trailing-newline/input/.ship/state.json
@@ -13,7 +13,6 @@
       }
     },
     "upstream": "https://github.com/replicatedhq/test-charts/tree/960955cdcf61891c3b5ff27c25dcde0184926add/plain-k8s-no-trailing-newline",
-    "metadata": null,
     "contentSHA": "e03f03a48d619be6a9ff2c56c19808b0cfa2cb84615346b1c867eeca20ff92d0",
     "lifecycle": {
       "stepsCompleted": {

--- a/pkg/lifecycle/daemon/headless/daemon_test.go
+++ b/pkg/lifecycle/daemon/headless/daemon_test.go
@@ -39,7 +39,7 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{},"metadata":null}}`),
+			ExpectedValue: []byte(`{"v1":{"config":{}}}`),
 			ExpectedError: false,
 		},
 		{
@@ -63,7 +63,7 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":""},"metadata":null}}`),
+			ExpectedValue: []byte(`{"v1":{"config":{"alpha":""}}}`),
 			ExpectedError: false,
 		},
 		{
@@ -87,7 +87,7 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{},"metadata":null}}`),
+			ExpectedValue: []byte(`{"v1":{"config":{}}}`),
 			ExpectedError: true,
 		},
 		{
@@ -111,7 +111,7 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"100"},"metadata":null}}`),
+			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"100"}}}`),
 			ExpectedError: false,
 		},
 		{
@@ -135,7 +135,7 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"100"},"metadata":null}}`),
+			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"100"}}}`),
 			ExpectedError: false,
 		},
 		{
@@ -159,7 +159,7 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":""},"metadata":null}}`),
+			ExpectedValue: []byte(`{"v1":{"config":{"alpha":""}}}`),
 			ExpectedError: false,
 		},
 		{
@@ -183,7 +183,7 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":""},"metadata":null}}`),
+			ExpectedValue: []byte(`{"v1":{"config":{"alpha":""}}}`),
 			ExpectedError: false,
 		},
 		{
@@ -207,7 +207,7 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"100"},"metadata":null}}`),
+			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"100"}}}`),
 			ExpectedError: false,
 		},
 		{
@@ -231,7 +231,7 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":""},"metadata":null}}`),
+			ExpectedValue: []byte(`{"v1":{"config":{"alpha":""}}}`),
 			ExpectedError: false,
 		},
 		{
@@ -255,7 +255,7 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"100"},"metadata":null}}`),
+			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"100"}}}`),
 			ExpectedError: false,
 		},
 		{
@@ -286,7 +286,7 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"","beta":""},"metadata":null}}`),
+			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"","beta":""}}}`),
 			ExpectedError: false,
 		},
 		{
@@ -317,7 +317,7 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{},"metadata":null}}`),
+			ExpectedValue: []byte(`{"v1":{"config":{}}}`),
 			ExpectedError: true,
 		},
 		{
@@ -348,7 +348,7 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"","beta":""},"metadata":null}}`),
+			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"","beta":""}}}`),
 			ExpectedError: true,
 		},
 		{
@@ -379,7 +379,7 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"100","beta":"200"},"metadata":null}}`),
+			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"100","beta":"200"}}}`),
 			ExpectedError: false,
 		},
 		{
@@ -410,7 +410,7 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"101","beta":"101"},"metadata":null}}`),
+			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"101","beta":"101"}}}`),
 			ExpectedError: false,
 		},
 		{
@@ -441,7 +441,7 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"101","beta":"101"},"metadata":null}}`),
+			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"101","beta":"101"}}}`),
 			ExpectedError: false,
 		},
 		{
@@ -479,7 +479,7 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"100","beta":"100","charlie":"100"},"metadata":null}}`),
+			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"100","beta":"100","charlie":"100"}}}`),
 			ExpectedError: false,
 		},
 		{
@@ -552,7 +552,7 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"100","beta":"100","charlie":"100"},"metadata":null}}`),
+			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"100","beta":"100","charlie":"100"}}}`),
 			ExpectedError: true,
 		},
 	}

--- a/pkg/state/models.go
+++ b/pkg/state/models.go
@@ -72,7 +72,7 @@ type V1 struct {
 	HelmValuesDefaults string                 `json:"helmValuesDefaults,omitempty" yaml:"helmValuesDefaults,omitempty" hcl:"helmValuesDefaults,omitempty"`
 	Kustomize          *Kustomize             `json:"kustomize,omitempty" yaml:"kustomize,omitempty" hcl:"kustomize,omitempty"`
 	Upstream           string                 `json:"upstream,omitempty" yaml:"upstream,omitempty" hcl:"upstream,omitempty"`
-	Metadata           *Metadata              `json:"metadata" yaml:"metadata" hcl:"metadata"`
+	Metadata           *Metadata              `json:"metadata,omitempty" yaml:"metadata,omitempty" hcl:"metadata,omitempty"`
 
 	//deprecated in favor of upstream
 	ChartURL string `json:"chartURL,omitempty" yaml:"chartURL,omitempty" hcl:"chartURL,omitempty"`


### PR DESCRIPTION
What I Did
------------

Removed `"metadata": null` from state file.

How I Did it
------------

By adding `omitempty` tag

How to verify it
------------

1. Run `ship init --headless https://honeycomb.io/download/kubernetes/logs/quickstart.yaml`
1. Look in `.ship/state.json`

There should not be `"metadata": null` key and value.

Description for the Changelog
------------

Don't serialize the `"metadata"` key into state data when it's nil.


Picture of a Boat (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

