### PR TITLE
disable return-statements check in codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -15,7 +15,9 @@ plugins:
         enabled: false
 
 exclude_paterns:
-  - "vendor/"
+  - "**/vendor/"
+  - "**/*_test.go"
+  - "**/node_modules"
 
 checks:
   return-statements:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,6 @@
 ---
+version: "2"
+
 plugins:
   govet:
    enabled: true
@@ -12,10 +14,10 @@ plugins:
       GoLint/Comments/DocComments:
         enabled: false
 
+exclude_paterns:
+  - "vendor/"
 
-ratings:
-  paths:
-    - "cmd/**.go"
-    - "pkg/**.go"
-exclude_paths:
-  - vendor
+checks:
+  return-statements:
+    enabled: false
+


### PR DESCRIPTION
disable the return-statements check in codeclimate, since it's not very useful in golang

What I Did
------------
Disabled the return-statements check in codeclimate.

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------
![image](https://user-images.githubusercontent.com/2318911/52005477-a4bf7200-247e-11e9-9b68-30b2f9342768.png)












<!-- (thanks https://github.com/docker/docker for this template) -->

