### PR TITLE
Allow vendor-supplied kustomize overlays

### DIFF
--- a/integration/init/kustomize-overlay/expected/.ship/state.json
+++ b/integration/init/kustomize-overlay/expected/.ship/state.json
@@ -1,0 +1,8 @@
+{
+  "v1": {
+    "config": {},
+    "releaseName": "ship",
+    "upstream": "__upstream__",
+    "contentSHA": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  }
+}

--- a/integration/init/kustomize-overlay/expected/base/common/ClusterRole-nginx-ingress-clusterrole.yaml
+++ b/integration/init/kustomize-overlay/expected/base/common/ClusterRole-nginx-ingress-clusterrole.yaml
@@ -1,0 +1,54 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  name: nginx-ingress-clusterrole
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - nodes
+  - pods
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses/status
+  verbs:
+  - update

--- a/integration/init/kustomize-overlay/expected/base/common/ClusterRoleBinding-nginx-ingress-clusterrole-nisa-binding.yaml
+++ b/integration/init/kustomize-overlay/expected/base/common/ClusterRoleBinding-nginx-ingress-clusterrole-nisa-binding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  name: nginx-ingress-clusterrole-nisa-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nginx-ingress-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: nginx-ingress-serviceaccount
+  namespace: ingress-nginx

--- a/integration/init/kustomize-overlay/expected/base/common/ConfigMap-nginx-configuration-ingress-nginx.yaml
+++ b/integration/init/kustomize-overlay/expected/base/common/ConfigMap-nginx-configuration-ingress-nginx.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  use-proxy-protocol: "true"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  name: nginx-configuration
+  namespace: ingress-nginx

--- a/integration/init/kustomize-overlay/expected/base/common/ConfigMap-tcp-services-ingress-nginx.yaml
+++ b/integration/init/kustomize-overlay/expected/base/common/ConfigMap-tcp-services-ingress-nginx.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  name: tcp-services
+  namespace: ingress-nginx

--- a/integration/init/kustomize-overlay/expected/base/common/ConfigMap-udp-services-ingress-nginx.yaml
+++ b/integration/init/kustomize-overlay/expected/base/common/ConfigMap-udp-services-ingress-nginx.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  name: udp-services
+  namespace: ingress-nginx

--- a/integration/init/kustomize-overlay/expected/base/common/Deployment-nginx-ingress-controller-ingress-nginx.yaml
+++ b/integration/init/kustomize-overlay/expected/base/common/Deployment-nginx-ingress-controller-ingress-nginx.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  name: nginx-ingress-controller
+  namespace: ingress-nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ingress-nginx
+      app.kubernetes.io/part-of: ingress-nginx
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
+    spec:
+      containers:
+      - args:
+        - /nginx-ingress-controller
+        - --configmap=$(POD_NAMESPACE)/nginx-configuration
+        - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-services
+        - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
+        - --publish-service=$(POD_NAMESPACE)/ingress-nginx
+        - --annotations-prefix=nginx.ingress.kubernetes.io
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.22.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: nginx-ingress-controller
+        ports:
+        - containerPort: 80
+          name: http
+        - containerPort: 443
+          name: https
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          runAsUser: 33
+      serviceAccountName: nginx-ingress-serviceaccount

--- a/integration/init/kustomize-overlay/expected/base/common/Namespace-ingress-nginx.yaml
+++ b/integration/init/kustomize-overlay/expected/base/common/Namespace-ingress-nginx.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  name: ingress-nginx

--- a/integration/init/kustomize-overlay/expected/base/common/Role-nginx-ingress-role-ingress-nginx.yaml
+++ b/integration/init/kustomize-overlay/expected/base/common/Role-nginx-ingress-role-ingress-nginx.yaml
@@ -1,0 +1,39 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  name: nginx-ingress-role
+  namespace: ingress-nginx
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resourceNames:
+  - ingress-controller-leader-nginx
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get

