### PR TITLE
render templates in noproxy github assets

### DIFF
--- a/integration/init/github-template-funcs/expected/.ship/state.json
+++ b/integration/init/github-template-funcs/expected/.ship/state.json
@@ -1,0 +1,10 @@
+{
+  "v1": {
+    "config": {
+      "option": "abc123"
+    },
+    "releaseName": "ship",
+    "upstream": "https://github.com/replicatedhq/test-charts/tree/fd6c6c83ff38d272311b0ed00d6e579ba8b3579e/template-functions-noproxy",
+    "contentSHA": "a28253e6e1fa4a1768c62f11be8fbc97eec2abe1d8ed77c19faaee4cd0a386d7"
+  }
+}

--- a/integration/init/github-template-funcs/expected/installer/github-noslash/template-functions/config.md
+++ b/integration/init/github-template-funcs/expected/installer/github-noslash/template-functions/config.md
@@ -1,0 +1,3 @@
+#This file tests a part of the Config suite of template functions in Ship
+
+Config option: abc123

--- a/integration/init/github-template-funcs/expected/installer/github-noslash/template-functions/installation.md
+++ b/integration/init/github-template-funcs/expected/installer/github-noslash/template-functions/installation.md
@@ -1,0 +1,4 @@
+#This file tests a part of the Integration suite of template functions in Ship
+
+Release semver: 
+

--- a/integration/init/github-template-funcs/expected/installer/github-noslash/template-functions/static.md
+++ b/integration/init/github-template-funcs/expected/installer/github-noslash/template-functions/static.md
@@ -1,0 +1,4 @@
+#This file tests a part of the Static suite of template functions in Ship
+
+TwoPlusTwo: 4
+UPPERCASE: UPPERCASE

--- a/integration/init/github-template-funcs/expected/installer/github-slash/template-functions/config.md
+++ b/integration/init/github-template-funcs/expected/installer/github-slash/template-functions/config.md
@@ -1,0 +1,3 @@
+#This file tests a part of the Config suite of template functions in Ship
+
+Config option: abc123

--- a/integration/init/github-template-funcs/expected/installer/github-slash/template-functions/installation.md
+++ b/integration/init/github-template-funcs/expected/installer/github-slash/template-functions/installation.md
@@ -1,0 +1,4 @@
+#This file tests a part of the Integration suite of template functions in Ship
+
+Release semver: 
+

--- a/integration/init/github-template-funcs/expected/installer/github-slash/template-functions/static.md
+++ b/integration/init/github-template-funcs/expected/installer/github-slash/template-functions/static.md
@@ -1,0 +1,4 @@
+#This file tests a part of the Static suite of template functions in Ship
+
+TwoPlusTwo: 4
+UPPERCASE: UPPERCASE

--- a/integration/init/github-template-funcs/expected/installer/github-stripped/config.md
+++ b/integration/init/github-template-funcs/expected/installer/github-stripped/config.md
@@ -1,0 +1,3 @@
+#This file tests a part of the Config suite of template functions in Ship
+
+Config option: abc123

--- a/integration/init/github-template-funcs/expected/installer/github-stripped/installation.md
+++ b/integration/init/github-template-funcs/expected/installer/github-stripped/installation.md
@@ -1,0 +1,4 @@
+#This file tests a part of the Integration suite of template functions in Ship
+
+Release semver: 
+

--- a/integration/init/github-template-funcs/expected/installer/github-stripped/static.md
+++ b/integration/init/github-template-funcs/expected/installer/github-stripped/static.md
@@ -1,0 +1,4 @@
+#This file tests a part of the Static suite of template functions in Ship
+
+TwoPlusTwo: 4
+UPPERCASE: UPPERCASE

--- a/integration/init/github-template-funcs/expected/installer/scripts/install.sh
+++ b/integration/init/github-template-funcs/expected/installer/scripts/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "installing nothing"
+echo "semver: "

--- a/integration/init/github-template-funcs/metadata.yaml
+++ b/integration/init/github-template-funcs/metadata.yaml
@@ -1,0 +1,3 @@
+upstream: "https://github.com/replicatedhq/test-charts/tree/fd6c6c83ff38d272311b0ed00d6e579ba8b3579e/template-functions-noproxy"
+args: ["--prefer-git"]
+skip_cleanup: false

--- a/pkg/lifecycle/render/github/render.go
+++ b/pkg/lifecycle/render/github/render.go
@@ -21,6 +21,7 @@ import (
 	"github.com/replicatedhq/ship/pkg/specs/gogetter"
 	"github.com/replicatedhq/ship/pkg/state"
 	"github.com/replicatedhq/ship/pkg/templates"
+
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
 )
