### PR TITLE
render templates in step yaml before running preexecute functions

### DIFF
--- a/pkg/lifecycle/daemon/routes_navcycle.go
+++ b/pkg/lifecycle/daemon/routes_navcycle.go
@@ -157,8 +157,14 @@ func (d *NavcycleRoutes) getRequiredButIncompleteStepFor(requires []string) (str
 	return "", nil
 }
 
-func (d *NavcycleRoutes) hydrateAndSend(step daemontypes.Step, c *gin.Context) {
-	result, err := d.hydrateStep(step)
+func (d *NavcycleRoutes) hydrateAndSend(step api.Step, c *gin.Context) {
+	step, err := d.buildStepContents(step)
+	if err != nil {
+		c.AbortWithError(500, err)
+		return
+	}
+
+	result, err := d.hydrateStep(daemontypes.NewStep(step))
 	if err != nil {
 		c.AbortWithError(500, err)
 		return

--- a/pkg/lifecycle/daemon/routes_navcycle_completestep.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_completestep.go
@@ -47,7 +47,7 @@ func (d *NavcycleRoutes) completeStep(c *gin.Context) {
 		// hack, give it 10 ms in case its an instant step. Hydrate and send will read progress from the syncMap
 		time.Sleep(10 * time.Millisecond)
 
-		d.hydrateAndSend(daemontypes.NewStep(step), c)
+		d.hydrateAndSend(step, c)
 		go d.handleAsync(errChan, debug, step, stepID)
 		return
 	}


### PR DESCRIPTION
What I Did
------------
Moved the 'render templates in lifecycle steps' step to before we run preexecute functions so that they receive the templated values

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------
Fixed an issue that caused template functions within the kustomize lifecycle step's base parameter to fail


Picture of a Boat (not required but encouraged)
------------

![Tomahawk missile sinking USS Agerholm (DD-826)](https://upload.wikimedia.org/wikipedia/commons/8/8c/Tomahawk_missile_sinking_USS_Agerholm_%28DD-826%29_1982.JPEG "Tomahawk missile sinking USS Agerholm (DD-826)")



![USS Agerholm (DD-826) tests a nuclear depth charge, 11 May 1962](https://upload.wikimedia.org/wikipedia/commons/9/98/Nuclear_depth_charge_explodes_near_USS_Agerholm_%28DD-826%29%2C_11_May_1962.jpg "USS Agerholm (DD-826) tests a nuclear depth charge, 11 May 1962")






<!-- (thanks https://github.com/docker/docker for this template) -->

