### PR TITLE
support additional replicated.app upstream formats

### DIFF
--- a/pkg/specs/replicatedapp/resolver.go
+++ b/pkg/specs/replicatedapp/resolver.go
@@ -169,7 +169,7 @@ func (r *resolver) resolveCloudRelease(selector *Selector) (*ShipRelease, error)
 	if err != nil {
 		if selector.InstallationID == "" {
 			debug.Log("event", "spec-resolve", "from", selector, "error", err)
-			fmt.Printf("Please enter a license id to continue: ")
+			fmt.Printf("Please enter your license to continue: ")
 			var input string
 			fmt.Scanln(&input)
 			selector.InstallationID = input

--- a/pkg/specs/replicatedapp/selector.go
+++ b/pkg/specs/replicatedapp/selector.go
@@ -2,6 +2,7 @@ package replicatedapp
 
 import (
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/google/go-querystring/query"
@@ -30,6 +31,8 @@ func (s *Selector) String() string {
 	return v.Encode()
 }
 
+var pathQuery = regexp.MustCompile(`replicated\.app/([\w_\-/]+)`)
+
 // this is less janky
 func (s *Selector) UnmarshalFrom(url *url.URL) *Selector {
 	for key, values := range url.Query() {
@@ -45,6 +48,13 @@ func (s *Selector) UnmarshalFrom(url *url.URL) *Selector {
 			s.ReleaseID = values[0]
 		case "release_semver":
 			s.ReleaseSemver = values[0]
+		}
+	}
+
+	if s.CustomerID == "" && pathQuery.MatchString(url.Path) {
+		matches := pathQuery.FindStringSubmatch(url.Path)
+		if len(matches) == 2 {
+			s.CustomerID = matches[1]
 		}
 	}
 

--- a/pkg/specs/replicatedapp/selector_test.go
+++ b/pkg/specs/replicatedapp/selector_test.go
@@ -34,6 +34,36 @@ func TestUnmarshalSelector(t *testing.T) {
 				Upstream:       "https://pg.staging.replicated.com/graphql",
 			},
 		},
+		{
+			name: "pathed app with customer id",
+			url:  "replicated.app/app_id_here?customer_id=123&installation_id=456&release_id=789&release_semver=7.8.9",
+			want: &Selector{
+				CustomerID:     "123",
+				InstallationID: "456",
+				ReleaseID:      "789",
+				ReleaseSemver:  "7.8.9",
+			},
+		},
+		{
+			name: "pathed app WITHOUT customer id",
+			url:  "replicated.app/app_id_here?installation_id=456&release_id=789&release_semver=7.8.9",
+			want: &Selector{
+				CustomerID:     "app_id_here",
+				InstallationID: "456",
+				ReleaseID:      "789",
+				ReleaseSemver:  "7.8.9",
+			},
+		},
+		{
+			name: "pathed app WITHOUT customer id and including forward slash in id",
+			url:  "replicated.app/app/id/here?installation_id=456&release_id=789&release_semver=7.8.9",
+			want: &Selector{
+				CustomerID:     "app/id/here",
+				InstallationID: "456",
+				ReleaseID:      "789",
+				ReleaseSemver:  "7.8.9",
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
What I Did
------------
Support `replicated.app/app_name_here` formats. If a license ID is required, ship will prompt for it on the command line.

How I Did it
------------
1. The path after `replicated.app/` is now used for customer_id if not provided.
2. If after querying the API an app is not found, ship will prompt for a license ID and try again.
3. After prompting for a license ID, the upstream URL within the ship state is modified to include the new license ID.

How to verify it
------------
`ship init replicated.app/myappname` and follow the prompts

Description for the Changelog
------------
Additional ship app upstream formats are supported.


Picture of a Boat (not required but encouraged)
------------


![USS Ozbourn (DD-846)](https://upload.wikimedia.org/wikipedia/commons/c/c6/USS_Ozbourn_%28DD-846%29_with_USS_Kitty_Hawk_%28CVA-63%29_in_1963.jpg "USS Ozbourn (DD-846)")









<!-- (thanks https://github.com/docker/docker for this template) -->

