### PR TITLE
nginx example with release notes

### DIFF
--- a/fixtures/just-nginx-releasenotes/ship.yaml
+++ b/fixtures/just-nginx-releasenotes/ship.yaml
@@ -1,0 +1,93 @@
+assets:
+  v1:
+  - inline:
+      contents: |
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: example-nginx labels:
+            component: nginx
+        spec:
+          replicas: {{repl ConfigOption "nginx_replicas" }}
+          selector:
+            matchLabels:
+              component: nginx
+          template:
+            metadata:
+              labels:
+                component: nginx
+            spec:
+              containers:
+                - name: nginx
+                  image: nginx
+      dest: k8s/nginx-deployment.yaml
+      mode: 0644
+  - inline:
+      contents: |
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: example-nginx
+          labels:
+            component: nginx
+        spec:
+          type: LoadBalancer
+          ports:
+          - port: 80
+          selector:
+            component: nginx
+      dest: k8s/nginx-service.yaml
+      mode: 0644
+
+config:
+  v1:
+    - name: nginx
+      title: Nginx Settings
+      description: Nginx configuration
+      items:
+      - name: nginx_replicas
+        title: Nginx Replicas
+        help_text: How many replicas do you need to run?
+        type: text
+        default: 3
+      - name: nginx_memory
+        title: Nginx Memory
+        type: text
+        default: 100Mi
+
+lifecycle:
+  v1:
+    # custom markdown messaging
+    - message:
+        contents: |
+          # Nginx Installer
+
+          This installer will walk you through setting up a scalable nginx pool
+          that will serve high-quality, relevant web content.
+    - message:
+        contents: |
+          ### {{repl Installation "channel_name"}} v{{repl Installation "semver"}}
+
+          {{repl Installation "release_notes"}}
+
+    - message:
+        contents: |
+          # Prerequisites
+
+          This installer assumes you already have a Kubernetes cluster up and running,
+          and that you have `kubectl` configured to access that cluster.
+
+    # collect info according to the `config` section
+    - config:
+        invalidates: ["render"]
+    # render assets
+    - render:
+        requires: ["config"]
+    - message:
+        id: outro
+        contents: |
+          ## You're all set!
+
+          If you have `kubectl` configured locally, you can deploy nginx by running
+
+              kubectl apply -f installer/nginx.yaml


### PR DESCRIPTION
What I Did
------------

Add an nginx example with release notes to `fixtures/`.


How I Did it
------------

Copied `fixtures/just-nginx`, added a lifecycle step that uses `{{repl Installation ...}}` to pull release metadata.

:canoe: