### PR TITLE
Add when for terraform lifecycle step

### DIFF
--- a/hack/docs/mutations.json
+++ b/hack/docs/mutations.json
@@ -1138,6 +1138,12 @@
     }
   },
   {
+    "path": "properties.lifecycle.properties.v1.items.properties.terraform.properties.when",
+    "merge": {
+      "description": "If 'when' is not empty and evaluates to false, the terraform lifecycle step will be skipped."
+    }
+  },
+  {
     "path": "properties.assets.properties.v1.items.properties.terraform.properties",
     "delete": ["github"]
   },

--- a/hack/docs/schema.json
+++ b/hack/docs/schema.json
@@ -1149,6 +1149,10 @@
                     "items": {
                       "type": "string"
                     }
+                  },
+                  "when": {
+                    "description": "If 'when' is not empty and evaluates to false, the terraform lifecycle step will be skipped.",
+                    "type": "string"
                   }
                 },
                 "required": []

--- a/integration/init/skipped-terraform/expected/.ship/state.json
+++ b/integration/init/skipped-terraform/expected/.ship/state.json
@@ -1,0 +1,10 @@
+{
+  "v1": {
+    "config": {
+      "id_length": "8"
+    },
+    "releaseName": "ship",
+    "upstream": "__upstream__",
+    "contentSHA": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  }
+}

--- a/integration/init/skipped-terraform/expected/installer/notrun-terraform/random.tf
+++ b/integration/init/skipped-terraform/expected/installer/notrun-terraform/random.tf
@@ -1,0 +1,4 @@
+resource "local_file" "foo" {
+  content     = "8"
+  filename = "/tmp/foo.bar"
+}

--- a/integration/init/skipped-terraform/expected/installer/terraform/plan.tfplan
+++ b/integration/init/skipped-terraform/expected/installer/terraform/plan.tfplan
@@ -1,0 +1,1 @@
+ignored

--- a/integration/init/skipped-terraform/expected/installer/terraform/random.tf
+++ b/integration/init/skipped-terraform/expected/installer/terraform/random.tf
@@ -1,0 +1,4 @@
+resource "local_file" "foo" {
+  content     = "8"
+  filename = "/tmp/foo.bar"
+}

--- a/integration/init/skipped-terraform/input/ship.yaml
+++ b/integration/init/skipped-terraform/input/ship.yaml
@@ -1,0 +1,43 @@
+assets:
+  v1:
+    - inline:
+        dest: ./notrun-terraform/random.tf
+        contents: |
+          resource "local_file" "foo" {
+            content     = "{{repl ConfigOption "id_length" }}"
+            filename = "/tmp/foo.bar"
+          }
+
+    - inline:
+        dest: ./terraform/random.tf
+        contents: |
+          resource "local_file" "foo" {
+            content     = "{{repl ConfigOption "id_length" }}"
+            filename = "/tmp/foo.bar"
+          }
+
+config:
+  v1:
+    - name: id
+      items:
+        - name: id_length
+          title: a silly example
+          type: text
+          required: true
+          default: 8
+          help_text: "if set to 6 terraform will run"
+
+lifecycle:
+  v1:
+    - message:
+        contents: "hi"
+    - config: {}
+    - render: {}
+    - terraform:
+        path: notrun-terraform/
+        when: '{{repl ConfigOptionEquals "id_length" "6"}}'
+    - terraform:
+        path: terraform/
+        when: '{{repl ConfigOptionEquals "id_length" "8"}}'
+    - message:
+        contents: "bye"

--- a/integration/init/skipped-terraform/metadata.yaml
+++ b/integration/init/skipped-terraform/metadata.yaml
@@ -1,0 +1,4 @@
+upstream: "input/ship.yaml"
+make_absolute: true
+args: []
+skip_cleanup: false

