### PR TITLE
Initial support for KubeSeal template function

### DIFF
--- a/pkg/templates/config_context.go
+++ b/pkg/templates/config_context.go
@@ -10,11 +10,7 @@ import (
 	"github.com/replicatedhq/libyaml"
 )
 
-func (bb *BuilderBuilder) NewConfigContext(
-	configGroups []libyaml.ConfigGroup,
-	templateContext map[string]interface{},
-) (*ConfigCtx, error) {
-
+func (bb *BuilderBuilder) NewConfigContext(configGroups []libyaml.ConfigGroup, templateContext map[string]interface{}) (*ConfigCtx, error) {
 	builder := bb.NewBuilder(
 		bb.NewStaticContext(),
 	)

--- a/pkg/templates/ship_context.go
+++ b/pkg/templates/ship_context.go
@@ -28,7 +28,7 @@ func (bb *BuilderBuilder) NewShipContext() (*ShipContext, error) {
 	return shipCtx, nil
 }
 
-// FuncMap represents the available functions in the ConfigCtx.
+// FuncMap represents the available functions in the ShipCtx.
 func (ctx ShipContext) FuncMap() template.FuncMap {
 	return template.FuncMap{
 		"AmazonEKS": ctx.amazonEKS,

--- a/pkg/templates/ship_context_test.go
+++ b/pkg/templates/ship_context_test.go
@@ -36,7 +36,6 @@ func makeTestShipCtx(t *testing.T) ShipContext {
 
 // tests that generated CAs can be referenced again + that more than one CA can be generated
 func TestShipContext_makeCa_repeat(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		caName       string
@@ -123,7 +122,6 @@ func TestShipContext_makeCa_repeat(t *testing.T) {
 // generates two certs, covering different sets of hosts, with the same CA
 // certs must cover the specified domains, be of the desired type, and be signed by the CA
 func TestShipContext_makeCert_repeat(t *testing.T) {
-
 	tests := []struct {
 		name           string
 		firstCertName  string

--- a/pkg/templates/static_context_test.go
+++ b/pkg/templates/static_context_test.go
@@ -1,0 +1,69 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/replicatedhq/ship/pkg/testing/logger"
+	"github.com/stretchr/testify/require"
+)
+
+func makeTestStaticCtx(t *testing.T) StaticCtx {
+	testLogger := logger.TestLogger{T: t}
+
+	return StaticCtx{
+		Logger: &testLogger,
+	}
+}
+
+func TestStaticContext_kubeSeal_badCert(t *testing.T) {
+	req := require.New(t)
+
+	ctx := makeTestStaticCtx(t)
+
+	cert := `-----BEGIN CERTIFICATE-----
+SPA=
+-----END CERTIFICATE-----`
+
+	sealed, err := ctx.kubeSeal(cert, "default", "mysecret", "clear")
+	req.Error(err, "invalid cert should return an error")
+	req.Empty(sealed, "should return empty string with provided invalid cert")
+}
+
+func TestStaticContext_kubeSeal_goodCert(t *testing.T) {
+	req := require.New(t)
+
+	ctx := makeTestStaticCtx(t)
+
+	cert := `-----BEGIN CERTIFICATE-----
+MIIErTCCApWgAwIBAgIQCDeIIck6VL8U9rDEP8ZECjANBgkqhkiG9w0BAQsFADAA
+MB4XDTE5MDEyNTE1MTIzMFoXDTI5MDEyMjE1MTIzMFowADCCAiIwDQYJKoZIhvcN
+AQEBBQADggIPADCCAgoCggIBALVuzNLJdwJ+cNkSINeMOmSgusRkkbZ5pqb7oeyw
+l6CwoqE2pshplKwqs5jDjidkGyJ/TjIa8Ar1cOTY3GO+OVc5xNQoTrCWhFZA9v/Q
+cY8aw91BV1Fha80gBgN4hghdiZnATLLBgT1pgCGnQhH8GLunQqSH+lV3TS0fnUGZ
+ivUld2gU8bvjoBzdd0o8aW/5VDYlyOmP9MnMldOcQ4kFNpdAtnKOBAvoxv4C94v6
+2aUo8j7XFpJpYJeECtlTATRvRC1pvDok3c5Mr7hgPy8Gsdatc6xvMkY2sZ0GBP4j
+ta2k2wGT8pmXUFMlSKrBYoOZ5t/VjalMZBUUYcCnkcFrDrm5p7HW1upei+z5THkg
+Y/H0foPj91vkB0BeL00QZOu30uTAVL+F/1Al0lg4VtTHiNMIruos91+F7SweSIXZ
+TkvFPpPK3d2Jt55o/cuW5m/JxzNqMlpVD2Foc7OoWy0PodPy+rFWYgRBUiGShq/2
+rC2UXCCisK/NL1ellW5p6K12tkBwoYLROe2IVPGVF7OCzLU8IbKHCzZ3E/O25CdL
+7cxC62kvCDNJI+s+cpRDg1OZppir6NCbEPPlQbmRPS/8NN0HJKULPCiGcpvGHG4r
+tWdkN8tc2wRyRQGAdxJr1CD0XLQO+Xo3f2wfvLiBwLpgqn33jfH3Ybnl9vU1jEYm
+abi9AgMBAAGjIzAhMA4GA1UdDwEB/wQEAwIAATAPBgNVHRMBAf8EBTADAQH/MA0G
+CSqGSIb3DQEBCwUAA4ICAQCTIwRIbCg+TB6/ZSzj1/52o/yEuqlOne2Og22B14pU
+JiwfpWm5GgG0jOBNHZ7f3EL/bdB5lQJXtvcAx8SwBLk8g/1ieSCcm23kDgdkls+F
+om0uiyXWTqJC+vktPhWyzFm3ltvHFNOcxo7eRXica7gNKbcFTQWmdkI+SwuBkBYp
+gQjxAZUnpN8byAyuZwPTRWVNmUF21DarC6Ol5TDt4HBGFv5ItLVxVh40t10jghOg
+xgr1i38dxZzaYQA+WdeDlJqbsu5tKGihEjBAgAMbhDe194y0ROjZJtdKG/gH7P0g
+ttIrjatPvoVLeHiS1bRpLEwbSOYi2yecQcvHLlsKUedQ/168oLR94jnlS8jejRAH
+WKwVf1QBx/UJWDW6SsunFuLMNUDUhhTfR6zOQNkD8AwIH7wsENIz0Denp/R0rsyJ
+bUrDhgY9tB4JpDXYcquL+zkC7Ivc3XBFNCEp5H/9njoDXHhit6Dv2eTG3Tu05Uzf
+Jrav2KaQ9pp8Oj28C1VTmTPMqZPpF7ZyfrFOHj/9wzOM5ecsQ4Ee91MyTkdyOB29
+f+ipeUSsw5HLNxJpkAZYclBkN+ZnL35FsH4wmEyqZodj+dDgkIiSQq6p3QfQ8NUu
+JgtOJZLvegJ7oeZsG8zHDP2BvmScSPJq6nLTD5i4P04EOIDNjH6GfNFKVwp9GSPT
+yw==
+-----END CERTIFICATE-----`
+
+	sealed, err := ctx.kubeSeal(cert, "default", "mysecret", "clear")
+	req.NoError(err, "kubeSeal should not return an error with a valid cert")
+	req.NotEmpty(sealed, "should return a non empty encrypted secret")
+}


### PR DESCRIPTION
What I Did
------------
Added initial support for [SealedSecrets](https://github.com/bitnami-labs/sealed-secrets) by implementing a template function that will KubeSeal a secret value. This closes #802. 

How I Did it
------------
Studied the kubeseal code to understand the encryption implementation there. Reimplemented the same, short and standard encryption implementation in Ship. Also added tests to cover some of the basic functionality (bad cert, valid cert) use cases, and confirm data is returned. 

How to verify it
------------
I pushed a publicly available ship.yaml that uses this. You can install and run this ship application with:

```
ship init github.com/shipapps/signal-sciences
```

For reference, the implementation in that ship.yaml is at https://github.com/shipapps/signal-sciences/blob/master/ship.yaml. Note, you'll have to look at the generated sealedsecret.yaml on the filesystem after manually verifying. This runbook doesn't yet support adding the sealedsecret resource as a new resource in the ship overlay.

Description for the Changelog
------------
Added a KubeSeal template function to support natively creating SealedSecrets


Picture of a Boat (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

