### PR TITLE
Prevent assets from writing files outside of the dir ship is run in

### DIFF
--- a/pkg/lifecycle/render/docker/step.go
+++ b/pkg/lifecycle/render/docker/step.go
@@ -14,6 +14,8 @@ import (
 	"github.com/replicatedhq/ship/pkg/images"
 	"github.com/replicatedhq/ship/pkg/lifecycle/render/root"
 	"github.com/replicatedhq/ship/pkg/templates"
+	"github.com/replicatedhq/ship/pkg/util"
+
 	"github.com/spf13/viper"
 )
 
@@ -96,6 +98,11 @@ func (p *DefaultStep) Execute(
 		}
 		destIsDockerURL := destinationURL.Scheme == "docker"
 		if !destIsDockerURL {
+			err = util.IsLegalPath(dest)
+			if err != nil {
+				return errors.Wrap(err, "find docker image dest")
+			}
+
 			basePath := filepath.Dir(dest)
 			debug.Log("event", "mkdirall.attempt", "dest", dest, "basePath", basePath)
 			if err := rootFs.MkdirAll(basePath, 0755); err != nil {

--- a/pkg/lifecycle/render/dockerlayer/layer.go
+++ b/pkg/lifecycle/render/dockerlayer/layer.go
@@ -70,7 +70,7 @@ func (u *Unpacker) Execute(
 
 		err = util.IsLegalPath(basePath)
 		if err != nil {
-			return errors.Wrap(err, "write github asset")
+			return errors.Wrap(err, "write docker layer")
 		}
 
 		debug.Log(

--- a/pkg/lifecycle/render/dockerlayer/layer.go
+++ b/pkg/lifecycle/render/dockerlayer/layer.go
@@ -12,6 +12,8 @@ import (
 	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/lifecycle/render/docker"
 	"github.com/replicatedhq/ship/pkg/lifecycle/render/root"
+	"github.com/replicatedhq/ship/pkg/util"
+
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
 )
@@ -64,6 +66,11 @@ func (u *Unpacker) Execute(
 		defer rootFs.RemoveAll("tmp")
 		if err != nil {
 			return errors.Wrap(err, "resolve unpack paths")
+		}
+
+		err = util.IsLegalPath(basePath)
+		if err != nil {
+			return errors.Wrap(err, "write github asset")
 		}
 
 		debug.Log(

--- a/pkg/lifecycle/render/github/render.go
+++ b/pkg/lifecycle/render/github/render.go
@@ -21,6 +21,7 @@ import (
 	"github.com/replicatedhq/ship/pkg/specs/gogetter"
 	"github.com/replicatedhq/ship/pkg/state"
 	"github.com/replicatedhq/ship/pkg/templates"
+	"github.com/replicatedhq/ship/pkg/util"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
@@ -251,10 +252,6 @@ func getDestPath(githubPath string, asset api.GitHubAsset, builder *templates.Bu
 		return "", errors.Wrapf(err, "get destination directory from %q", asset.Dest)
 	}
 
-	if filepath.IsAbs(destDir) {
-		return "", fmt.Errorf("cannot write to an absolute path: %s", destDir)
-	}
-
 	if stripPath {
 		// remove asset.Path's directory from the beginning of githubPath
 		sourcePathDir := filepath.ToSlash(filepath.Dir(asset.Path)) + "/"
@@ -269,13 +266,9 @@ func getDestPath(githubPath string, asset api.GitHubAsset, builder *templates.Bu
 
 	combinedPath := filepath.Join(destDir, githubPath)
 
-	relPath, err := filepath.Rel(".", combinedPath)
+	err = util.IsLegalPath(combinedPath)
 	if err != nil {
-		return "", errors.Wrap(err, "find relative path to dest")
-	}
-
-	if strings.Contains(relPath, "..") {
-		return "", fmt.Errorf("cannot write to a path that is a parent of the working dir: %s", relPath)
+		return "", errors.Wrap(err, "write github asset")
 	}
 
 	return combinedPath, nil

--- a/pkg/lifecycle/render/github/render_test.go
+++ b/pkg/lifecycle/render/github/render_test.go
@@ -206,6 +206,36 @@ func Test_getDestPath(t *testing.T) {
 			want:    "",
 			wantErr: true,
 		},
+		{
+			name: "file in root",
+			args: args{
+				githubPath: "subdir/README.md",
+				asset: api.GitHubAsset{
+					Path:      "",
+					StripPath: "",
+					AssetShared: api.AssetShared{
+						Dest: "/bin/runc",
+					},
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "file in parent dir",
+			args: args{
+				githubPath: "subdir/README.md",
+				asset: api.GitHubAsset{
+					Path:      "abc/",
+					StripPath: "",
+					AssetShared: api.AssetShared{
+						Dest: "../../../bin/runc",
+					},
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/lifecycle/render/helm/template.go
+++ b/pkg/lifecycle/render/helm/template.go
@@ -324,6 +324,11 @@ func (f *LocalTemplater) cleanUpAndOutputRenderedFiles(
 	tempRenderedChartTemplatesDir := path.Join(tempRenderedChartDir, "templates")
 	tempRenderedSubChartsDir := path.Join(tempRenderedChartDir, subChartsDirName)
 
+	err := util.IsLegalPath(asset.Dest)
+	if err != nil {
+		return errors.Wrap(err, "write helm asset")
+	}
+
 	if f.Viper.GetBool("rm-asset-dest") {
 		debug.Log("event", "baseDir.rm", "path", asset.Dest)
 		if err := f.FS.RemoveAll(asset.Dest); err != nil {

--- a/pkg/lifecycle/render/local/render.go
+++ b/pkg/lifecycle/render/local/render.go
@@ -9,6 +9,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/libyaml"
 	"github.com/replicatedhq/ship/pkg/api"
+	"github.com/replicatedhq/ship/pkg/util"
+
 	"github.com/spf13/afero"
 )
 
@@ -46,6 +48,16 @@ func (r *LocalRenderer) Execute(
 ) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
 		debug := level.Debug(log.With(r.Logger, "step.type", "render", "render.phase", "execute", "asset.type", "local"))
+
+		err := util.IsLegalPath(asset.Dest)
+		if err != nil {
+			return errors.Wrap(err, "local asset dest")
+		}
+
+		err = util.IsLegalPath(asset.Path)
+		if err != nil {
+			return errors.Wrap(err, "local asset path")
+		}
 
 		if err := r.Fs.MkdirAll(filepath.Dir(asset.Dest), 0777); err != nil {
 			return errors.Wrapf(err, "mkdir %s", asset.Dest)

--- a/pkg/lifecycle/render/web/step.go
+++ b/pkg/lifecycle/render/web/step.go
@@ -14,6 +14,8 @@ import (
 	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/lifecycle/render/root"
 	"github.com/replicatedhq/ship/pkg/templates"
+	"github.com/replicatedhq/ship/pkg/util"
+
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
 )
@@ -80,6 +82,11 @@ func (p *DefaultStep) Execute(
 		if err != nil {
 			debug.Log("event", "build.fail", "err", err)
 			return errors.Wrapf(err, "Build web asset")
+		}
+
+		err = util.IsLegalPath(built.Dest)
+		if err != nil {
+			return errors.Wrap(err, "write web asset")
 		}
 
 		basePath := filepath.Dir(asset.Dest)

--- a/pkg/lifecycle/render/web/step_test.go
+++ b/pkg/lifecycle/render/web/step_test.go
@@ -200,6 +200,36 @@ func TestWebStep(t *testing.T) {
 			ExpectFiles: map[string]interface{}{},
 			ExpectedErr: errors.New("Get web asset from http://foo.bar: received response with status 500"),
 		},
+		{
+			Name: "illegal dest path",
+			Asset: api.WebAsset{
+				AssetShared: api.AssetShared{
+					Dest: "/bin/runc",
+				},
+				URL: "http://foo.bar",
+			},
+			RegisterResponders: func() {
+				httpmock.RegisterResponder("GET", "http://foo.bar",
+					httpmock.NewStringResponder(200, "hi from foo.bar"))
+			},
+			ExpectFiles: map[string]interface{}{},
+			ExpectedErr: errors.Wrap(errors.New("cannot write to an absolute path: /bin/runc"), "write web asset"),
+		},
+		{
+			Name: "illegal dest path",
+			Asset: api.WebAsset{
+				AssetShared: api.AssetShared{
+					Dest: "../../../bin/runc",
+				},
+				URL: "http://foo.bar",
+			},
+			RegisterResponders: func() {
+				httpmock.RegisterResponder("GET", "http://foo.bar",
+					httpmock.NewStringResponder(200, "hi from foo.bar"))
+			},
+			ExpectFiles: map[string]interface{}{},
+			ExpectedErr: errors.Wrap(errors.New("cannot write to a path that is a parent of the working dir: ../../../bin/runc"), "write web asset"),
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/util/legal_path.go
+++ b/pkg/util/legal_path.go
@@ -2,16 +2,28 @@ package util
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
 )
 
-// IsLegalPath checks if the provided path is a relative path within the current working directory. If it is not, it returns an error.
+// IsLegalPath checks if the provided path is a relative path within the current working directory or within the os tempdir.
+// If it is not, it returns an error.
 func IsLegalPath(path string) error {
 
 	if filepath.IsAbs(path) {
+		relAbsPath, err := filepath.Rel(os.TempDir(), path)
+		if err != nil {
+			return fmt.Errorf("cannot write to an absolute path: %s, got error finding relative path from tempdir: %s", path, err.Error())
+		}
+
+		// subdirectories of the os tempdir are fine
+		if !strings.Contains(relAbsPath, "..") {
+			return nil
+		}
+
 		return fmt.Errorf("cannot write to an absolute path: %s", path)
 	}
 

--- a/pkg/util/legal_path.go
+++ b/pkg/util/legal_path.go
@@ -1,0 +1,28 @@
+package util
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// IsLegalPath checks if the provided path is a relative path within the current working directory. If it is not, it returns an error.
+func IsLegalPath(path string) error {
+
+	if filepath.IsAbs(path) {
+		return fmt.Errorf("cannot write to an absolute path: %s", path)
+	}
+
+	relPath, err := filepath.Rel(".", path)
+	if err != nil {
+		return errors.Wrap(err, "find relative path to dest")
+	}
+
+	if strings.Contains(relPath, "..") {
+		return fmt.Errorf("cannot write to a path that is a parent of the working dir: %s", relPath)
+	}
+
+	return nil
+}

--- a/pkg/util/legal_path_test.go
+++ b/pkg/util/legal_path_test.go
@@ -1,0 +1,39 @@
+package util
+
+import "testing"
+
+func TestIsLegalPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{
+			name:    "relative path",
+			path:    "./happy/path",
+			wantErr: false,
+		},
+		{
+			name:    "absolute path",
+			path:    "/unhappy/path",
+			wantErr: true,
+		},
+		{
+			name:    "relative parent path",
+			path:    "../../unhappy/path",
+			wantErr: true,
+		},
+		{
+			name:    "embedded relative parent path",
+			path:    "./happy/../../../unhappy/path",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := IsLegalPath(tt.path); (err != nil) != tt.wantErr {
+				t.Errorf("IsLegalPath() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/util/legal_path_test.go
+++ b/pkg/util/legal_path_test.go
@@ -1,6 +1,10 @@
 package util
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestIsLegalPath(t *testing.T) {
 	tests := []struct {
@@ -27,6 +31,11 @@ func TestIsLegalPath(t *testing.T) {
 			name:    "embedded relative parent path",
 			path:    "./happy/../../../unhappy/path",
 			wantErr: true,
+		},
+		{
+			name:    "absolute path to tempdir",
+			path:    filepath.Join(os.TempDir(), "mydir"),
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
What I Did
------------
Fixes #841 

How I Did it
------------
Asset types check whether a destination is legal (relative paths within the working directory OR the system temp directory) before writing.

How to verify it
------------
Unit tests of the checker function, or attempt to run a ship yaml that has an asset with a dest of `hello/../../../world` or `/bin/runc`.


Description for the Changelog
------------
Ship assets can no longer refer to destinations outside of the working directory. 


Picture of a Boat (not required but encouraged)
------------

![USS Fiske (DD-842)](https://upload.wikimedia.org/wikipedia/commons/thumb/b/b9/USS_Fiske_%28DD-842%29_underway_in_the_Narragansett_Bay_on_18_October_1971_%28NH_102964%29.jpg/1280px-USS_Fiske_%28DD-842%29_underway_in_the_Narragansett_Bay_on_18_October_1971_%28NH_102964%29.jpg "USS Fiske (DD-842)")










<!-- (thanks https://github.com/docker/docker for this template) -->

