### PR TITLE
Fix missing state file path in error message on "ship update"

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -59,7 +59,7 @@ func RootCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolP("navcycle", "", true, "set to false to run ship in v1/non-navigable mode (deprecated)")
 
 	cmd.PersistentFlags().String("state-from", "file", "type of resource to use when loading/saving state (currently supported values: 'file', 'secret'")
-	cmd.PersistentFlags().String("state-file", "", fmt.Sprintf("path to the state file to read from, defaults to %s", constants.StatePath))
+	cmd.PersistentFlags().String("state-file", constants.StatePath, fmt.Sprintf("path to the state file to read from, defaults to %s", constants.StatePath))
 	cmd.PersistentFlags().String("secret-namespace", "default", "namespace containing the state secret")
 	cmd.PersistentFlags().String("secret-name", "", "name of the secret to laod state from")
 	cmd.PersistentFlags().String("secret-key", "", "name of the key in the secret containing state")

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -59,7 +59,7 @@ func RootCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolP("navcycle", "", true, "set to false to run ship in v1/non-navigable mode (deprecated)")
 
 	cmd.PersistentFlags().String("state-from", "file", "type of resource to use when loading/saving state (currently supported values: 'file', 'secret'")
-	cmd.PersistentFlags().String("state-file", constants.StatePath, fmt.Sprintf("path to the state file to read from, defaults to %s", constants.StatePath))
+	cmd.PersistentFlags().String("state-file", "", fmt.Sprintf("path to the state file to read from, defaults to %s", constants.StatePath))
 	cmd.PersistentFlags().String("secret-namespace", "default", "namespace containing the state secret")
 	cmd.PersistentFlags().String("secret-name", "", "name of the secret to laod state from")
 	cmd.PersistentFlags().String("secret-key", "", "name of the key in the secret containing state")

--- a/pkg/lifecycle/kustomize/patch.go
+++ b/pkg/lifecycle/kustomize/patch.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
-
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"

--- a/pkg/lifecycle/kustomize/patch_test.go
+++ b/pkg/lifecycle/kustomize/patch_test.go
@@ -5,10 +5,9 @@ import (
 	"testing"
 
 	"github.com/ghodss/yaml"
-	"github.com/replicatedhq/ship/pkg/constants"
-
 	"github.com/go-kit/kit/log"
 	"github.com/replicatedhq/ship/pkg/api"
+	"github.com/replicatedhq/ship/pkg/constants"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 	kustomizepatch "sigs.k8s.io/kustomize/pkg/patch"

--- a/pkg/lifecycle/kustomize/pre_kustomize.go
+++ b/pkg/lifecycle/kustomize/pre_kustomize.go
@@ -6,12 +6,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/replicatedhq/ship/pkg/constants"
-
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/ship/pkg/api"
+	"github.com/replicatedhq/ship/pkg/constants"
 	"github.com/replicatedhq/ship/pkg/util"
 	yaml "gopkg.in/yaml.v2"
 )

--- a/pkg/lifecycle/render/helm/dependency.go
+++ b/pkg/lifecycle/render/helm/dependency.go
@@ -6,15 +6,13 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/constants"
-
 	"github.com/replicatedhq/ship/pkg/specs/apptype"
 	"github.com/replicatedhq/ship/pkg/specs/githubclient"
 	"github.com/replicatedhq/ship/pkg/specs/gogetter"
 	"github.com/replicatedhq/ship/pkg/util"
-
-	"github.com/pkg/errors"
-	"github.com/replicatedhq/ship/pkg/api"
 	"k8s.io/helm/pkg/chartutil"
 )
 

--- a/pkg/ship/update.go
+++ b/pkg/ship/update.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/ship/pkg/constants"
 	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
 	"github.com/replicatedhq/ship/pkg/state"
 )
@@ -33,15 +34,20 @@ func (s *Ship) Update(ctx context.Context) error {
 		return errors.Wrap(err, "load state")
 	}
 
+	uiPrintableStatePath := s.Viper.GetString("state-file")
+	if uiPrintableStatePath == "" {
+		uiPrintableStatePath = constants.StatePath
+	}
+
 	if _, noExistingState := existingState.(state.Empty); noExistingState {
 		debug.Log("event", "state.missing")
-		return errors.New(`No state file found at ` + s.Viper.GetString("state-file") + `, please run "ship init"`)
+		return errors.New(fmt.Sprintf(`No state file found at %s please run "ship init"`, uiPrintableStatePath))
 	}
 
 	debug.Log("event", "read.upstream")
 	upstreamURL := existingState.Upstream()
 	if upstreamURL == "" {
-		return errors.New(fmt.Sprintf(`No upstream URL found at %s, please run "ship init"`, s.Viper.GetString("state-file")))
+		return errors.New(fmt.Sprintf(`No upstream URL found at %s, please run "ship init"`, uiPrintableStatePath))
 	}
 
 	maybeVersionedUpstream, err := s.Resolver.MaybeResolveVersionedUpstream(ctx, upstreamURL, existingState)

