### PR TITLE
Fix errors caused by non-kubernetes yaml files

### DIFF
--- a/integration/init/factorio/metadata.yaml
+++ b/integration/init/factorio/metadata.yaml
@@ -1,6 +1,7 @@
 upstream: "https://github.com/helm/charts/tree/ffb84f85a861e765caade879491a75a6dd3091a5/stable/factorio"
 args:
   - --upload-assets-to=http://localhost:4569/some-bucket/some-key
+  - --prefer-git
 skip_cleanup: false
 
 

--- a/integration/init/grafana-preserve-state/metadata.yaml
+++ b/integration/init/grafana-preserve-state/metadata.yaml
@@ -1,4 +1,5 @@
 upstream: "https://github.com/helm/charts/tree/353ba5ef6467fd64035b7d5446df426f86d60153/stable/grafana"
 args:
   - --preserve-state
+  - --prefer-git
 skip_cleanup: false

--- a/integration/init/grafana-with-values/metadata.yaml
+++ b/integration/init/grafana-with-values/metadata.yaml
@@ -1,6 +1,7 @@
 upstream: "https://github.com/helm/charts/tree/353ba5ef6467fd64035b7d5446df426f86d60153/stable/grafana"
 args:
   - --upload-assets-to=http://localhost:4569/some-bucket/some-key
+  - --prefer-git
 skip_cleanup: false
 valuesFile: input/values.yaml
 

--- a/integration/init/istio-1.0.3/expected/base/kustomization.yaml
+++ b/integration/init/istio-1.0.3/expected/base/kustomization.yaml
@@ -76,7 +76,6 @@ resources:
 - charts/security/templates/clusterrolebinding.yaml
 - charts/security/templates/configmap.yaml
 - charts/security/templates/deployment.yaml
-- charts/security/templates/meshexpansion.yaml
 - charts/security/templates/service.yaml
 - charts/security/templates/serviceaccount.yaml
 - charts/sidecarInjectorWebhook/templates/clusterrole.yaml

--- a/integration/init/jaeger-cassandra/metadata.yaml
+++ b/integration/init/jaeger-cassandra/metadata.yaml
@@ -1,2 +1,3 @@
 upstream: "input/ship.yaml"
+args: ["--prefer-git"]
 make_absolute: true

--- a/integration/init/non-k8s-yaml/expected/.ship/state.json
+++ b/integration/init/non-k8s-yaml/expected/.ship/state.json
@@ -1,0 +1,8 @@
+{
+  "v1": {
+    "config": {},
+    "releaseName": "ship",
+    "upstream": "https://github.com/replicatedhq/test-charts/tree/32a4d5e55d190205a7d73eb6c366df044bd19b54/non-k8s-yaml",
+    "contentSHA": "8efb7923a3a4ab712a2ea986978e074763e7240a701e916be9640ff2b70dd536"
+  }
+}

--- a/integration/init/non-k8s-yaml/expected/base/.dotfile.yml
+++ b/integration/init/non-k8s-yaml/expected/base/.dotfile.yml
@@ -1,0 +1,4 @@
+#this dotfile is valid yaml (though also nonsense)
+#but not valid kubernetes yaml
+
+ignore: "something"

--- a/integration/init/non-k8s-yaml/expected/base/ci_settings.yaml
+++ b/integration/init/non-k8s-yaml/expected/base/ci_settings.yaml
@@ -1,0 +1,5 @@
+#this is valid yaml (though also nonsense)
+#but not valid kubernetes yaml
+
+build: true
+platform_version: "2.0.1"

--- a/integration/init/non-k8s-yaml/expected/base/frontend-deployment.yaml
+++ b/integration/init/non-k8s-yaml/expected/base/frontend-deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: guestbook
+      tier: frontend
+  template:
+    metadata:
+      labels:
+        app: guestbook
+        tier: frontend
+    spec:
+      containers:
+      - env:
+        - name: GET_HOSTS_FROM
+          value: dns
+        image: gcr.io/google-samples/gb-frontend:v4
+        name: php-redis
+        ports:
+        - containerPort: 80
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi

--- a/integration/init/non-k8s-yaml/expected/base/frontend-service.yaml
+++ b/integration/init/non-k8s-yaml/expected/base/frontend-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: guestbook
+    tier: frontend
+  name: frontend
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: guestbook
+    tier: frontend
+  type: NodePort