@@ -230,6 +231,10 @@ func (r *LocalRenderer) resolveNoProxyGithubAssets(asset api.GitHubAsset, builde
 
 	if err := r.Fs.RemoveAll(localFetchPath); err != nil {
 		return errors.Wrap(err, "remove tmp github asset")
+	}
+
+	if err := templates.BuildDir(dest, &r.Fs, builder); err != nil {
+		return errors.Wrapf(err, "render templates in github asset %s", dest)
 	}
 
 	return nil

--- a/pkg/templates/util.go
+++ b/pkg/templates/util.go
@@ -1,0 +1,58 @@
+package templates
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+)
+
+func BuildDir(buildPath string, fs *afero.Afero, builder *Builder) error {
+	isDir, err := fs.IsDir(buildPath)
+	if err != nil {
+		return errors.Wrapf(err, "check if dir %s", buildPath)
+	}
+	if !isDir {
+		return buildFile(buildPath, fs, builder)
+	}
+
+	files, err := fs.ReadDir(buildPath)
+	if err != nil {
+		return errors.Wrapf(err, "read dir %s", buildPath)
+	}
+	for _, file := range files {
+		childPath := filepath.Join(buildPath, file.Name())
+		if file.IsDir() {
+			err = BuildDir(childPath, fs, builder)
+			if err != nil {
+				return errors.Wrapf(err, "build dir %s", childPath)
+			}
+		} else {
+			err = buildFile(childPath, fs, builder)
+			if err != nil {
+				return errors.Wrapf(err, "build file %s", childPath)
+			}
+		}
+	}
+
+	return nil
+}
+
+func buildFile(buildPath string, fs *afero.Afero, builder *Builder) error {
+	fileContents, err := fs.ReadFile(buildPath)
+	if err != nil {
+		return errors.Wrapf(err, "read file %s", buildPath)
+	}
+
+	newContents, err := builder.String(string(fileContents))
+	if err != nil {
+		return errors.Wrapf(err, "template file %s", buildPath)
+	}
+
+	err = fs.WriteFile(buildPath, []byte(newContents), os.FileMode(777))
+	if err != nil {
+		return errors.Wrapf(err, "write file %s", buildPath)
+	}
+	return nil
+}

--- a/pkg/templates/util_test.go
+++ b/pkg/templates/util_test.go
@@ -1,0 +1,144 @@
+package templates
+
+import (
+	"os"
+	"testing"
+
+	"github.com/replicatedhq/ship/pkg/testing/logger"
+	"github.com/spf13/afero"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildDir(t *testing.T) {
+	type file struct {
+		contents string
+		path     string
+	}
+
+	tests := []struct {
+		name        string
+		buildPath   string
+		inputFiles  []file
+		outputFiles []file
+	}{
+		{
+			name:      "no templates",
+			buildPath: "dir",
+			inputFiles: []file{
+				{
+					contents: "notATemplate",
+					path:     "dir/file.txt",
+				},
+			},
+			outputFiles: []file{
+				{
+					contents: "notATemplate",
+					path:     "dir/file.txt",
+				},
+			},
+		},
+		{
+			name:      "template not in dir",
+			buildPath: "dir",
+			inputFiles: []file{
+				{
+					contents: "notATemplate",
+					path:     "dir/file.txt",
+				},
+				{
+					contents: `{{repl ConfigOption "option_1"}}`,
+					path:     "notDir/template.txt",
+				},
+			},
+			outputFiles: []file{
+				{
+					contents: "notATemplate",
+					path:     "dir/file.txt",
+				},
+				{
+					contents: `{{repl ConfigOption "option_1"}}`,
+					path:     "notDir/template.txt",
+				},
+			},
+		},
+		{
+			name:      "template in dir",
+			buildPath: "dir",
+			inputFiles: []file{
+				{
+					contents: "notATemplate",
+					path:     "dir/file.txt",
+				},
+				{
+					contents: `{{repl ConfigOption "option_1"}}`,
+					path:     "dir/template.txt",
+				},
+			},
+			outputFiles: []file{
+				{
+					contents: "notATemplate",
+					path:     "dir/file.txt",
+				},
+				{
+					contents: "Option 1",
+					path:     "dir/template.txt",
+				},
+			},
+		},
+		{
+			name:      "template in subdir",
+			buildPath: "anotherdir",
+			inputFiles: []file{
+				{
+					contents: "notATemplate",
+					path:     "anotherdir/file.txt",
+				},
+				{
+					contents: `{{repl ConfigOption "option_2"}}`,
+					path:     "anotherdir/subdir/template.txt",
+				},
+			},
+			outputFiles: []file{
+				{
+					contents: "notATemplate",
+					path:     "anotherdir/file.txt",
+				},
+				{
+					contents: "Option 2",
+					path:     "anotherdir/subdir/template.txt",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			fs := afero.Afero{Fs: afero.NewMemMapFs()}
+
+			for _, file := range tt.inputFiles {
+				req.NoError(fs.WriteFile(file.path, []byte(file.contents), os.FileMode(777)))
+			}
+
+			builderBuilder := &BuilderBuilder{
+				Logger: &logger.TestLogger{T: t},
+				Viper:  viper.New(),
+			}
+
+			builder := builderBuilder.NewBuilder(
+				builderBuilder.NewStaticContext(),
+				testContext{},
+			)
+
+			err := BuildDir(tt.buildPath, &fs, &builder)
+			req.NoError(err)
+
+			for _, file := range tt.outputFiles {
+				actualContents, err := fs.ReadFile(file.path)
+				req.NoError(err)
+				req.Equal(file.contents, string(actualContents))
+			}
+		})
+	}
+}


### PR DESCRIPTION
What I Did
------------
Resolved #716 by templating noproxy GitHub assets.

How I Did it
------------
Added a new function 'BuildDir' that recursively renders templates within all files in a dir.

How to verify it
------------
Integration tests (and new unit tests) pass

Description for the Changelog
------------
All GitHub assets now have template functions run.


Picture of a Boat (not required but encouraged)
------------




![USS Herbert J. Thomas (DDR-833)](https://upload.wikimedia.org/wikipedia/commons/thumb/4/43/USS_Herbert_J._Thomas_%28DDR-833%29_underway_in_San_Francisco_Bay_on_13_June_1957_%28NH_94309%29.jpg/1280px-USS_Herbert_J._Thomas_%28DDR-833%29_underway_in_San_Francisco_Bay_on_13_June_1957_%28NH_94309%29.jpg "USS Herbert J. Thomas (DDR-833)")







<!-- (thanks https://github.com/docker/docker for this template) -->