--- a/integration/init/kustomize-overlay/expected/base/common/RoleBinding-nginx-ingress-role-nisa-binding-ingress-nginx.yaml
+++ b/integration/init/kustomize-overlay/expected/base/common/RoleBinding-nginx-ingress-role-nisa-binding-ingress-nginx.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  name: nginx-ingress-role-nisa-binding
+  namespace: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nginx-ingress-role
+subjects:
+- kind: ServiceAccount
+  name: nginx-ingress-serviceaccount
+  namespace: ingress-nginx

--- a/integration/init/kustomize-overlay/expected/base/common/ServiceAccount-nginx-ingress-serviceaccount-ingress-nginx.yaml
+++ b/integration/init/kustomize-overlay/expected/base/common/ServiceAccount-nginx-ingress-serviceaccount-ingress-nginx.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  name: nginx-ingress-serviceaccount
+  namespace: ingress-nginx

--- a/integration/init/kustomize-overlay/expected/base/kustomization.yaml
+++ b/integration/init/kustomize-overlay/expected/base/kustomization.yaml
@@ -1,0 +1,14 @@
+kind: ""
+apiversion: ""
+resources:
+- common/ClusterRole-nginx-ingress-clusterrole.yaml
+- common/ClusterRoleBinding-nginx-ingress-clusterrole-nisa-binding.yaml
+- common/ConfigMap-nginx-configuration-ingress-nginx.yaml
+- common/ConfigMap-tcp-services-ingress-nginx.yaml
+- common/ConfigMap-udp-services-ingress-nginx.yaml
+- common/Deployment-nginx-ingress-controller-ingress-nginx.yaml
+- common/Namespace-ingress-nginx.yaml
+- common/Role-nginx-ingress-role-ingress-nginx.yaml
+- common/RoleBinding-nginx-ingress-role-nisa-binding-ingress-nginx.yaml
+- common/ServiceAccount-nginx-ingress-serviceaccount-ingress-nginx.yaml
+- service-l4.yaml

--- a/integration/init/kustomize-overlay/expected/base/service-l4.yaml
+++ b/integration/init/kustomize-overlay/expected/base/service-l4.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
+    service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  name: ingress-nginx
+  namespace: ingress-nginx
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+  - name: https
+    port: 443
+    targetPort: https
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  type: LoadBalancer

--- a/integration/init/kustomize-overlay/expected/installer/.gitkeep
+++ b/integration/init/kustomize-overlay/expected/installer/.gitkeep
@@ -1,0 +1,1 @@
+a workaround for the fact that ship always creates the installer directory

--- a/integration/init/kustomize-overlay/expected/nginx-ingress-controller.yaml
+++ b/integration/init/kustomize-overlay/expected/nginx-ingress-controller.yaml
@@ -1,0 +1,273 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  name: ingress-nginx
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  name: nginx-ingress-serviceaccount
+  namespace: ingress-nginx
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  name: nginx-ingress-role
+  namespace: ingress-nginx
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resourceNames:
+  - ingress-controller-leader-nginx
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  name: nginx-ingress-clusterrole
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - nodes
+  - pods
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  name: nginx-ingress-role-nisa-binding
+  namespace: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nginx-ingress-role
+subjects:
+- kind: ServiceAccount
+  name: nginx-ingress-serviceaccount
+  namespace: ingress-nginx
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  name: nginx-ingress-clusterrole-nisa-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nginx-ingress-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: nginx-ingress-serviceaccount
+  namespace: ingress-nginx
+---
+apiVersion: v1
+data:
+  use-proxy-protocol: "true"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  name: nginx-configuration
+  namespace: ingress-nginx
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  name: tcp-services
+  namespace: ingress-nginx
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  name: udp-services
+  namespace: ingress-nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
+    service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  name: ingress-nginx
+  namespace: ingress-nginx
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+  - name: https
+    port: 443
+    targetPort: https
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  name: nginx-ingress-controller
+  namespace: ingress-nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ingress-nginx
+      app.kubernetes.io/part-of: ingress-nginx
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
+    spec:
+      containers:
+      - args:
+        - /nginx-ingress-controller
+        - --configmap=$(POD_NAMESPACE)/nginx-configuration
+        - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-services
+        - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
+        - --publish-service=$(POD_NAMESPACE)/ingress-nginx
+        - --annotations-prefix=nginx.ingress.kubernetes.io
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.22.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: nginx-ingress-controller
+        ports:
+        - containerPort: 80
+          name: http
+        - containerPort: 443
+          name: https
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          runAsUser: 33
+      serviceAccountName: nginx-ingress-serviceaccount