--- a/pkg/ship/update.go
+++ b/pkg/ship/update.go
@@ -2,7 +2,6 @@ package ship
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -41,13 +40,13 @@ func (s *Ship) Update(ctx context.Context) error {
 
 	if _, noExistingState := existingState.(state.Empty); noExistingState {
 		debug.Log("event", "state.missing")
-		return errors.New(fmt.Sprintf(`No state file found at %s please run "ship init"`, uiPrintableStatePath))
+		return errors.Errorf(`No state file found at %s please run "ship init"`, uiPrintableStatePath)
 	}
 
 	debug.Log("event", "read.upstream")
 	upstreamURL := existingState.Upstream()
 	if upstreamURL == "" {
-		return errors.New(fmt.Sprintf(`No upstream URL found at %s, please run "ship init"`, uiPrintableStatePath))
+		return errors.Errorf(`No upstream URL found at %s, please run "ship init"`, uiPrintableStatePath)
 	}
 
 	maybeVersionedUpstream, err := s.Resolver.MaybeResolveVersionedUpstream(ctx, upstreamURL, existingState)

--- a/pkg/ship/watch.go
+++ b/pkg/ship/watch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/ship/pkg/constants"
 	"github.com/replicatedhq/ship/pkg/state"
 )
 
@@ -30,9 +31,15 @@ func (s *Ship) Watch(ctx context.Context) error {
 			return errors.Wrap(err, "load state")
 		}
 
+		// This is duped and should probably be a method on state.Manager or something
+		uiPrintableStatePath := s.Viper.GetString("state-file")
+		if uiPrintableStatePath == "" {
+			uiPrintableStatePath = constants.StatePath
+		}
+
 		if _, noExistingState := existingState.(state.Empty); noExistingState {
 			debug.Log("event", "state.missing")
-			return errors.New(`No state found, please run "ship init"`)
+			return errors.New(fmt.Sprintf(`No state found at %s, please run "ship init"`, uiPrintableStatePath))
 		}
 
 		debug.Log("event", "read.upstream")

--- a/pkg/ship/watch.go
+++ b/pkg/ship/watch.go
@@ -39,7 +39,7 @@ func (s *Ship) Watch(ctx context.Context) error {
 
 		if _, noExistingState := existingState.(state.Empty); noExistingState {
 			debug.Log("event", "state.missing")
-			return errors.New(fmt.Sprintf(`No state found at %s, please run "ship init"`, uiPrintableStatePath))
+			return errors.Errorf(`No state found at %s, please run "ship init"`, uiPrintableStatePath)
 		}
 
 		debug.Log("event", "read.upstream")

--- a/pkg/specs/apptype/determine_type.go
+++ b/pkg/specs/apptype/determine_type.go
@@ -96,7 +96,7 @@ func (r *inspector) DetermineApplicationType(ctx context.Context, upstream strin
 		return r.determineTypeFromContents(ctx, upstream, &fetcher)
 	}
 
-	return nil, errors.New(fmt.Sprintf("upstream %s is not a replicated app, a github repo, or compatible with go-getter", upstream))
+	return nil, errors.Errorf("upstream %s is not a replicated app, a github repo, or compatible with go-getter", upstream)
 }
 
 func (r *inspector) determineTypeFromContents(ctx context.Context, upstream string, fetcher FileFetcher) (app LocalAppCopy, err error) {

--- a/pkg/specs/githubclient/client.go
+++ b/pkg/specs/githubclient/client.go
@@ -212,7 +212,7 @@ func validateGithubURL(upstream string) (*url.URL, error) {
 	}
 
 	if !strings.Contains(upstreamURL.Host, "github.com") {
-		return nil, errors.New(fmt.Sprintf("%s is not a Github URL", upstream))
+		return nil, errors.Errorf("%s is not a Github URL", upstream)
 	}
 
 	return upstreamURL, nil

--- a/pkg/util/github.go
+++ b/pkg/util/github.go
@@ -41,7 +41,7 @@ func ParseGithubURL(url string, defaultRef string) (GithubURL, error) {
 	}
 
 	if parsed.Owner == "" {
-		return GithubURL{}, errors.New(fmt.Sprintf("Unable to parse %q as a github url", url))
+		return GithubURL{}, errors.Errorf("Unable to parse %q as a github url", url)
 	}
 
 	return parsed, nil


### PR DESCRIPTION
What I Did
------------

Fix missing state file path on "ship update". Previously the following was printed

```
There was an unexpected error! No state file found at , please run "ship init"
```

How I Did it
------------

Set a default in the pflags StringVar `state-file` to the value of `constants.StatePath`

How to verify it
------------

```
$ rm -rf .ship && ship update
```

should print

```
There was an unexpected error! No state file found at .ship/state.json, please run "ship init"

There was an error configuring the application. A debug log has been written to ".ship/debug.log", please include it in any support inquiries.
```

Description for the Changelog
------------

Fix missing state file path in error message on "ship update"

:boat: