### PR TITLE
Register install for ship apps

### DIFF
--- a/pkg/ship/kustomize.go
+++ b/pkg/ship/kustomize.go
@@ -45,7 +45,7 @@ func (s *Ship) Init(ctx context.Context) error {
 
 	if s.Viper.GetString("raw") != "" {
 		release := s.fakeKustomizeRawRelease()
-		return s.execute(ctx, release, nil, true)
+		return s.execute(ctx, release, nil)
 	}
 
 	if s.Viper.GetString("helm-values-file") != "" {
@@ -107,7 +107,7 @@ func (s *Ship) Init(ctx context.Context) error {
 	}
 
 	release.Spec.Lifecycle = s.IDPatcher.EnsureAllStepsHaveUniqueIDs(release.Spec.Lifecycle)
-	return s.execute(ctx, release, nil, true)
+	return s.execute(ctx, release, nil)
 }
 
 func (s *Ship) promptToRemoveState() error {

--- a/pkg/ship/ship.go
+++ b/pkg/ship/ship.go
@@ -178,10 +178,10 @@ func (s *Ship) Execute(ctx context.Context) error {
 	}
 	release.Spec.Lifecycle = s.IDPatcher.EnsureAllStepsHaveUniqueIDs(release.Spec.Lifecycle)
 
-	return s.execute(ctx, release, selector, false)
+	return s.execute(ctx, release, selector)
 }
 
-func (s *Ship) execute(ctx context.Context, release *api.Release, selector *replicatedapp.Selector, isKustomize bool) error {
+func (s *Ship) execute(ctx context.Context, release *api.Release, selector *replicatedapp.Selector) error {
 	debug := level.Debug(log.With(s.Logger, "method", "execute"))
 	warn := level.Debug(log.With(s.Logger, "method", "execute"))
 	runResultCh := make(chan error)

--- a/pkg/ship/ship.go
+++ b/pkg/ship/ship.go
@@ -211,7 +211,7 @@ func (s *Ship) execute(ctx context.Context, release *api.Release, selector *repl
 			return
 		}
 
-		if !isKustomize && selector != nil {
+		if selector != nil {
 			_ = s.AppResolver.RegisterInstall(ctx, *selector, release)
 		}
 

--- a/pkg/ship/ship_test.go
+++ b/pkg/ship/ship_test.go
@@ -20,7 +20,6 @@ func TestExecute(t *testing.T) {
 		release        *api.Release
 		selector       *replicatedapp.Selector
 		uploadAssetsTo string
-		isKustomize    bool
 		expectError    error
 	}{
 		{
@@ -56,7 +55,7 @@ func TestExecute(t *testing.T) {
 			d.EXPECT().AwaitShutdown().Return(nil)
 			uploader.EXPECT().UploadAssets(test.uploadAssetsTo)
 
-			err := s.execute(ctx, test.release, test.selector, test.isKustomize)
+			err := s.execute(ctx, test.release, test.selector)
 
 			if test.expectError == nil {
 				req.NoError(err)

--- a/pkg/ship/unfork.go
+++ b/pkg/ship/unfork.go
@@ -66,5 +66,5 @@ func (s *Ship) Unfork(ctx context.Context) error {
 
 	release.Spec.Lifecycle = s.IDPatcher.EnsureAllStepsHaveUniqueIDs(release.Spec.Lifecycle)
 
-	return s.execute(ctx, release, nil, true)
+	return s.execute(ctx, release, nil)
 }

--- a/pkg/ship/update.go
+++ b/pkg/ship/update.go
@@ -69,5 +69,5 @@ func (s *Ship) Update(ctx context.Context) error {
 
 	release.Spec.Lifecycle = s.IDPatcher.EnsureAllStepsHaveUniqueIDs(release.Spec.Lifecycle)
 
-	return s.execute(ctx, release, nil, true)
+	return s.execute(ctx, release, nil)
 }


### PR DESCRIPTION
What I Did
------------
- Register install for ship apps

How I Did it
------------
- Remove `isKustomize`, which was used to determine if `ship` was using the `init` or `app` flow

How to verify it
------------
- Verification that install is registered when `ship` is run with a vendored app

Description for the Changelog
------------
- Register install for ship apps


Picture of a Boat (not required but encouraged)
------------
🛶 











<!-- (thanks https://github.com/docker/docker for this template) -->