--- a/integration/init/non-k8s-yaml/expected/base/kustomization.yaml
+++ b/integration/init/non-k8s-yaml/expected/base/kustomization.yaml
@@ -1,0 +1,5 @@
+kind: ""
+apiversion: ""
+resources:
+- frontend-deployment.yaml
+- frontend-service.yaml

--- a/integration/init/non-k8s-yaml/expected/overlays/ship/kustomization.yaml
+++ b/integration/init/non-k8s-yaml/expected/overlays/ship/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: ""
+apiversion: ""
+bases:
+- ../../base

--- a/integration/init/non-k8s-yaml/expected/rendered.yaml
+++ b/integration/init/non-k8s-yaml/expected/rendered.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: guestbook
+    tier: frontend
+  name: frontend
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: guestbook
+    tier: frontend
+  type: NodePort
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: guestbook
+      tier: frontend
+  template:
+    metadata:
+      labels:
+        app: guestbook
+        tier: frontend
+    spec:
+      containers:
+      - env:
+        - name: GET_HOSTS_FROM
+          value: dns
+        image: gcr.io/google-samples/gb-frontend:v4
+        name: php-redis
+        ports:
+        - containerPort: 80
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi

--- a/integration/init/non-k8s-yaml/metadata.yaml
+++ b/integration/init/non-k8s-yaml/metadata.yaml
@@ -1,0 +1,3 @@
+upstream: "https://github.com/replicatedhq/test-charts/tree/32a4d5e55d190205a7d73eb6c366df044bd19b54/non-k8s-yaml"
+args: ["--prefer-git"]
+skip_cleanup: false

--- a/integration/unfork/istio-k8s/expected/base/kustomization.yaml
+++ b/integration/unfork/istio-k8s/expected/base/kustomization.yaml
@@ -76,7 +76,6 @@ resources:
 - charts/security/templates/clusterrolebinding.yaml
 - charts/security/templates/configmap.yaml
 - charts/security/templates/deployment.yaml
-- charts/security/templates/meshexpansion.yaml
 - charts/security/templates/service.yaml
 - charts/security/templates/serviceaccount.yaml
 - charts/sidecarInjectorWebhook/templates/clusterrole.yaml

--- a/pkg/lifecycle/kustomize/kustomizer_test.go
+++ b/pkg/lifecycle/kustomize/kustomizer_test.go
@@ -18,6 +18,12 @@ import (
 	"sigs.k8s.io/kustomize/pkg/patch"
 )
 