--- a/pkg/api/lifecycle.go
+++ b/pkg/api/lifecycle.go
@@ -100,6 +100,7 @@ func (r *Render) RenderRoot() string {
 type Terraform struct {
 	StepShared `json:",inline" yaml:",inline" hcl:",inline"`
 	Path       string `json:"path,omitempty" yaml:"path,omitempty" hcl:"path,omitempty"`
+	When       string `json:"when,omitempty" yaml:"when,omitempty" hcl:"when,omitempty"`
 }
 
 func (t *Terraform) Shared() *StepShared { return &t.StepShared }

--- a/pkg/lifecycle/terraform/daemonless.go
+++ b/pkg/lifecycle/terraform/daemonless.go
@@ -80,7 +80,14 @@ func (t *DaemonlessTerraformer) WithStatusReceiver(
 }
 
 func (t *DaemonlessTerraformer) Execute(ctx context.Context, release api.Release, step api.Terraform, confirmedChan chan bool) error {
-	debug := level.Debug(log.With(t.Logger, "struct", "ForkTerraformer", "method", "execute"))
+	debug := level.Debug(log.With(t.Logger, "struct", "DaemonlessTerraformer", "method", "execute"))
+
+	shouldExecute := t.evaluateWhen(step.When, release)
+	if !shouldExecute {
+		_ = debug.Log("event", "terraform.skipping")
+		return nil
+	}
+
 	renderRoot := release.FindRenderRoot()
 	dir := path.Join(renderRoot, step.Path)
 

--- a/pkg/lifecycle/terraform/when.go
+++ b/pkg/lifecycle/terraform/when.go
@@ -1,0 +1,50 @@
+package terraform
+
+import (
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/replicatedhq/ship/pkg/api"
+	"github.com/replicatedhq/ship/pkg/state"
+	"github.com/replicatedhq/ship/pkg/templates"
+	"github.com/spf13/viper"
+)
+
+func (t *ForkTerraformer) evaluateWhen(when string, release api.Release) bool {
+	debug := level.Debug(log.With(t.Logger, "struct", "ForkTerraformer", "method", "execute"))
+
+	return evaluateWhen(when, release, debug, t.Viper, t.StateManager)
+}
+
+func (t *DaemonlessTerraformer) evaluateWhen(when string, release api.Release) bool {
+	debug := level.Debug(log.With(t.Logger, "struct", "DaemonlessTerraformer", "method", "execute"))
+
+	return evaluateWhen(when, release, debug, t.Viper, t.StateManager)
+}
+
+func evaluateWhen(when string, release api.Release, logger log.Logger, viper *viper.Viper, manager state.Manager) bool {
+	if manager == nil {
+		return true
+	}
+
+	builderBuilder := templates.BuilderBuilder{Logger: logger, Viper: viper, Manager: manager}
+
+	configState, err := manager.TryLoad()
+	if err != nil {
+		_ = logger.Log("terraform.when.loadState", err.Error())
+	}
+
+	fullBuilder, err := builderBuilder.FullBuilder(release.Metadata, release.Spec.Config.V1, configState.CurrentConfig())
+	if err != nil {
+		_ = logger.Log("terraform.when.buildBuilder", err.Error())
+	}
+
+	build, err := fullBuilder.Bool(when, true)
+
+	if err != nil {
+		_ = logger.Log("terraform.when.error", err.Error())
+		// the terraform step should be run if the template function returns an error
+		return true
+	}
+
+	return build
+}

--- a/pkg/lifecycle/terraform/when_test.go
+++ b/pkg/lifecycle/terraform/when_test.go
@@ -1,0 +1,98 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/replicatedhq/ship/pkg/api"
+	"github.com/replicatedhq/ship/pkg/state"
+	"github.com/replicatedhq/ship/pkg/testing/logger"
+	"github.com/spf13/afero"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvaluateWhen(t *testing.T) {
+	tests := []struct {
+		name    string
+		State   state.VersionedState
+		when    string
+		release api.Release
+		want    bool
+	}{
+		{
+			name:    "no when",
+			State:   state.VersionedState{V1: &state.V1{}},
+			when:    "",
+			release: api.Release{Metadata: api.ReleaseMetadata{}},
+			want:    true,
+		},
+		{
+			name:    "true when",
+			State:   state.VersionedState{V1: &state.V1{}},
+			when:    "true",
+			release: api.Release{Metadata: api.ReleaseMetadata{}},
+			want:    true,
+		},
+		{
+			name:    "false when",
+			State:   state.VersionedState{V1: &state.V1{}},
+			when:    "false",
+			release: api.Release{Metadata: api.ReleaseMetadata{}},
+			want:    false,
+		},
+		{
+			name:    "trivial template when true",
+			State:   state.VersionedState{V1: &state.V1{}},
+			when:    "{{repl eq 1 1}}",
+			release: api.Release{Metadata: api.ReleaseMetadata{}},
+			want:    true,
+		},
+		{
+			name:    "trivial template when false",
+			State:   state.VersionedState{V1: &state.V1{}},
+			when:    "{{repl eq 1 2}}",
+			release: api.Release{Metadata: api.ReleaseMetadata{}},
+			want:    false,
+		},
+		{
+			name:    "configOption template when true",
+			State:   state.VersionedState{V1: &state.V1{Config: map[string]interface{}{"theOption": "hello_world"}}},
+			when:    `{{repl ConfigOptionEquals "theOption" "hello_world"}}`,
+			release: api.Release{Metadata: api.ReleaseMetadata{}},
+			want:    true,
+		},
+		{
+			name:    "configOption template when false",
+			State:   state.VersionedState{V1: &state.V1{Config: map[string]interface{}{"theOption": "hello_world"}}},
+			when:    `{{repl ConfigOptionEquals "theOption" "something else"}}`,
+			release: api.Release{Metadata: api.ReleaseMetadata{}},
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+			fs := afero.Afero{Fs: afero.NewMemMapFs()}
+			tlogger := &logger.TestLogger{T: t}
+			tviper := viper.New()
+			stateManager := state.NewManager(tlogger, fs, tviper)
+
+			req.NoError(stateManager.Save(tt.State))
+			req.NoError(stateManager.SerializeAppMetadata(tt.release.Metadata))
+
+			forkTF := &ForkTerraformer{
+				Logger:       tlogger,
+				Viper:        tviper,
+				StateManager: stateManager,
+			}
+			daemonlessTF := &DaemonlessTerraformer{
+				Logger:       tlogger,
+				Viper:        tviper,
+				StateManager: stateManager,
+			}
+
+			req.Equal(tt.want, forkTF.evaluateWhen(tt.when, tt.release), "ForkTerraformer.evaluateWhen()")
+			req.Equal(tt.want, daemonlessTF.evaluateWhen(tt.when, tt.release), "DaemonlessTerraformer.evaluateWhen()")
+		})
+	}
+}


### PR DESCRIPTION
What I Did
------------
Added a `when` property to the Terraform lifecycle step, allowing it to be conditionally skipped.

How I Did it
------------
`when` was added as a property specific to the Terraform lifecycle step (we will likely make it common to all lifecycle steps in the future). This is then evaluated when the lifecycle step is being run, and the lifecycle step is ended immediately if it evaluates to false. (This results in a step that automatically advances to the next with a minimal delay, similar to the 'render' step)

How to verify it
------------
Run the integration test and observe that the one where the config option matches is run, and the one that does not match is not.

Description for the Changelog
------------
Added a `when` property to the Terraform lifecycle step

Picture of a Boat (not required but encouraged)
------------




![USS Bagley (DD-386)](https://upload.wikimedia.org/wikipedia/commons/f/f6/BagleyDD386.jpg "USS Bagley (DD-386)")







<!-- (thanks https://github.com/docker/docker for this template) -->