--- a/integration/init/kustomize-overlay/expected/overlays/cloud/kustomization.yaml
+++ b/integration/init/kustomize-overlay/expected/overlays/cloud/kustomization.yaml
@@ -1,0 +1,6 @@
+kind: ""
+apiversion: ""
+bases:
+  - ../../base
+patches:
+  - ./patch-configmap-l4.yaml

--- a/integration/init/kustomize-overlay/expected/overlays/cloud/patch-configmap-l4.yaml
+++ b/integration/init/kustomize-overlay/expected/overlays/cloud/patch-configmap-l4.yaml
@@ -1,0 +1,10 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: nginx-configuration
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+data:
+  use-proxy-protocol: "true"

--- a/integration/init/kustomize-overlay/expected/overlays/ship/kustomization.yaml
+++ b/integration/init/kustomize-overlay/expected/overlays/ship/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: ""
+apiversion: ""
+bases:
+- ../../base

--- a/integration/init/kustomize-overlay/input/ship.yaml
+++ b/integration/init/kustomize-overlay/input/ship.yaml
@@ -1,0 +1,56 @@
+assets:
+  v1:
+    - github:
+        dest: ../base/common
+        repo: kubernetes/ingress-nginx
+        path: deploy/mandatory.yaml
+        ref: nginx-0.22.0
+        proxy: false
+        strip_path: true
+
+    - github:
+        dest: ../base
+        repo: kubernetes/ingress-nginx
+        path: deploy/provider/aws/service-l4.yaml
+        ref: nginx-0.22.0
+        proxy: false
+        strip_path: true
+
+    - github:
+        dest: ../overlays/cloud
+        repo: kubernetes/ingress-nginx
+        path: deploy/provider/aws/patch-configmap-l4.yaml
+        ref: nginx-0.22.0
+        proxy: false
+        strip_path: true
+
+    - inline:
+        dest: ./overlays/cloud/kustomization.yaml
+        contents: |
+          kind: ""
+          apiversion: ""
+          bases:
+            - ../../base
+          patches:
+            - ./patch-configmap-l4.yaml
+
+    - inline:
+        dest: ./installer/.gitkeep
+        contents: |
+          a workaround for the fact that ship always creates the installer directory
+
+config:
+  v1: []
+
+lifecycle:
+  v1:
+    - render:
+        root: .
+
+    - kustomize:
+        requires: ["render"]
+        base: overlays/cloud
+        overlay: overlays/ship
+        dest: nginx-ingress-controller.yaml
+    - message:
+        contents: "outro"

--- a/integration/init/kustomize-overlay/metadata.yaml
+++ b/integration/init/kustomize-overlay/metadata.yaml
@@ -1,0 +1,4 @@
+upstream: "input/ship.yaml"
+make_absolute: true
+args: []
+skip_cleanup: false

