### PR TITLE
fix the expected output of the jaeger-helm integration test

### DIFF
--- a/integration/init/jaeger-helm/expected/base/charts/cassandra/templates/statefulset.yaml
+++ b/integration/init/jaeger-helm/expected/base/charts/cassandra/templates/statefulset.yaml
@@ -88,6 +88,7 @@ spec:
         volumeMounts:
         - mountPath: /var/lib/cassandra
           name: data
+      hostNetwork: false
       terminationGracePeriodSeconds: 30
       volumes:
       - emptyDir: {}

--- a/integration/init/jaeger-helm/expected/rendered.yaml
+++ b/integration/init/jaeger-helm/expected/rendered.yaml
@@ -387,6 +387,7 @@ spec:
         volumeMounts:
         - mountPath: /var/lib/cassandra
           name: data
+      hostNetwork: false
       terminationGracePeriodSeconds: 30
       volumes:
       - emptyDir: {}


### PR DESCRIPTION
we need to make this truly static in the future

What I Did
------------
added a new line to the cassandra chart included within the jaeger-init integration test

How I Did it
------------
It's that simple

How to verify it
------------


Description for the Changelog
------------



Picture of a Boat (not required but encouraged)
------------





![PT-1](http://www.navsource.org/archives/12/120500104.jpg "PT-1")






<!-- (thanks https://github.com/docker/docker for this template) -->

