### PR TITLE
don't render empty kubernetes yaml lists

### DIFF
--- a/pkg/lifecycle/kustomize/daemonless.go
+++ b/pkg/lifecycle/kustomize/daemonless.go
@@ -118,7 +118,7 @@ func (l *Kustomizer) Execute(ctx context.Context, release *api.Release, step api
 	return nil
 }
 
-func (l *Kustomizer) kustomizeBuild(kustomizePath string) ([]postKustomizeFile, error) {
+func (l *Kustomizer) kustomizeBuild(kustomizePath string) ([]util.PostKustomizeFile, error) {
 	debug := level.Debug(log.With(l.Logger, "struct", "daemonless.kustomizer", "method", "kustomizeBuild"))
 
 	builtYAML, err := l.Patcher.RunKustomize(kustomizePath)
@@ -127,7 +127,7 @@ func (l *Kustomizer) kustomizeBuild(kustomizePath string) ([]postKustomizeFile, 
 	}
 
 	files := strings.Split(string(builtYAML), "\n---\n")
-	postKustomizeFiles := make([]postKustomizeFile, 0)
+	postKustomizeFiles := make([]util.PostKustomizeFile, 0)
 	for idx, file := range files {
 		var fullYaml interface{}
 
@@ -142,10 +142,10 @@ func (l *Kustomizer) kustomizeBuild(kustomizePath string) ([]postKustomizeFile, 
 			return postKustomizeFiles, errors.Wrap(err, "unmarshal part of rendered to minimal")
 		}
 
-		postKustomizeFiles = append(postKustomizeFiles, postKustomizeFile{
-			order:   idx,
-			minimal: minimal,
-			full:    fullYaml,
+		postKustomizeFiles = append(postKustomizeFiles, util.PostKustomizeFile{
+			Order:   idx,
+			Minimal: minimal,
+			Full:    fullYaml,
 		})
 	}
 

--- a/pkg/lifecycle/kustomize/post_kustomize.go
+++ b/pkg/lifecycle/kustomize/post_kustomize.go
@@ -50,6 +50,11 @@ func (l *Kustomizer) rebuildListYaml(lists []util.List, kustomizedYamlFiles []po
 			}
 		}
 
+		// don't render empty lists
+		if len(allListItems) == 0 {
+			continue
+		}
+
 		debug.Log("event", "reconstruct list")
 		reconstructedList := ListK8sYaml{
 			APIVersion: list.APIVersion,

--- a/pkg/lifecycle/kustomize/post_kustomize.go
+++ b/pkg/lifecycle/kustomize/post_kustomize.go
@@ -1,112 +1,21 @@
 package kustomize
 
 import (
-	"os"
-	"sort"
-
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/pkg/errors"
+
 	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/util"
-	yaml "gopkg.in/yaml.v2"
 )
 
-type postKustomizeFile struct {
-	order   int
-	minimal util.MinimalK8sYaml
-	full    interface{}
-}
-
-type postKustomizeFileCollection []postKustomizeFile
-
-func (c postKustomizeFileCollection) Len() int {
-	return len(c)
-}
-
-func (c postKustomizeFileCollection) Swap(i, j int) {
-	c[i], c[j] = c[j], c[i]
-}
-
-func (c postKustomizeFileCollection) Less(i, j int) bool {
-	return c[i].order < c[j].order
-}
-
-func (l *Kustomizer) rebuildListYaml(lists []util.List, kustomizedYamlFiles []postKustomizeFile) ([]postKustomizeFile, error) {
+func (l *Kustomizer) rebuildListYaml(lists []util.List, kustomizedYamlFiles []util.PostKustomizeFile) ([]util.PostKustomizeFile, error) {
 	debug := level.Debug(log.With(l.Logger, "struct", "daemonless.kustomizer", "method", "rebuildListYaml"))
-	yamlMap := make(map[util.MinimalK8sYaml]postKustomizeFile)
 
-	for _, postKustomizeFile := range kustomizedYamlFiles {
-		yamlMap[postKustomizeFile.minimal] = postKustomizeFile
-	}
-
-	fullReconstructedRendered := make([]postKustomizeFile, 0)
-	for _, list := range lists {
-		var allListItems []interface{}
-		for _, item := range list.Items {
-			if pkFile, exists := yamlMap[item]; exists {
-				delete(yamlMap, item)
-				allListItems = append(allListItems, pkFile.full)
-			}
-		}
-
-		// don't render empty lists
-		if len(allListItems) == 0 {
-			continue
-		}
-
-		debug.Log("event", "reconstruct list")
-		reconstructedList := ListK8sYaml{
-			APIVersion: list.APIVersion,
-			Kind:       "List",
-			Items:      allListItems,
-		}
-
-		postKustomizeList := postKustomizeFile{
-			minimal: util.MinimalK8sYaml{
-				Kind: "List",
-			},
-			full: reconstructedList,
-		}
-
-		fullReconstructedRendered = append(fullReconstructedRendered, postKustomizeList)
-	}
-
-	for nonListYamlMinimal, pkFile := range yamlMap {
-		fullReconstructedRendered = append(fullReconstructedRendered, postKustomizeFile{
-			order:   pkFile.order,
-			minimal: nonListYamlMinimal,
-			full:    pkFile.full,
-		})
-	}
-
-	return fullReconstructedRendered, nil
+	return util.RebuildListYaml(debug, lists, kustomizedYamlFiles)
 }
 
-func (l *Kustomizer) writePostKustomizeFiles(step api.Kustomize, postKustomizeFiles []postKustomizeFile) error {
+func (l *Kustomizer) writePostKustomizeFiles(step api.Kustomize, postKustomizeFiles []util.PostKustomizeFile) error {
 	debug := level.Debug(log.With(l.Logger, "struct", "daemonless.kustomizer", "method", "writePostKustomizeFiles"))
 
-	sort.Stable(postKustomizeFileCollection(postKustomizeFiles))
-
-	var joinedFinal string
-	for _, file := range postKustomizeFiles {
-		debug.Log("event", "marshal post kustomize file")
-		fileB, err := yaml.Marshal(file.full)
-		if err != nil {
-			return errors.Wrapf(err, "marshal file %s", file.minimal.Metadata.Name)
-		}
-
-		if joinedFinal != "" {
-			joinedFinal += "---\n" + string(fileB)
-		} else {
-			joinedFinal += string(fileB)
-		}
-	}
-
-	debug.Log("event", "write post kustomize files", "dest", step.Dest)
-	if err := l.FS.WriteFile(step.Dest, []byte(joinedFinal), os.FileMode(0644)); err != nil {
-		return errors.Wrapf(err, "write kustomized and post processed yaml at %s", step.Dest)
-	}
-
-	return nil
+	return util.WritePostKustomizeFiles(debug, l.FS, step.Dest, postKustomizeFiles)
 }

--- a/pkg/lifecycle/kustomize/post_kustomize_test.go
+++ b/pkg/lifecycle/kustomize/post_kustomize_test.go
@@ -392,6 +392,18 @@ items:
 				},
 			},
 		},
+		{
+			name: "empty list",
+			lists: []util.List{
+				{
+					APIVersion: "v1",
+					Path:       "test/empty.yaml",
+					Items:      []util.MinimalK8sYaml{},
+				},
+			},
+			kustomizedFiles: []kustomizeTestFile{},
+			expectFiles:     []kustomizeTestFile{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/lifecycle/kustomize/pre_kustomize.go
+++ b/pkg/lifecycle/kustomize/pre_kustomize.go
@@ -16,12 +16,6 @@ import (
 	ktypes "sigs.k8s.io/kustomize/pkg/types"
 )
 
-type ListK8sYaml struct {
-	APIVersion string        `json:"apiVersion" yaml:"apiVersion"`
-	Kind       string        `json:"kind" yaml:"kind" hcl:"kind"`
-	Items      []interface{} `json:"items" yaml:"items"`
-}
-
 func (l *Kustomizer) PreExecute(ctx context.Context, step api.Step) error {
 	// Check if the 'base' already includes a kustomization.yaml
 	// if it does, and that refers to another base, we should apply those patches to the upstream base, and then use that in the future
@@ -126,7 +120,7 @@ func (l *Kustomizer) maybeSplitListYaml(ctx context.Context, path string) error 
 			return errors.Wrapf(err, "read %s", filePath)
 		}
 
-		k8sYaml := ListK8sYaml{}
+		k8sYaml := util.ListK8sYaml{}
 		if err := yaml.Unmarshal(fileB, &k8sYaml); err != nil {
 			return errors.Wrapf(err, "unmarshal %s", filePath)
 		}
@@ -218,10 +212,10 @@ func (l *Kustomizer) runProvidedOverlays(ctx context.Context, originalBase, newB
 	return nil
 }
 
-func (l *Kustomizer) replaceOriginal(base string, built []postKustomizeFile) error {
-	builtMap := make(map[util.MinimalK8sYaml]postKustomizeFile)
+func (l *Kustomizer) replaceOriginal(base string, built []util.PostKustomizeFile) error {
+	builtMap := make(map[util.MinimalK8sYaml]util.PostKustomizeFile)
 	for _, builtFile := range built {
-		builtMap[builtFile.minimal] = builtFile
+		builtMap[builtFile.Minimal] = builtFile
 	}
 
 	if err := l.FS.Walk(base, func(targetPath string, info os.FileInfo, err error) error {
@@ -264,7 +258,7 @@ func (l *Kustomizer) replaceOriginal(base string, built []postKustomizeFile) err
 			return errors.Wrap(err, "remove original file")
 		}
 
-		initKustomizedB, err := yaml.Marshal(initKustomized.full)
+		initKustomizedB, err := yaml.Marshal(initKustomized.Full)
 		if err != nil {
 			return errors.Wrap(err, "marshal init kustomized")
 		}

--- a/pkg/lifecycle/kustomize/pre_kustomize_test.go
+++ b/pkg/lifecycle/kustomize/pre_kustomize_test.go
@@ -445,7 +445,7 @@ func TestKustomizer_replaceOriginal(t *testing.T) {
 	tests := []struct {
 		name     string
 		step     api.Kustomize
-		built    []postKustomizeFile
+		built    []util.PostKustomizeFile
 		original []testFile
 		expect   []testFile
 		wantErr  bool
@@ -455,15 +455,15 @@ func TestKustomizer_replaceOriginal(t *testing.T) {
 			step: api.Kustomize{
 				Base: "",
 			},
-			built: []postKustomizeFile{
+			built: []util.PostKustomizeFile{
 				{
-					minimal: util.MinimalK8sYaml{
+					Minimal: util.MinimalK8sYaml{
 						Kind: "Fruit",
 						Metadata: util.MinimalK8sMetadata{
 							Name: "strawberry",
 						},
 					},
-					full: map[string]interface{}{
+					Full: map[string]interface{}{
 						"kind": "Fruit",
 						"metadata": map[string]interface{}{
 							"name": "strawberry",
@@ -502,15 +502,15 @@ spec:
 			step: api.Kustomize{
 				Base: "",
 			},
-			built: []postKustomizeFile{
+			built: []util.PostKustomizeFile{
 				{
-					minimal: util.MinimalK8sYaml{
+					Minimal: util.MinimalK8sYaml{
 						Kind: "CustomResourceDefinition",
 						Metadata: util.MinimalK8sMetadata{
 							Name: "strawberry",
 						},
 					},
-					full: map[string]interface{}{
+					Full: map[string]interface{}{
 						"kind": "CustomResourceDefinition",
 						"metadata": map[string]interface{}{
 							"name": "strawberry",
@@ -549,15 +549,15 @@ spec:
 			step: api.Kustomize{
 				Base: "",
 			},
-			built: []postKustomizeFile{
+			built: []util.PostKustomizeFile{
 				{
-					minimal: util.MinimalK8sYaml{
+					Minimal: util.MinimalK8sYaml{
 						Kind: "Fruit",
 						Metadata: util.MinimalK8sMetadata{
 							Name: "banana",
 						},
 					},
-					full: map[string]interface{}{
+					Full: map[string]interface{}{
 						"kind": "Fruit",
 						"metadata": map[string]interface{}{
 							"name": "banana",
@@ -596,15 +596,15 @@ spec:
 			step: api.Kustomize{
 				Base: "",
 			},
-			built: []postKustomizeFile{
+			built: []util.PostKustomizeFile{
 				{
-					minimal: util.MinimalK8sYaml{
+					Minimal: util.MinimalK8sYaml{
 						Kind: "Fruit",
 						Metadata: util.MinimalK8sMetadata{
 							Name: "dragonfruit",
 						},
 					},
-					full: map[string]interface{}{
+					Full: map[string]interface{}{
 						"kind": "Fruit",
 						"metadata": map[string]interface{}{
 							"name": "dragonfruit",
@@ -615,13 +615,13 @@ spec:
 					},
 				},
 				{
-					minimal: util.MinimalK8sYaml{
+					Minimal: util.MinimalK8sYaml{
 						Kind: "Fruit",
 						Metadata: util.MinimalK8sMetadata{
 							Name: "pomegranate",
 						},
 					},
-					full: map[string]interface{}{
+					Full: map[string]interface{}{
 						"kind": "Fruit",
 						"metadata": map[string]interface{}{
 							"name": "pomegranate",

--- a/pkg/lifecycle/unfork/daemonless.go
+++ b/pkg/lifecycle/unfork/daemonless.go
@@ -121,8 +121,8 @@ func (l *Unforker) Execute(ctx context.Context, release *api.Release, step api.U
 	return nil
 }
 
-func (l *Unforker) unforkBuild(kustomizePath string) ([]postKustomizeFile, error) {
-	debug := level.Debug(log.With(l.Logger, "struct", "daemonless.unforker", "method", "kustomizeBuild"))
+func (l *Unforker) unforkBuild(kustomizePath string) ([]util.PostKustomizeFile, error) {
+	debug := level.Debug(log.With(l.Logger, "struct", "daemonless.unforker", "method", "unforkBuild"))
 
 	builtYAML, err := l.Patcher.RunKustomize(kustomizePath)
 	if err != nil {
@@ -130,7 +130,7 @@ func (l *Unforker) unforkBuild(kustomizePath string) ([]postKustomizeFile, error
 	}
 
 	files := strings.Split(string(builtYAML), "\n---\n")
-	postKustomizeFiles := make([]postKustomizeFile, 0)
+	postKustomizeFiles := make([]util.PostKustomizeFile, 0)
 	for idx, file := range files {
 		var fullYaml interface{}
 
@@ -145,10 +145,10 @@ func (l *Unforker) unforkBuild(kustomizePath string) ([]postKustomizeFile, error
 			return postKustomizeFiles, errors.Wrap(err, "unmarshal part of rendered to minimal")
 		}
 
-		postKustomizeFiles = append(postKustomizeFiles, postKustomizeFile{
-			order:   idx,
-			minimal: minimal,
-			full:    fullYaml,
+		postKustomizeFiles = append(postKustomizeFiles, util.PostKustomizeFile{
+			Order:   idx,
+			Minimal: minimal,
+			Full:    fullYaml,
 		})
 	}
 

--- a/pkg/lifecycle/unfork/post_unfork.go
+++ b/pkg/lifecycle/unfork/post_unfork.go
@@ -1,107 +1,20 @@
 package unfork
 
 import (
-	"os"
-	"sort"
-
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/pkg/errors"
 	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/util"
-	yaml "gopkg.in/yaml.v2"
 )
 
-type postKustomizeFile struct {
-	order   int
-	minimal util.MinimalK8sYaml
-	full    interface{}
-}
-
-type postKustomizeFileCollection []postKustomizeFile
-
-func (c postKustomizeFileCollection) Len() int {
-	return len(c)
-}
-
-func (c postKustomizeFileCollection) Swap(i, j int) {
-	c[i], c[j] = c[j], c[i]
-}
-
-func (c postKustomizeFileCollection) Less(i, j int) bool {
-	return c[i].order < c[j].order
-}
-
-func (l *Unforker) rebuildListYaml(lists []util.List, kustomizedYamlFiles []postKustomizeFile) ([]postKustomizeFile, error) {
+func (l *Unforker) rebuildListYaml(lists []util.List, kustomizedYamlFiles []util.PostKustomizeFile) ([]util.PostKustomizeFile, error) {
 	debug := level.Debug(log.With(l.Logger, "struct", "daemonless.unforker", "method", "rebuildListYaml"))
-	yamlMap := make(map[util.MinimalK8sYaml]postKustomizeFile)
 
-	for _, postKustomizeFile := range kustomizedYamlFiles {
-		yamlMap[postKustomizeFile.minimal] = postKustomizeFile
-	}
-
-	fullReconstructedRendered := make([]postKustomizeFile, 0)
-	for _, list := range lists {
-		var allListItems []interface{}
-		for _, item := range list.Items {
-			if pkFile, exists := yamlMap[item]; exists {
-				delete(yamlMap, item)
-				allListItems = append(allListItems, pkFile.full)
-			}
-		}
-
-		debug.Log("event", "reconstruct list")
-		reconstructedList := ListK8sYaml{
-			APIVersion: list.APIVersion,
-			Kind:       "List",
-			Items:      allListItems,
-		}
-
-		postKustomizeList := postKustomizeFile{
-			minimal: util.MinimalK8sYaml{
-				Kind: "List",
-			},
-			full: reconstructedList,
-		}
-
-		fullReconstructedRendered = append(fullReconstructedRendered, postKustomizeList)
-	}
-
-	for nonListYamlMinimal, pkFile := range yamlMap {
-		fullReconstructedRendered = append(fullReconstructedRendered, postKustomizeFile{
-			order:   pkFile.order,
-			minimal: nonListYamlMinimal,
-			full:    pkFile.full,
-		})
-	}
-
-	return fullReconstructedRendered, nil
+	return util.RebuildListYaml(debug, lists, kustomizedYamlFiles)
 }
 
-func (l *Unforker) writePostKustomizeFiles(step api.Unfork, postKustomizeFiles []postKustomizeFile) error {
+func (l *Unforker) writePostKustomizeFiles(step api.Unfork, postKustomizeFiles []util.PostKustomizeFile) error {
 	debug := level.Debug(log.With(l.Logger, "struct", "daemonless.unforker", "method", "writePostKustomizeFiles"))
 
-	sort.Stable(postKustomizeFileCollection(postKustomizeFiles))
-
-	var joinedFinal string
-	for _, file := range postKustomizeFiles {
-		debug.Log("event", "marshal post kustomize file")
-		fileB, err := yaml.Marshal(file.full)
-		if err != nil {
-			return errors.Wrapf(err, "marshal file %s", file.minimal.Metadata.Name)
-		}
-
-		if joinedFinal != "" {
-			joinedFinal += "---\n" + string(fileB)
-		} else {
-			joinedFinal += string(fileB)
-		}
-	}
-
-	debug.Log("event", "write post kustomize files", "dest", step.Dest)
-	if err := l.FS.WriteFile(step.Dest, []byte(joinedFinal), os.FileMode(0644)); err != nil {
-		return errors.Wrapf(err, "write kustomized and post processed yaml at %s", step.Dest)
-	}
-
-	return nil
+	return util.WritePostKustomizeFiles(debug, l.FS, step.Dest, postKustomizeFiles)
 }

--- a/pkg/lifecycle/unfork/pre_unfork.go
+++ b/pkg/lifecycle/unfork/pre_unfork.go
@@ -138,10 +138,10 @@ func (l *Unforker) initialKustomizeRun(ctx context.Context, step api.Unfork) err
 	return nil
 }
 
-func (l *Unforker) replaceOriginal(step api.Unfork, built []postKustomizeFile) error {
-	builtMap := make(map[util.MinimalK8sYaml]postKustomizeFile)
+func (l *Unforker) replaceOriginal(step api.Unfork, built []util.PostKustomizeFile) error {
+	builtMap := make(map[util.MinimalK8sYaml]util.PostKustomizeFile)
 	for _, builtFile := range built {
-		builtMap[builtFile.minimal] = builtFile
+		builtMap[builtFile.Minimal] = builtFile
 	}
 
 	if err := l.FS.Walk(step.UpstreamBase, func(targetPath string, info os.FileInfo, err error) error {
@@ -184,7 +184,7 @@ func (l *Unforker) replaceOriginal(step api.Unfork, built []postKustomizeFile) e
 			return errors.Wrap(err, "remove original file")
 		}
 
-		initKustomizedB, err := yaml.Marshal(initKustomized.full)
+		initKustomizedB, err := yaml.Marshal(initKustomized.Full)
 		if err != nil {
 			return errors.Wrap(err, "marshal init kustomized")
 		}

--- a/pkg/util/kubernetes_rebuild.go
+++ b/pkg/util/kubernetes_rebuild.go
@@ -1,0 +1,114 @@
+package util
+
+import (
+	"os"
+	"sort"
+
+	"github.com/go-kit/kit/log"
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+	yaml "gopkg.in/yaml.v2"
+)
+
+type PostKustomizeFile struct {
+	Order   int
+	Minimal MinimalK8sYaml
+	Full    interface{}
+}
+
+type PostKustomizeFileCollection []PostKustomizeFile
+
+func (c PostKustomizeFileCollection) Len() int {
+	return len(c)
+}
+
+func (c PostKustomizeFileCollection) Swap(i, j int) {
+	c[i], c[j] = c[j], c[i]
+}
+
+func (c PostKustomizeFileCollection) Less(i, j int) bool {
+	return c[i].Order < c[j].Order
+}
+
+type ListK8sYaml struct {
+	APIVersion string        `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string        `json:"kind" yaml:"kind" hcl:"kind"`
+	Items      []interface{} `json:"items" yaml:"items"`
+}
+
+func RebuildListYaml(debug log.Logger, lists []List, kustomizedYamlFiles []PostKustomizeFile) ([]PostKustomizeFile, error) {
+	yamlMap := make(map[MinimalK8sYaml]PostKustomizeFile)
+
+	for _, PostKustomizeFile := range kustomizedYamlFiles {
+		yamlMap[PostKustomizeFile.Minimal] = PostKustomizeFile
+	}
+
+	fullReconstructedRendered := make([]PostKustomizeFile, 0)
+	for _, list := range lists {
+		var allListItems []interface{}
+		for _, item := range list.Items {
+			if pkFile, exists := yamlMap[item]; exists {
+				delete(yamlMap, item)
+				allListItems = append(allListItems, pkFile.Full)
+			}
+		}
+
+		// don't render empty lists
+		if len(allListItems) == 0 {
+			continue
+		}
+
+		debug.Log("event", "reconstruct list")
+		reconstructedList := ListK8sYaml{
+			APIVersion: list.APIVersion,
+			Kind:       "List",
+			Items:      allListItems,
+		}
+
+		postKustomizeList := PostKustomizeFile{
+			Minimal: MinimalK8sYaml{
+				Kind: "List",
+			},
+			Full: reconstructedList,
+		}
+
+		fullReconstructedRendered = append(fullReconstructedRendered, postKustomizeList)
+	}
+
+	for nonListYamlMinimal, pkFile := range yamlMap {
+		fullReconstructedRendered = append(fullReconstructedRendered, PostKustomizeFile{
+			Order:   pkFile.Order,
+			Minimal: nonListYamlMinimal,
+			Full:    pkFile.Full,
+		})
+	}
+
+	return fullReconstructedRendered, nil
+}
+
+func WritePostKustomizeFiles(debug log.Logger, FS afero.Afero, dest string, postKustomizeFiles []PostKustomizeFile) error {
+
+	sort.Stable(PostKustomizeFileCollection(postKustomizeFiles))
+
+	var joinedFinal string
+	for _, file := range postKustomizeFiles {
+		debug.Log("event", "marshal post kustomize file")
+		fileB, err := yaml.Marshal(file.Full)
+		if err != nil {
+			return errors.Wrapf(err, "marshal file %s", file.Minimal.Metadata.Name)
+		}
+
+		if joinedFinal != "" {
+			joinedFinal += "---\n" + string(fileB)
+		} else {
+			joinedFinal += string(fileB)
+		}
+	}
+
+	debug.Log("event", "write post kustomize files", "dest", dest)
+	if err := FS.WriteFile(dest, []byte(joinedFinal), os.FileMode(0644)); err != nil {
+		return errors.Wrapf(err, "write kustomized and post processed yaml at %s", dest)
+	}
+
+	return nil
+}

--- a/pkg/util/kubernetes_rebuild_test.go
+++ b/pkg/util/kubernetes_rebuild_test.go
@@ -1,54 +1,53 @@
-package kustomize
+package util
 
 import (
 	"testing"
 
 	"github.com/replicatedhq/ship/pkg/testing/logger"
-	"github.com/replicatedhq/ship/pkg/util"
 	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v2"
 )
 
 type kustomizeTestFile struct {
-	kustomizedFile postKustomizeFile
+	kustomizedFile PostKustomizeFile
 	contents       string
 }
 
-func (k kustomizeTestFile) toPostKustomizeFile() (postKustomizeFile, error) {
+func (k kustomizeTestFile) toPostKustomizeFile() (PostKustomizeFile, error) {
 	var out interface{}
 	if err := yaml.Unmarshal([]byte(k.contents), &out); err != nil {
-		return postKustomizeFile{}, err
+		return PostKustomizeFile{}, err
 	}
 
-	return postKustomizeFile{
-		minimal: k.kustomizedFile.minimal,
-		full:    out,
+	return PostKustomizeFile{
+		Minimal: k.kustomizedFile.Minimal,
+		Full:    out,
 	}, nil
 }
 
 func TestRebuildListyaml(t *testing.T) {
 	tests := []struct {
 		name            string
-		lists           []util.List
+		lists           []List
 		kustomizedFiles []kustomizeTestFile
 		expectFiles     []kustomizeTestFile
 	}{
 		{
 			name: "single list",
-			lists: []util.List{
+			lists: []List{
 				{
 					APIVersion: "v1",
 					Path:       "test/animal.yaml",
-					Items: []util.MinimalK8sYaml{
+					Items: []MinimalK8sYaml{
 						{
 							Kind: "Deployment",
-							Metadata: util.MinimalK8sMetadata{
+							Metadata: MinimalK8sMetadata{
 								Name: "cat",
 							},
 						},
 						{
 							Kind: "Deployment",
-							Metadata: util.MinimalK8sMetadata{
+							Metadata: MinimalK8sMetadata{
 								Name: "dog",
 							},
 						},
@@ -57,10 +56,10 @@ func TestRebuildListyaml(t *testing.T) {
 			},
 			kustomizedFiles: []kustomizeTestFile{
 				{
-					kustomizedFile: postKustomizeFile{
-						minimal: util.MinimalK8sYaml{
+					kustomizedFile: PostKustomizeFile{
+						Minimal: MinimalK8sYaml{
 							Kind: "Deployment",
-							Metadata: util.MinimalK8sMetadata{
+							Metadata: MinimalK8sMetadata{
 								Name: "cat",
 							},
 						},
@@ -70,10 +69,10 @@ hi: hello
 `,
 				},
 				{
-					kustomizedFile: postKustomizeFile{
-						minimal: util.MinimalK8sYaml{
+					kustomizedFile: PostKustomizeFile{
+						Minimal: MinimalK8sYaml{
 							Kind: "Deployment",
-							Metadata: util.MinimalK8sMetadata{
+							Metadata: MinimalK8sMetadata{
 								Name: "dog",
 							},
 						},
@@ -85,8 +84,8 @@ bye: goodbye
 			},
 			expectFiles: []kustomizeTestFile{
 				{
-					kustomizedFile: postKustomizeFile{
-						minimal: util.MinimalK8sYaml{
+					kustomizedFile: PostKustomizeFile{
+						Minimal: MinimalK8sYaml{
 							Kind: "List",
 						},
 					},
@@ -101,13 +100,13 @@ items:
 		},
 		{
 			name:  "no list",
-			lists: []util.List{},
+			lists: []List{},
 			kustomizedFiles: []kustomizeTestFile{
 				{
-					kustomizedFile: postKustomizeFile{
-						minimal: util.MinimalK8sYaml{
+					kustomizedFile: PostKustomizeFile{
+						Minimal: MinimalK8sYaml{
 							Kind: "Deployment",
-							Metadata: util.MinimalK8sMetadata{
+							Metadata: MinimalK8sMetadata{
 								Name: "cat",
 							},
 						},
@@ -115,10 +114,10 @@ items:
 					contents: `hi: hello`,
 				},
 				{
-					kustomizedFile: postKustomizeFile{
-						minimal: util.MinimalK8sYaml{
+					kustomizedFile: PostKustomizeFile{
+						Minimal: MinimalK8sYaml{
 							Kind: "Deployment",
-							Metadata: util.MinimalK8sMetadata{
+							Metadata: MinimalK8sMetadata{
 								Name: "dog",
 							},
 						},
@@ -128,10 +127,10 @@ items:
 			},
 			expectFiles: []kustomizeTestFile{
 				{
-					kustomizedFile: postKustomizeFile{
-						minimal: util.MinimalK8sYaml{
+					kustomizedFile: PostKustomizeFile{
+						Minimal: MinimalK8sYaml{
 							Kind: "Deployment",
-							Metadata: util.MinimalK8sMetadata{
+							Metadata: MinimalK8sMetadata{
 								Name: "cat",
 							},
 						},
@@ -140,10 +139,10 @@ items:
 `,
 				},
 				{
-					kustomizedFile: postKustomizeFile{
-						minimal: util.MinimalK8sYaml{
+					kustomizedFile: PostKustomizeFile{
+						Minimal: MinimalK8sYaml{
 							Kind: "Deployment",
-							Metadata: util.MinimalK8sMetadata{
+							Metadata: MinimalK8sMetadata{
 								Name: "dog",
 							},
 						},
@@ -155,20 +154,20 @@ items:
 		},
 		{
 			name: "single list with other yaml",
-			lists: []util.List{
+			lists: []List{
 				{
 					APIVersion: "v1",
 					Path:       "test/animal.yaml",
-					Items: []util.MinimalK8sYaml{
+					Items: []MinimalK8sYaml{
 						{
 							Kind: "Deployment",
-							Metadata: util.MinimalK8sMetadata{
+							Metadata: MinimalK8sMetadata{
 								Name: "cat",
 							},
 						},
 						{
 							Kind: "Deployment",
-							Metadata: util.MinimalK8sMetadata{
+							Metadata: MinimalK8sMetadata{
 								Name: "dog",
 							},
 						},
@@ -177,10 +176,10 @@ items:
 			},
 			kustomizedFiles: []kustomizeTestFile{
 				{
-					kustomizedFile: postKustomizeFile{
-						minimal: util.MinimalK8sYaml{
+					kustomizedFile: PostKustomizeFile{
+						Minimal: MinimalK8sYaml{
 							Kind: "Deployment",
-							Metadata: util.MinimalK8sMetadata{
+							Metadata: MinimalK8sMetadata{
 								Name: "cat",
 							},
 						},
@@ -190,10 +189,10 @@ hi: hello
 `,
 				},
 				{
-					kustomizedFile: postKustomizeFile{
-						minimal: util.MinimalK8sYaml{
+					kustomizedFile: PostKustomizeFile{
+						Minimal: MinimalK8sYaml{
 							Kind: "Deployment",
-							Metadata: util.MinimalK8sMetadata{
+							Metadata: MinimalK8sMetadata{
 								Name: "dog",
 							},
 						},
@@ -203,10 +202,10 @@ bye: goodbye
 `,
 				},
 				{
-					kustomizedFile: postKustomizeFile{
-						minimal: util.MinimalK8sYaml{
+					kustomizedFile: PostKustomizeFile{
+						Minimal: MinimalK8sYaml{
 							Kind: "Deployment",
-							Metadata: util.MinimalK8sMetadata{
+							Metadata: MinimalK8sMetadata{
 								Name: "monkey",
 							},
 						},
@@ -218,8 +217,8 @@ icecream: great
 			},
 			expectFiles: []kustomizeTestFile{
 				{
-					kustomizedFile: postKustomizeFile{
-						minimal: util.MinimalK8sYaml{
+					kustomizedFile: PostKustomizeFile{
+						Minimal: MinimalK8sYaml{
 							Kind: "List",
 						},
 					},
@@ -231,10 +230,10 @@ items:
 `,
 				},
 				{
-					kustomizedFile: postKustomizeFile{
-						minimal: util.MinimalK8sYaml{
+					kustomizedFile: PostKustomizeFile{
+						Minimal: MinimalK8sYaml{
 							Kind: "Deployment",
-							Metadata: util.MinimalK8sMetadata{
+							Metadata: MinimalK8sMetadata{
 								Name: "monkey",
 							},
 						},
@@ -246,20 +245,20 @@ items:
 		},
 		{
 			name: "multiple lists with other yaml",
-			lists: []util.List{
+			lists: []List{
 				{
 					APIVersion: "v1",
 					Path:       "test/animal.yaml",
-					Items: []util.MinimalK8sYaml{
+					Items: []MinimalK8sYaml{
 						{
 							Kind: "Deployment",
-							Metadata: util.MinimalK8sMetadata{
+							Metadata: MinimalK8sMetadata{
 								Name: "cat",
 							},
 						},
 						{
 							Kind: "Deployment",
-							Metadata: util.MinimalK8sMetadata{
+							Metadata: MinimalK8sMetadata{
 								Name: "dog",
 							},
 						},
@@ -268,16 +267,16 @@ items:
 				{
 					APIVersion: "v1",
 					Path:       "test/icecream.yaml",
-					Items: []util.MinimalK8sYaml{
+					Items: []MinimalK8sYaml{
 						{
 							Kind: "Deployment",
-							Metadata: util.MinimalK8sMetadata{
+							Metadata: MinimalK8sMetadata{
 								Name: "chocolate",
 							},
 						},
 						{
 							Kind: "Deployment",
-							Metadata: util.MinimalK8sMetadata{
+							Metadata: MinimalK8sMetadata{
 								Name: "strawberry",
 							},
 						},
@@ -286,10 +285,10 @@ items:
 			},
 			kustomizedFiles: []kustomizeTestFile{
 				{
-					kustomizedFile: postKustomizeFile{
-						minimal: util.MinimalK8sYaml{
+					kustomizedFile: PostKustomizeFile{
+						Minimal: MinimalK8sYaml{
 							Kind: "Deployment",
-							Metadata: util.MinimalK8sMetadata{
+							Metadata: MinimalK8sMetadata{
 								Name: "cat",
 							},
 						},
@@ -299,10 +298,10 @@ hi: hello
 `,
 				},
 				{
-					kustomizedFile: postKustomizeFile{
-						minimal: util.MinimalK8sYaml{
+					kustomizedFile: PostKustomizeFile{
+						Minimal: MinimalK8sYaml{
 							Kind: "Deployment",
-							Metadata: util.MinimalK8sMetadata{
+							Metadata: MinimalK8sMetadata{
 								Name: "dog",
 							},
 						},
@@ -312,10 +311,10 @@ bye: goodbye
 `,
 				},
 				{
-					kustomizedFile: postKustomizeFile{
-						minimal: util.MinimalK8sYaml{
+					kustomizedFile: PostKustomizeFile{
+						Minimal: MinimalK8sYaml{
 							Kind: "Deployment",
-							Metadata: util.MinimalK8sMetadata{
+							Metadata: MinimalK8sMetadata{
 								Name: "strawberry",
 							},
 						},
@@ -325,10 +324,10 @@ icecream: great
 `,
 				},
 				{
-					kustomizedFile: postKustomizeFile{
-						minimal: util.MinimalK8sYaml{
+					kustomizedFile: PostKustomizeFile{
+						Minimal: MinimalK8sYaml{
 							Kind: "Deployment",
-							Metadata: util.MinimalK8sMetadata{
+							Metadata: MinimalK8sMetadata{
 								Name: "chocolate",
 							},
 						},
@@ -338,10 +337,10 @@ cookies: wow
 `,
 				},
 				{
-					kustomizedFile: postKustomizeFile{
-						minimal: util.MinimalK8sYaml{
+					kustomizedFile: PostKustomizeFile{
+						Minimal: MinimalK8sYaml{
 							Kind: "Deployment",
-							Metadata: util.MinimalK8sMetadata{
+							Metadata: MinimalK8sMetadata{
 								Name: "ghost",
 							},
 						},
@@ -353,8 +352,8 @@ mint: chocolate
 			},
 			expectFiles: []kustomizeTestFile{
 				{
-					kustomizedFile: postKustomizeFile{
-						minimal: util.MinimalK8sYaml{
+					kustomizedFile: PostKustomizeFile{
+						Minimal: MinimalK8sYaml{
 							Kind: "List",
 						},
 					},
@@ -366,8 +365,8 @@ items:
 `,
 				},
 				{
-					kustomizedFile: postKustomizeFile{
-						minimal: util.MinimalK8sYaml{
+					kustomizedFile: PostKustomizeFile{
+						Minimal: MinimalK8sYaml{
 							Kind: "List",
 						},
 					},
@@ -379,10 +378,10 @@ items:
 `,
 				},
 				{
-					kustomizedFile: postKustomizeFile{
-						minimal: util.MinimalK8sYaml{
+					kustomizedFile: PostKustomizeFile{
+						Minimal: MinimalK8sYaml{
 							Kind: "Deployment",
-							Metadata: util.MinimalK8sMetadata{
+							Metadata: MinimalK8sMetadata{
 								Name: "ghost",
 							},
 						},
@@ -394,11 +393,11 @@ items:
 		},
 		{
 			name: "empty list",
-			lists: []util.List{
+			lists: []List{
 				{
 					APIVersion: "v1",
 					Path:       "test/empty.yaml",
-					Items:      []util.MinimalK8sYaml{},
+					Items:      []MinimalK8sYaml{},
 				},
 			},
 			kustomizedFiles: []kustomizeTestFile{},
@@ -410,33 +409,30 @@ items:
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
 			testLogger := &logger.TestLogger{T: t}
-			l := Kustomizer{
-				Logger: testLogger,
-			}
 
-			kustomizeFiles := make([]postKustomizeFile, 0)
+			kustomizeFiles := make([]PostKustomizeFile, 0)
 			for _, kustomizeTestFile := range tt.kustomizedFiles {
 				actualPostKustomizeFile, err := kustomizeTestFile.toPostKustomizeFile()
 				req.NoError(err)
 				kustomizeFiles = append(kustomizeFiles, actualPostKustomizeFile)
 			}
 
-			rebuilt, err := l.rebuildListYaml(tt.lists, kustomizeFiles)
+			rebuilt, err := RebuildListYaml(testLogger, tt.lists, kustomizeFiles)
 			req.NoError(err)
 
 			actualContents := make([]string, 0)
-			actualMinimal := make([]util.MinimalK8sYaml, 0)
+			actualMinimal := make([]MinimalK8sYaml, 0)
 			expectedContents := make([]string, 0)
-			expectedMinimal := make([]util.MinimalK8sYaml, 0)
+			expectedMinimal := make([]MinimalK8sYaml, 0)
 			for idx, rebuiltFile := range rebuilt {
-				rebuiltFileB, err := yaml.Marshal(rebuiltFile.full)
+				rebuiltFileB, err := yaml.Marshal(rebuiltFile.Full)
 				req.NoError(err)
 
 				actualContents = append(actualContents, string(rebuiltFileB))
-				actualMinimal = append(actualMinimal, rebuiltFile.minimal)
+				actualMinimal = append(actualMinimal, rebuiltFile.Minimal)
 
 				expectedContents = append(expectedContents, string(tt.expectFiles[idx].contents))
-				expectedMinimal = append(expectedMinimal, tt.expectFiles[idx].kustomizedFile.minimal)
+				expectedMinimal = append(expectedMinimal, tt.expectFiles[idx].kustomizedFile.Minimal)
 			}
 			req.ElementsMatch(expectedContents, actualContents)
 			req.ElementsMatch(expectedMinimal, actualMinimal)


### PR DESCRIPTION
What I Did
------------
Added a list length check to the render step - and only render the list if the length is nonzero.

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------
Empty kubernetes lists will not be included in ship output.


Picture of a Boat (not required but encouraged)
------------
![USS Carpenter (DD-825)](https://upload.wikimedia.org/wikipedia/commons/thumb/9/95/USS_Carpenter_%28DD-825%29_underway_off_the_coast_of_San_Diego%2C_in_February_1976_%28NH_107128%29.jpg/1599px-USS_Carpenter_%28DD-825%29_underway_off_the_coast_of_San_Diego%2C_in_February_1976_%28NH_107128%29.jpg "USS Carpenter (DD-825)")











<!-- (thanks https://github.com/docker/docker for this template) -->