+const minimalValidYaml = `
+kind: Deployment
+metadata:
+  name: myDeployment
+`
+
 func Test_kustomizer_writePatches(t *testing.T) {
 	destDir := path.Join("overlays", "ship")
 
@@ -218,7 +224,7 @@ func Test_kustomizer_writeBase(t *testing.T) {
 					for _, file := range files {
 						if err := fs.WriteFile(
 							path.Join(constants.KustomizeBasePath, file),
-							[]byte{},
+							[]byte(minimalValidYaml),
 							0777,
 						); err != nil {
 							return afero.Afero{}, err
@@ -257,7 +263,7 @@ resources:
 					for _, file := range files {
 						if err := fs.WriteFile(
 							path.Join(constants.KustomizeBasePath, file),
-							[]byte{},
+							[]byte(minimalValidYaml),
 							0777,
 						); err != nil {
 							return afero.Afero{}, err
@@ -296,7 +302,7 @@ resources:
 					for _, file := range files {
 						if err := fs.WriteFile(
 							path.Join(constants.KustomizeBasePath, file),
-							[]byte{},
+							[]byte(minimalValidYaml),
 							0777,
 						); err != nil {
 							return afero.Afero{}, err
@@ -486,7 +492,7 @@ resources:
 
 			err = mockFS.WriteFile(
 				path.Join(constants.KustomizeBasePath, "deployment.yaml"),
-				[]byte{},
+				[]byte(minimalValidYaml),
 				0666,
 			)
 			req.NoError(err)
@@ -531,45 +537,6 @@ resources:
 			}
 
 			req.NoError(err)
-		})
-	}
-}
-
-func TestKustomizer_shouldAddFile(t *testing.T) {
-	k := daemonkustomizer{}
-
-	tests := []struct {
-		name          string
-		targetPath    string
-		want          bool
-		excludedPaths []string
-	}{
-		{name: "empty", targetPath: "", want: false, excludedPaths: []string{}},
-		{name: "no extension", targetPath: "file", want: false, excludedPaths: []string{}},
-		{name: "wrong extension", targetPath: "file.txt", want: false, excludedPaths: []string{}},
-		{name: "yaml file", targetPath: "file.yaml", want: true, excludedPaths: []string{}},
-		{name: "yml file", targetPath: "file.yml", want: true, excludedPaths: []string{}},
-		{name: "kustomization yaml", targetPath: "kustomization.yaml", want: false, excludedPaths: []string{}},
-		{name: "Chart yaml", targetPath: "Chart.yaml", want: false, excludedPaths: []string{}},
-		{name: "values yaml", targetPath: "values.yaml", want: false, excludedPaths: []string{}},
-		{name: "no extension in dir", targetPath: "dir/file", want: false, excludedPaths: []string{}},
-		{name: "wrong extension in dir", targetPath: "dir/file.txt", want: false, excludedPaths: []string{}},
-		{name: "yaml in dir", targetPath: "dir/file.yaml", want: true, excludedPaths: []string{}},
-		{name: "yml in dir", targetPath: "dir/file.yml", want: true, excludedPaths: []string{}},
-		{name: "kustomization yaml in dir", targetPath: "dir/kustomization.yaml", want: false, excludedPaths: []string{}},
-		{name: "Chart yaml in dir", targetPath: "dir/Chart.yaml", want: false, excludedPaths: []string{}},
-		{name: "values yaml in dir", targetPath: "dir/values.yaml", want: false, excludedPaths: []string{}},
-		{name: "path in excluded", targetPath: "deployment.yaml", want: false, excludedPaths: []string{"/deployment.yaml"}},
-		{name: "path not in excluded", targetPath: "service.yaml", want: true, excludedPaths: []string{"/deployment.yaml"}},
-		{name: "similar path in excluded", targetPath: "dir/service.yaml", want: true, excludedPaths: []string{"/service.yaml"}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			req := require.New(t)
-
-			got := k.shouldAddFileToBase(tt.excludedPaths, tt.targetPath)
-
-			req.Equal(tt.want, got, "expected %t for path %s, got %t", tt.want, tt.targetPath, got)
 		})
 	}
 }

--- a/pkg/lifecycle/kustomize/pre_kustomize.go
+++ b/pkg/lifecycle/kustomize/pre_kustomize.go
@@ -223,7 +223,7 @@ func (l *Kustomizer) replaceOriginal(base string, built []util.PostKustomizeFile
 			return errors.Wrap(err, "failed to walk base path")
 		}
 
-		if !l.shouldAddFileToBase([]string{}, targetPath) {
+		if !l.shouldAddFileToBase(base, []string{}, targetPath) {
 			if strings.HasSuffix(targetPath, "kustomization.yaml") {
 				if err := l.FS.Remove(targetPath); err != nil {
 					return errors.Wrap(err, "remove kustomization yaml")

--- a/pkg/lifecycle/unfork/pre_unfork.go
+++ b/pkg/lifecycle/unfork/pre_unfork.go
@@ -149,7 +149,7 @@ func (l *Unforker) replaceOriginal(step api.Unfork, built []util.PostKustomizeFi
 			return errors.Wrap(err, "failed to walk base path")
 		}
 
-		if !l.shouldAddFileToBase([]string{}, targetPath) {
+		if !l.shouldAddFileToBase(step.UpstreamBase, []string{}, targetPath) {
 			if strings.HasSuffix(targetPath, "kustomization.yaml") {
 				if err := l.FS.Remove(targetPath); err != nil {
 					return errors.Wrap(err, "remove kustomization yaml")

--- a/pkg/util/kubernetes_is_k8s_yaml.go
+++ b/pkg/util/kubernetes_is_k8s_yaml.go
@@ -1,0 +1,52 @@
+package util
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/afero"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func ShouldAddFileToBase(fs *afero.Afero, excludedBases []string, targetPath string) bool {
+	if filepath.Ext(targetPath) != ".yaml" && filepath.Ext(targetPath) != ".yml" {
+		return false
+	}
+
+	for _, base := range excludedBases {
+		basePathWOLeading := strings.TrimPrefix(base, "/")
+		if basePathWOLeading == targetPath {
+			return false
+		}
+	}
+
+	if !IsK8sYaml(fs, targetPath) {
+		return false
+	}
+
+	return !strings.HasSuffix(targetPath, "kustomization.yaml") &&
+		!strings.HasSuffix(targetPath, "Chart.yaml") &&
+		!strings.HasSuffix(targetPath, "values.yaml")
+}
+
+func IsK8sYaml(fs *afero.Afero, target string) bool {
+	fileContents, err := fs.ReadFile(target)
+	if err != nil {
+		// if we cannot read a file, we assume that it is valid k8s yaml
+		return true
+	}
+
+	originalMinimal := MinimalK8sYaml{}
+	if err := yaml.Unmarshal(fileContents, &originalMinimal); err != nil {
+		// if we cannot unmarshal the file, it is not valid k8s yaml
+		return false
+	}
+
+	if originalMinimal.Kind == "" {
+		// if there is not a kind, it is not valid k8s yaml
+		return false
+	}
+
+	// k8s yaml must have a name OR be a list type
+	return originalMinimal.Metadata.Name != "" || strings.HasSuffix(originalMinimal.Kind, "List")
+}

--- a/pkg/util/kubernetes_is_k8s_yaml_test.go
+++ b/pkg/util/kubernetes_is_k8s_yaml_test.go
@@ -158,6 +158,58 @@ notkind: aList
 			target: "dir/nokind.yaml",
 			want:   false,
 		},
+		{
+			name: "multidoc yaml",
+			files: []file{
+				{
+					path: "dir/multidoc.yaml",
+					contents: `
+---
+# Source: concourse/templates/web-rolebinding.yaml
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: concourse-web-main
+  namespace: concourse-main
+  labels:
+    app: concourse-web
+    chart: concourse-3.7.2
+    heritage: Tiller
+    release: concourse
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: concourse-web
+subjects:
+- kind: ServiceAccount
+  name: concourse-web
+  namespace: default
+`,
+				},
+			},
+			target: "dir/multidoc.yaml",
+			want:   true,
+		},
+		{
+			name: "multidoc yaml, both unacceptable",
+			files: []file{
+				{
+					path: "dir/multidoc.yaml",
+					contents: `
+---
+# Source: concourse/templates/web-rolebinding.yaml
+
+---
+metadata:
+  name: concourse-web-main
+`,
+				},
+			},
+			target: "dir/multidoc.yaml",
+			want:   false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/util/kubernetes_is_k8s_yaml_test.go
+++ b/pkg/util/kubernetes_is_k8s_yaml_test.go
@@ -1,0 +1,175 @@
+package util
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldAddFileToBase(t *testing.T) {
+	type file struct {
+		contents string
+		path     string
+	}
+	tests := []struct {
+		name          string
+		targetPath    string
+		files         []file
+		want          bool
+		excludedPaths []string
+	}{
+		{name: "empty", targetPath: "", want: false, excludedPaths: []string{}},
+		{name: "no extension", targetPath: "file", want: false, excludedPaths: []string{}},
+		{name: "wrong extension", targetPath: "file.txt", want: false, excludedPaths: []string{}},
+		{name: "yaml file", targetPath: "file.yaml", want: true, excludedPaths: []string{}},
+		{name: "yml file", targetPath: "file.yml", want: true, excludedPaths: []string{}},
+		{name: "kustomization yaml", targetPath: "kustomization.yaml", want: false, excludedPaths: []string{}},
+		{name: "Chart yaml", targetPath: "Chart.yaml", want: false, excludedPaths: []string{}},
+		{name: "values yaml", targetPath: "values.yaml", want: false, excludedPaths: []string{}},
+		{name: "no extension in dir", targetPath: "dir/file", want: false, excludedPaths: []string{}},
+		{name: "wrong extension in dir", targetPath: "dir/file.txt", want: false, excludedPaths: []string{}},
+		{name: "yaml in dir", targetPath: "dir/file.yaml", want: true, excludedPaths: []string{}},
+		{name: "yml in dir", targetPath: "dir/file.yml", want: true, excludedPaths: []string{}},
+		{name: "kustomization yaml in dir", targetPath: "dir/kustomization.yaml", want: false, excludedPaths: []string{}},
+		{name: "Chart yaml in dir", targetPath: "dir/Chart.yaml", want: false, excludedPaths: []string{}},
+		{name: "values yaml in dir", targetPath: "dir/values.yaml", want: false, excludedPaths: []string{}},
+		{name: "path in excluded", targetPath: "deployment.yaml", want: false, excludedPaths: []string{"/deployment.yaml"}},
+		{name: "path not in excluded", targetPath: "service.yaml", want: true, excludedPaths: []string{"/deployment.yaml"}},
+		{name: "similar path in excluded", targetPath: "dir/service.yaml", want: true, excludedPaths: []string{"/service.yaml"}},
+		{name: "non-k8s yaml file", targetPath: "file.yaml", want: false, excludedPaths: []string{}, files: []file{{contents: "a: b", path: "file.yaml"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			fs := afero.Afero{Fs: afero.NewMemMapFs()}
+			for _, file := range tt.files {
+				req.NoError(fs.WriteFile(file.path, []byte(file.contents), os.FileMode(777)))
+			}
+
+			got := ShouldAddFileToBase(&fs, tt.excludedPaths, tt.targetPath)
+
+			req.Equal(tt.want, got, "expected %t for path %s, got %t", tt.want, tt.targetPath, got)
+		})
+	}
+}
+
+func TestIsK8sYaml(t *testing.T) {
+	type file struct {
+		contents string
+		path     string
+	}
+	tests := []struct {
+		name     string
+		basePath string
+		files    []file
+		target   string
+		want     bool
+	}{
+		{
+			name:   "file does not exist",
+			files:  []file{},
+			target: "myfile.yaml",
+			want:   true,
+		},
+		{
+			name: "invalid file",
+			files: []file{
+				{
+					path: "dir/myfile.yaml",
+					contents: `
+this is not valid k8s yaml
+`,
+				},
+			},
+			target: "dir/myfile.yaml",
+			want:   false,
+		},
+		{
+			name: "file does not exist but another does",
+			files: []file{
+				{
+					path: "notmyfile.yaml",
+					contents: `
+kind: Something
+metadata:
+  name: something
+`,
+				},
+			},
+			target: "myfile.yaml",
+			want:   true,
+		},
+		{
+			name: "valid file in subdir",
+			files: []file{
+				{
+					path: "dir/myfile.yaml",
+					contents: `
+kind: Something
+metadata:
+  name: something
+`,
+				},
+			},
+			target: "dir/myfile.yaml",
+			want:   true,
+		},
+		{
+			name: "missing name, not a list",
+			files: []file{
+				{
+					path: "dir/notlist.yaml",
+					contents: `
+kind: notalisttype
+metadata:
+  namespace: notaname
+`,
+				},
+			},
+			target: "dir/notlist.yaml",
+			want:   false,
+		},
+		{
+			name: "missing name, is a list",
+			files: []file{
+				{
+					path: "dir/islist.yaml",
+					contents: `
+kind: aList
+`,
+				},
+			},
+			target: "dir/islist.yaml",
+			want:   true,
+		},
+		{
+			name: "missing kind",
+			files: []file{
+				{
+					path: "dir/nokind.yaml",
+					contents: `
+notkind: aList
+`,
+				},
+			},
+			target: "dir/nokind.yaml",
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			fs := afero.Afero{Fs: afero.NewMemMapFs()}
+			for _, file := range tt.files {
+				req.NoError(fs.WriteFile(file.path, []byte(file.contents), os.FileMode(777)))
+			}
+
+			got := IsK8sYaml(&fs, tt.target)
+			req.Equal(tt.want, got, "IsK8sYaml() = %v, want %v for file %s", got, tt.want, tt.target)
+		})
+	}
+}


### PR DESCRIPTION
What I Did
------------
Before including a file in kustomization.yaml, check to make sure it contains the minimum values needed - `kind` and (if the `kind` is not `*List`) `metadata.name`. This fixes #828.

How I Did it
------------
Read each file being considered, parse each doc in that file, if one of them meets requirements (or there is an error reading the file) include the file in the kustomization yaml.

Both `init` and `unfork` now rely upon the same logic to determine whether a file should be included within kustomization.yaml.

How to verify it
------------
An integration test containing two non-kubernetes yaml files has been added. Alternatively, run `ship init --prefer-git https://github.com/VirtusLab/jenkins-operator` as in #828.

Description for the Changelog
------------
non-kubernetes yaml files are no longer mistakenly included in autogenerated kustomize bases.


Picture of a Boat (not required but encouraged)
------------

![USS Sarsfield (DD-837)](https://upload.wikimedia.org/wikipedia/commons/c/c2/USS_Sarsfield_%28DD-837%29_off_Boston_1945.jpg "USS Sarsfield (DD-837)")










<!-- (thanks https://github.com/docker/docker for this template) -->