--- a/pkg/lifecycle/kustomize/daemonless.go
+++ b/pkg/lifecycle/kustomize/daemonless.go
@@ -39,7 +39,7 @@ func (l *Kustomizer) Execute(ctx context.Context, release *api.Release, step api
 	debug := level.Debug(log.With(l.Logger, "struct", "daemonless.kustomizer", "method", "execute"))
 
 	debug.Log("event", "write.base.kustomization.yaml")
-	err := l.writeBase(step)
+	err := l.writeBase(step.Base)
 	if err != nil {
 		return errors.Wrap(err, "write base kustomization")
 	}

--- a/pkg/lifecycle/kustomize/kustomizer.go
+++ b/pkg/lifecycle/kustomize/kustomizer.go
@@ -195,7 +195,7 @@ func (l *Kustomizer) writeOverlay(
 	return nil
 }
 
-func (l *Kustomizer) writeBase(step api.Kustomize) error {
+func (l *Kustomizer) writeBase(base string) error {
 	debug := level.Debug(log.With(l.Logger, "method", "writeBase"))
 
 	currentState, err := l.State.TryLoad()
@@ -211,15 +211,15 @@ func (l *Kustomizer) writeBase(step api.Kustomize) error {
 
 	baseKustomization := ktypes.Kustomization{}
 	if err := l.FS.Walk(
-		step.Base,
+		base,
 		func(targetPath string, info os.FileInfo, err error) error {
 			if err != nil {
 				debug.Log("event", "walk.fail", "path", targetPath)
 				return errors.Wrap(err, "failed to walk path")
 			}
-			relativePath, err := filepath.Rel(step.Base, targetPath)
+			relativePath, err := filepath.Rel(base, targetPath)
 			if err != nil {
-				debug.Log("event", "relativepath.fail", "base", step.Base, "target", targetPath)
+				debug.Log("event", "relativepath.fail", "base", base, "target", targetPath)
 				return errors.Wrap(err, "failed to get relative path")
 			}
 			if l.shouldAddFileToBase(shipOverlay.ExcludedBases, relativePath) {
@@ -241,7 +241,7 @@ func (l *Kustomizer) writeBase(step api.Kustomize) error {
 	}
 
 	// write base kustomization
-	name := path.Join(step.Base, "kustomization.yaml")
+	name := path.Join(base, "kustomization.yaml")
 	err = l.FS.WriteFile(name, []byte(marshalled), 0666)
 	if err != nil {
 		return errors.Wrapf(err, "write file %s", name)

--- a/pkg/lifecycle/kustomize/kustomizer_test.go
+++ b/pkg/lifecycle/kustomize/kustomizer_test.go
@@ -347,7 +347,7 @@ resources:
 				Daemon: mockDaemon,
 			}
 
-			if err := l.writeBase(mockStep); (err != nil) != tt.wantErr {
+			if err := l.writeBase(mockStep.Base); (err != nil) != tt.wantErr {
 				t.Errorf("kustomizer.writeBase() error = %v, wantErr %v", err, tt.wantErr)
 			} else if err == nil {
 				basePathDest := path.Join(mockStep.Base, "kustomization.yaml")


### PR DESCRIPTION
What I Did
------------
Implements and closes #806. When the 'base' directory in a kustomize lifecycle step includes a `kustomize.yaml` file with exactly one `base` specified, the patches from that step will be applied to the base, updating the files present, before presenting the user with the opportunity to create patches for the resulting files.

How I Did it
------------
Reused the 'apply kustomize in-place' code we had previously for removing 'chart' and 'heritage' metadata entries to apply the specified set of patches. (iff the kustomize file exists and has a base) 

How to verify it
------------
When running the ship yaml present in the newly added integration test, the specified patch will be included within the files are presented to you to kustomize during that lifecycle step.

Description for the Changelog
------------

Vendors can include kustomize patches for resources and allow users to add their own patches afterwards


Picture of a Boat (not required but encouraged)
------------

![DD-381](https://upload.wikimedia.org/wikipedia/commons/7/7b/USS_Somers_%28DD-381%29_at_the_Charleston_Naval_Shipyard_on_16_February_1942_%28NH_98021%29.jpg "DD-381")


Known shortcomings
------------

This code does not allow vendors to provide a kustomization.yaml file in the base directory - if one exists, it will be overwritten with a generated file.







<!-- (thanks https://github.com/docker/docker for this template) -->

