### PR TITLE
Use kustomize head, allowing the use of other list types

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1968,7 +1968,8 @@
   revision = "045dc31ee5c40e8240241ce28dc24d7b56130373"
 
 [[projects]]
-  digest = "1:8a16a47f24297f163b8943a7905f59d88bd0bb6e73c90924d8c53c89d07076bd"
+  branch = "master"
+  digest = "1:a0b085e66b6af85b6662b1fdf481261cbe47a6bf9f40ca8ac1523a49aef7e0ab"
   name = "sigs.k8s.io/kustomize"
   packages = [
     "k8sdeps",
@@ -2002,8 +2003,7 @@
     "pkg/types",
   ]
   pruneopts = "UT"
-  revision = "ce7e5ee2c30cc5856fea01fe423cf167f2a2d0c3"
-  version = "v2.0.1"
+  revision = "e65b45f96964498c45d3b38b23d39c5893024a57"
 
 [[projects]]
   digest = "1:7719608fe0b52a4ece56c2dde37bedd95b938677d1ab0f84b8a7852e4c59f849"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -89,7 +89,7 @@ ignored = [
 
 [[constraint]]
   name = "sigs.k8s.io/kustomize"
-  version = "2.0.1"
+  branch = "master"
 
 [[override]]
   name = "k8s.io/kubernetes"

--- a/integration/init/other-list-types/expected/.ship/state.json
+++ b/integration/init/other-list-types/expected/.ship/state.json
@@ -1,0 +1,8 @@
+{
+  "v1": {
+    "config": {},
+    "releaseName": "ship",
+    "upstream": "https://github.com/replicatedhq/test-charts/tree/0e13bc2c19778b67f83f68c5e2886de0cd43d59f/other-list-types",
+    "contentSHA": "78ca09c481a6c8b2d507da0c171defab38aa33dc990b4034b5447d75f74b7fdf"
+  }
+}

--- a/integration/init/other-list-types/expected/base/configmapList.yaml
+++ b/integration/init/other-list-types/expected/base/configmapList.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMapList
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: winnie
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: notwinnie

--- a/integration/init/other-list-types/expected/base/kustomization.yaml
+++ b/integration/init/other-list-types/expected/base/kustomization.yaml
@@ -1,0 +1,6 @@
+kind: ""
+apiversion: ""
+resources:
+- configmapList.yaml
+- roleBindingList.yaml
+- roleList.yaml

--- a/integration/init/other-list-types/expected/base/roleBindingList.yaml
+++ b/integration/init/other-list-types/expected/base/roleBindingList.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBindingList
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: rolebinding-prometheus
+    labels:
+      app: default-prometheus
+    namespace: default
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: role-prometheus
+  subjects:
+  - kind: ServiceAccount
+    name: role-prometheus
+    namespace: default

--- a/integration/init/other-list-types/expected/base/roleList.yaml
+++ b/integration/init/other-list-types/expected/base/roleList.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleList
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: role-prometheus
+    labels:
+      app: default-prometheus
+    namespace: default
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - nodes
+    - services
+    - endpoints
+    - pods
+    verbs:
+    - get
+    - list
+    - watch

--- a/integration/init/other-list-types/expected/overlays/ship/kustomization.yaml
+++ b/integration/init/other-list-types/expected/overlays/ship/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: ""
+apiversion: ""
+bases:
+- ../../base

--- a/integration/init/other-list-types/expected/rendered.yaml
+++ b/integration/init/other-list-types/expected/rendered.yaml
@@ -1,0 +1,45 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: default-prometheus
+  name: role-prometheus
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: default-prometheus
+  name: rolebinding-prometheus
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: role-prometheus
+subjects:
+- kind: ServiceAccount
+  name: role-prometheus
+  namespace: default
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: notwinnie
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: winnie

--- a/integration/init/other-list-types/metadata.yaml
+++ b/integration/init/other-list-types/metadata.yaml
@@ -1,0 +1,3 @@
+upstream: "https://github.com/replicatedhq/test-charts/tree/0e13bc2c19778b67f83f68c5e2886de0cd43d59f/other-list-types"
+args: ["--prefer-git"]
+skip_cleanup: false

--- a/pkg/patch/kustomize.go
+++ b/pkg/patch/kustomize.go
@@ -36,7 +36,7 @@ func (p *ShipPatcher) runKustomize(out io.Writer, fSys fs.FileSystem, kustomizat
 
 	k8sFactory := k8sdeps.NewFactory()
 
-	kt, err := target.NewKustTarget(ldr, fSys, k8sFactory.ResmapF, k8sFactory.TransformerF)
+	kt, err := target.NewKustTarget(ldr, k8sFactory.ResmapF, k8sFactory.TransformerF)
 	if err != nil {
 		return errors.Wrap(err, "make customized kustomize target")
 	}

--- a/vendor/sigs.k8s.io/kustomize/k8sdeps/configmapandsecret/configmapfactory.go
+++ b/vendor/sigs.k8s.io/kustomize/k8sdeps/configmapandsecret/configmapfactory.go
@@ -81,8 +81,8 @@ func (f *ConfigMapFactory) MakeConfigMap(
 	}
 	all = append(all, pairs...)
 
-	for _, kv := range all {
-		err = addKvToConfigMap(cm, kv.Key, kv.Value)
+	for _, p := range all {
+		err = addKvToConfigMap(cm, p.Key, p.Value)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/sigs.k8s.io/kustomize/k8sdeps/configmapandsecret/secretfactory.go
+++ b/vendor/sigs.k8s.io/kustomize/k8sdeps/configmapandsecret/secretfactory.go
@@ -80,8 +80,8 @@ func (f *SecretFactory) MakeSecret(args *types.SecretArgs, options *types.Genera
 	}
 	all = append(all, pairs...)
 
-	for _, kv := range all {
-		err = addKvToSecret(s, kv.Key, kv.Value)
+	for _, p := range all {
+		err = addKvToSecret(s, p.Key, p.Value)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/sigs.k8s.io/kustomize/k8sdeps/kunstruct/factory.go
+++ b/vendor/sigs.k8s.io/kustomize/k8sdeps/kunstruct/factory.go
@@ -108,7 +108,7 @@ func (kf *KunstructuredFactoryImpl) validate(u unstructured.Unstructured) error 
 	kind := u.GetKind()
 	if kind == "" {
 		return fmt.Errorf("missing kind in object %v", u)
-	} else if kind == "List" {
+	} else if strings.HasSuffix(kind, "List") {
 		return nil
 	}
 	if u.GetName() == "" {

--- a/vendor/sigs.k8s.io/kustomize/pkg/git/repospec.go
+++ b/vendor/sigs.k8s.io/kustomize/pkg/git/repospec.go
@@ -24,6 +24,13 @@ import (
 	"sigs.k8s.io/kustomize/pkg/fs"
 )
 
+// Used as a temporary non-empty occupant of the cloneDir
+// field, as something distinguishable from the empty string
+// in various outputs (especially tests). Not using an
+// actual directory name here, as that's a temporary directory
+// with a unique name that isn't created until clone time.
+const notCloned = fs.ConfirmedDir("/notCloned")
+
 // RepoSpec specifies a git repository and a branch and path therein.
 type RepoSpec struct {
 	// Raw, original spec, used to look for cycles.
@@ -88,7 +95,7 @@ func NewRepoSpecFromUrl(n string) (*RepoSpec, error) {
 	}
 	return &RepoSpec{
 		raw: n, host: host, orgRepo: orgRepo,
-		path: path, ref: gitRef}, nil
+		cloneDir: notCloned, path: path, ref: gitRef}, nil
 }
 
 const (

--- a/vendor/sigs.k8s.io/kustomize/pkg/resource/factory.go
+++ b/vendor/sigs.k8s.io/kustomize/pkg/resource/factory.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
 
 	"sigs.k8s.io/kustomize/pkg/ifc"
 	internal "sigs.k8s.io/kustomize/pkg/internal/error"
@@ -94,10 +95,14 @@ func (rf *Factory) SliceFromBytes(in []byte) ([]*Resource, error) {
 	for len(kunStructs) > 0 {
 		u := kunStructs[0]
 		kunStructs = kunStructs[1:]
-		if u.GetKind() == "List" {
+		if strings.HasSuffix(u.GetKind(), "List") {
 			items := u.Map()["items"]
 			itemsSlice, ok := items.([]interface{})
 			if !ok {
+				if items == nil {
+					// an empty list
+					continue
+				}
 				return nil, fmt.Errorf("items in List is type %T, expected array", items)
 			}
 			for _, item := range itemsSlice {

--- a/vendor/sigs.k8s.io/kustomize/pkg/resource/resource.go
+++ b/vendor/sigs.k8s.io/kustomize/pkg/resource/resource.go
@@ -38,7 +38,7 @@ func (r *Resource) String() string {
 	if err != nil {
 		return "<" + err.Error() + ">"
 	}
-	return strings.TrimSpace(string(bs))
+	return strings.TrimSpace(string(bs)) + r.options.String()
 }
 
 // DeepCopy returns a new copy of resource

--- a/vendor/sigs.k8s.io/kustomize/pkg/target/kusttarget.go
+++ b/vendor/sigs.k8s.io/kustomize/pkg/target/kusttarget.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/kustomize/pkg/constants"
-	"sigs.k8s.io/kustomize/pkg/fs"
 	"sigs.k8s.io/kustomize/pkg/ifc"
 	"sigs.k8s.io/kustomize/pkg/ifc/transformer"
 	interror "sigs.k8s.io/kustomize/pkg/internal/error"
@@ -42,7 +41,6 @@ import (
 type KustTarget struct {
 	kustomization *types.Kustomization
 	ldr           ifc.Loader
-	fSys          fs.FileSystem
 	rFactory      *resmap.Factory
 	tFactory      transformer.Factory
 }
@@ -50,7 +48,6 @@ type KustTarget struct {
 // NewKustTarget returns a new instance of KustTarget primed with a Loader.
 func NewKustTarget(
 	ldr ifc.Loader,
-	fSys fs.FileSystem,
 	rFactory *resmap.Factory,
 	tFactory transformer.Factory) (*KustTarget, error) {
 	content, err := loadKustFile(ldr)
@@ -70,10 +67,21 @@ func NewKustTarget(
 	return &KustTarget{
 		kustomization: &k,
 		ldr:           ldr,
-		fSys:          fSys,
 		rFactory:      rFactory,
 		tFactory:      tFactory,
 	}, nil
+}
+
+func quoted(l []string) []string {
+	r := make([]string, len(l))
+	for i, v := range l {
+		r[i] = "'" + v + "'"
+	}
+	return r
+}
+
+func commaOr(q []string) string {
+	return strings.Join(q[:len(q)-1], ", ") + " or " + q[len(q)-1]
 }
 
 func loadKustFile(ldr ifc.Loader) ([]byte, error) {
@@ -88,8 +96,9 @@ func loadKustFile(ldr ifc.Loader) ([]byte, error) {
 	}
 	switch match {
 	case 0:
-		return nil, fmt.Errorf("No kustomization file found in %s. Kustomize supports the following kustomization files: %s",
-			ldr.Root(), strings.Join(constants.KustomizationFileNames, ", "))
+		return nil, fmt.Errorf(
+			"unable to find one of %v in directory '%s'",
+			commaOr(quoted(constants.KustomizationFileNames)), ldr.Root())
 	case 1:
 		return content, nil
 	default:
@@ -110,7 +119,7 @@ func unmarshal(y []byte, o interface{}) error {
 // MakeCustomizedResMap creates a ResMap per kustomization instructions.
 // The Resources in the returned ResMap are fully customized.
 func (kt *KustTarget) MakeCustomizedResMap() (resmap.ResMap, error) {
-	ra, err := kt.accumulateTarget()
+	ra, err := kt.AccumulateTarget()
 	if err != nil {
 		return nil, err
 	}
@@ -134,11 +143,11 @@ func (kt *KustTarget) shouldAddHashSuffixesToGeneratedResources() bool {
 		!kt.kustomization.GeneratorOptions.DisableNameSuffixHash
 }
 
-// accumulateTarget returns a new ResAccumulator,
+// AccumulateTarget returns a new ResAccumulator,
 // holding customized resources and the data/rules used
 // to do so.  The name back references and vars are
 // not yet fixed.
-func (kt *KustTarget) accumulateTarget() (
+func (kt *KustTarget) AccumulateTarget() (
 	ra *ResAccumulator, err error) {
 	// TODO(monopole): Get rid of the KustomizationErrors accumulator.
 	// It's not consistently used, and complicates tests.
@@ -236,15 +245,15 @@ func (kt *KustTarget) accumulateBases() (
 			continue
 		}
 		subKt, err := NewKustTarget(
-			ldr, kt.fSys, kt.rFactory, kt.tFactory)
+			ldr, kt.rFactory, kt.tFactory)
 		if err != nil {
 			errs.Append(errors.Wrap(err, "couldn't make target for "+path))
 			ldr.Cleanup()
 			continue
 		}
-		subRa, err := subKt.accumulateTarget()
+		subRa, err := subKt.AccumulateTarget()
 		if err != nil {
-			errs.Append(errors.Wrap(err, "accumulateTarget"))
+			errs.Append(errors.Wrap(err, "AccumulateTarget"))
 			ldr.Cleanup()
 			continue
 		}

--- a/vendor/sigs.k8s.io/kustomize/pkg/target/resaccumulator.go
+++ b/vendor/sigs.k8s.io/kustomize/pkg/target/resaccumulator.go
@@ -55,6 +55,11 @@ func (ra *ResAccumulator) ResMap() resmap.ResMap {
 	return result
 }
 
+// Vars returns a copy of underlying vars.
+func (ra *ResAccumulator) Vars() []types.Var {
+	return ra.varSet.Set()
+}
+
 func (ra *ResAccumulator) MergeResourcesWithErrorOnIdCollision(
 	resources resmap.ResMap) (err error) {
 	ra.resMap, err = resmap.MergeWithErrorOnIdCollision(

--- a/vendor/sigs.k8s.io/kustomize/pkg/transformers/config/defaultconfig/varreference.go
+++ b/vendor/sigs.k8s.io/kustomize/pkg/transformers/config/defaultconfig/varreference.go
@@ -105,5 +105,47 @@ varReference:
 
 - path: spec/tls/hosts
   kind: Ingress
+
+- path: spec/template/spec/containers/volumeMounts/mountPath
+  kind: StatefulSet
+
+- path: spec/template/spec/initContainers/volumeMounts/mountPath
+  kind: StatefulSet
+
+- path: spec/containers/volumeMounts/mountPath
+  kind: Pod
+
+- path: spec/initContainers/volumeMounts/mountPath
+  kind: Pod
+
+- path: spec/template/spec/containers/volumeMounts/mountPath
+  kind: ReplicaSet
+
+- path: spec/template/spec/initContainers/volumeMounts/mountPath
+  kind: ReplicaSet
+
+- path: spec/template/spec/containers/volumeMounts/mountPath
+  kind: Job
+
+- path: spec/template/spec/initContainers/volumeMounts/mountPath
+  kind: Job
+
+- path: spec/template/spec/containers/volumeMounts/mountPath
+  kind: CronJob
+
+- path: spec/template/spec/initContainers/volumeMounts/mountPath
+  kind: CronJob
+
+- path: spec/template/spec/containers/volumeMounts/mountPath
+  kind: DaemonSet
+
+- path: spec/template/spec/initContainers/volumeMounts/mountPath
+  kind: DaemonSet
+
+- path: spec/template/spec/containers/volumeMounts/mountPath
+  kind: Deployment
+
+- path: spec/template/spec/initContainers/volumeMounts/mountPath
+  kind: Deployment
 `
 )

--- a/vendor/sigs.k8s.io/kustomize/pkg/transformers/image.go
+++ b/vendor/sigs.k8s.io/kustomize/pkg/transformers/image.go
@@ -85,20 +85,21 @@ func (pt *imageTransformer) updateContainers(obj map[string]interface{}, path st
 
 		imageName := containerImage.(string)
 		for _, img := range pt.images {
-			if isImageMatched(imageName, img.Name) {
-				name, tag := split(imageName)
-				if img.NewName != "" {
-					name = img.NewName
-				}
-				if img.NewTag != "" {
-					tag = ":" + img.NewTag
-				}
-				if img.Digest != "" {
-					tag = "@" + img.Digest
-				}
-				container["image"] = name + tag
-				break
+			if !isImageMatched(imageName, img.Name) {
+				continue
 			}
+			name, tag := split(imageName)
+			if img.NewName != "" {
+				name = img.NewName
+			}
+			if img.NewTag != "" {
+				tag = ":" + img.NewTag
+			}
+			if img.Digest != "" {
+				tag = "@" + img.Digest
+			}
+			container["image"] = name + tag
+			break
 		}
 	}
 	return nil

--- a/vendor/sigs.k8s.io/kustomize/pkg/types/genargs.go
+++ b/vendor/sigs.k8s.io/kustomize/pkg/types/genargs.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package types
 
+import (
+	"strconv"
+	"strings"
+)
+
 // GenArgs contains both generator args and options
 type GenArgs struct {
 	args *GeneratorArgs
@@ -28,6 +33,18 @@ func NewGenArgs(args *GeneratorArgs, opts *GeneratorOptions) *GenArgs {
 		args: args,
 		opts: opts,
 	}
+}
+
+func (g *GenArgs) String() string {
+	if g == nil {
+		return "{nilGenArgs}"
+	}
+	return "{" +
+		strings.Join([]string{
+			"nsfx:" + strconv.FormatBool(g.NeedsHashSuffix()),
+			"beh:" + g.Behavior().String()},
+			",") +
+		"}"
 }
 
 // NeedHashSuffix returns true if the hash suffix is needed.

--- a/vendor/sigs.k8s.io/kustomize/pkg/types/var.go
+++ b/vendor/sigs.k8s.io/kustomize/pkg/types/var.go
@@ -75,9 +75,11 @@ type VarSet struct {
 	set []Var
 }
 
-// Set returns the var set.
+// Set returns a copy of the var set.
 func (vs *VarSet) Set() []Var {
-	return vs.set
+	s := make([]Var, len(vs.set))
+	copy(s, vs.set)
+	return s
 }
 
 // MergeSet absorbs other vars with error on name collision.


### PR DESCRIPTION
What I Did
------------
Updated Ship to use kustomize head (again) which includes support for any '*List' types

How I Did it
------------


How to verify it
------------
Look at the integration test.

Description for the Changelog
------------
Alternative Kubernetes list types no longer cause kustomize errors


Picture of a Boat (not required but encouraged)
------------

![USS Myles C Fox (DD-829)](https://upload.wikimedia.org/wikipedia/commons/2/28/USS_Myles_C_Fox_%28DD-829%29_underway_in_early_1970s.jpg "USS Myles C Fox (DD-829)")











<!-- (thanks https://github.com/docker/docker for this template) -->

