### PR TITLE
WIP: Support for helm repository aliases

### DIFF
--- a/pkg/lifecycle/render/helm/dependency.go
+++ b/pkg/lifecycle/render/helm/dependency.go
@@ -26,6 +26,10 @@ func (f *LocalTemplater) addDependencies(
 ) (depPaths []string, err error) {
 	for _, dependency := range dependencies {
 		if dependency.Repository != "" {
+			if strings.HasPrefix(dependency.Repository, "@") || strings.HasPrefix(dependency.Repository, "alias:") {
+				// The repository is an alias. Assume it has already been added.
+				return depPaths, nil
+			}
 			repoURL, err := url.Parse(dependency.Repository)
 			if err != nil {
 				return depPaths, errors.Wrapf(err, "parse dependency repo %s", dependency.Repository)

--- a/pkg/lifecycle/render/helm/dependency.go
+++ b/pkg/lifecycle/render/helm/dependency.go
@@ -28,7 +28,7 @@ func (f *LocalTemplater) addDependencies(
 		if dependency.Repository != "" {
 			if strings.HasPrefix(dependency.Repository, "@") || strings.HasPrefix(dependency.Repository, "alias:") {
 				// The repository is an alias. Assume it has already been added.
-				return depPaths, nil
+				continue
 			}
 			repoURL, err := url.Parse(dependency.Repository)
 			if err != nil {


### PR DESCRIPTION
Related to #832

Relevant comment from slack:

> I've been digging into https://github.com/replicatedhq/ship/issues/832 and the solution is going to be a bit more complicated than I thought since ship creates its own helm home. After adding basic support for aliases to the func mentioned in that issue, I can get it working with the following flow, but it's pretty cumbersome:

```
$ ship init https://github.com/istio/istio/tree/1.1.0-snapshot.6/install/kubernetes/helm/istio
# From another terminal, before proceeding to the ship UI
$ helm init --client-only --home ~/ship-istio/.ship/tmp/.helm
$ helm --home ~/ship-istio/.ship/tmp/.helm repo add istio.io https://storage.googleapis.com/istio-release/releases/1.1.0-snapshot.6/charts
```

> I suspect the right solution would be to add a step in the UI for configuring the URLs for any repo aliases found in the project's `requirements.yaml`, but that seems like a fairly large chunk of work. Maybe it's sufficient to just add a flag to `ship init` that lets you set any needed alias URLs?

This PR currently just contains the changes needed to make the `addDependencies` method not choke on aliased dependencies, but it does not solve the problem around more elegantly adding those aliases to ship's helm home.