### PR TITLE
use the app slug graphql query for 'replicated.app/slug' upstreams

### DIFF
--- a/integration/init_app/basic-slug/expected/.ship/release.yml
+++ b/integration/init_app/basic-slug/expected/.ship/release.yml
@@ -1,0 +1,31 @@
+---
+assets:
+  v1:
+    - inline:
+        contents: |
+          #!/bin/bash
+          echo "installing nothing"
+          echo "config option: {{repl ConfigOption "test_option" }}"
+        dest: ./scripts/install.sh
+        mode: 0777
+    - inline:
+        contents: |
+          #!/bin/bash
+          echo "tested nothing"
+          echo "customer {{repl Installation "customer_id" }}"
+          echo "install {{repl Installation "installation_id" }}"
+        dest: ./scripts/test.sh
+        mode: 0777
+config:
+  v1:
+    - name: test_options
+      title: Test Options
+      description: testing testing 123
+      items:
+      - name: test_option
+        title: Test Option
+        default: abc123_test-option-value
+        type: text
+lifecycle:
+  v1:
+    - render: {}

--- a/integration/init_app/basic-slug/expected/.ship/state.json
+++ b/integration/init_app/basic-slug/expected/.ship/state.json
@@ -1,0 +1,15 @@
+{
+  "v1": {
+    "config": {},
+    "upstream": "__upstream__",
+    "contentSHA": "051f545274f45b1fe98e7ffc29052ae775f23b432dd044ab456662acae6664e9",
+    "metadata": {
+      "applicationType": "replicated.app",
+      "appSlug": "__appSlug__",
+      "licenseID": "__licenseID__",
+      "releaseNotes": "",
+      "version": "1.0.2"
+    },
+    "releaseName": "nightly"
+  }
+}

--- a/integration/init_app/basic-slug/expected/installer/scripts/install.sh
+++ b/integration/init_app/basic-slug/expected/installer/scripts/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "installing nothing"
+echo "config option: abc123_test-option-value"

--- a/integration/init_app/basic-slug/expected/installer/scripts/test.sh
+++ b/integration/init_app/basic-slug/expected/installer/scripts/test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo "tested nothing"
+echo "customer "
+echo "install "

--- a/integration/init_app/basic-slug/input/.ship/release.yml
+++ b/integration/init_app/basic-slug/input/.ship/release.yml
@@ -1,0 +1,31 @@
+---
+assets:
+  v1:
+    - inline:
+        contents: |
+          #!/bin/bash
+          echo "installing nothing"
+          echo "config option: {{repl ConfigOption "test_option" }}"
+        dest: ./scripts/install.sh
+        mode: 0777
+    - inline:
+        contents: |
+          #!/bin/bash
+          echo "tested nothing"
+          echo "customer {{repl Installation "customer_id" }}"
+          echo "install {{repl Installation "installation_id" }}"
+        dest: ./scripts/test.sh
+        mode: 0777
+config:
+  v1:
+    - name: test_options
+      title: Test Options
+      description: testing testing 123
+      items:
+      - name: test_option
+        title: Test Option
+        default: abc123_test-option-value
+        type: text
+lifecycle:
+  v1:
+    - render: {}

--- a/integration/init_app/basic-slug/metadata.yaml
+++ b/integration/init_app/basic-slug/metadata.yaml
@@ -1,0 +1,4 @@
+app_slug: "laverya-ship"
+license_id: "oAD8r_OGQcgCDGsTQr99IFqo1q2Gx8R5"
+release_version: "1.0.2"
+skip_cleanup: false

--- a/pkg/api/spec.go
+++ b/pkg/api/spec.go
@@ -77,6 +77,8 @@ type ReleaseMetadata struct {
 	CustomerID      string          `json:"customerId" yaml:"customerId" hcl:"customerId" meta:"customer-id"`
 	InstallationID  string          `json:"installation" yaml:"installation" hcl:"installation" meta:"installation-id"`
 	ChannelID       string          `json:"channelId" yaml:"channelId" hcl:"channelId" meta:"channel-id"`
+	AppSlug         string          `json:"appSlug" yaml:"appSlug" hcl:"appSlug" meta:"app-slug"`
+	LicenseID       string          `json:"licenseId" yaml:"licenseId" hcl:"licenseId" meta:"license-id"`
 	ChannelName     string          `json:"channelName" yaml:"channelName" hcl:"channelName" meta:"channel-name"`
 	ChannelIcon     string          `json:"channelIcon" yaml:"channelIcon" hcl:"channelIcon" meta:"channel-icon"`
 	Semver          string          `json:"semver" yaml:"semver" hcl:"semver" meta:"release-version"`

--- a/pkg/specs/interface_test.go
+++ b/pkg/specs/interface_test.go
@@ -341,6 +341,7 @@ func TestResolver_ReadContentSHAForWatch(t *testing.T) {
 				mockAppResolver.EXPECT().FetchRelease(ctx, &replicatedapp2.Selector{
 					CustomerID:     "foo",
 					InstallationID: "bar",
+					AppSlug:        "",
 				}).Return(&replicatedapp2.ShipRelease{Spec: "its fake"}, nil)
 			},
 			expectSHA: "a9274e43955abe372d508864d19aa8be39872a39f44c8c5e2e04a4ef98c4aa04", // sha256.Sum256([]byte("its fake"))

--- a/pkg/specs/replicatedapp/resolver_test.go
+++ b/pkg/specs/replicatedapp/resolver_test.go
@@ -136,6 +136,15 @@ func Test_resolver_updateUpstream(t *testing.T) {
 			},
 			expectUpstream: "staging.replicated.app/?customer_id=abc&installation_id=xyz",
 		},
+		{
+			name:         "slug app",
+			initUpstream: "replicated.app/abc",
+			selector: Selector{
+				AppSlug:   "abc",
+				LicenseID: "xyz",
+			},
+			expectUpstream: "replicated.app/abc/?license_id=xyz",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/specs/replicatedapp/selector_test.go
+++ b/pkg/specs/replicatedapp/selector_test.go
@@ -39,6 +39,7 @@ func TestUnmarshalSelector(t *testing.T) {
 			url:  "replicated.app/app_id_here?customer_id=123&installation_id=456&release_id=789&release_semver=7.8.9",
 			want: &Selector{
 				CustomerID:     "123",
+				AppSlug:        "",
 				InstallationID: "456",
 				ReleaseID:      "789",
 				ReleaseSemver:  "7.8.9",
@@ -48,20 +49,28 @@ func TestUnmarshalSelector(t *testing.T) {
 			name: "pathed app WITHOUT customer id",
 			url:  "replicated.app/app_id_here?installation_id=456&release_id=789&release_semver=7.8.9",
 			want: &Selector{
-				CustomerID:     "app_id_here",
+				AppSlug:        "app_id_here",
 				InstallationID: "456",
 				ReleaseID:      "789",
 				ReleaseSemver:  "7.8.9",
 			},
 		},
 		{
-			name: "pathed app WITHOUT customer id and including forward slash in id",
-			url:  "replicated.app/app/id/here?installation_id=456&release_id=789&release_semver=7.8.9",
+			name: "app slug with license id and release number",
+			url:  "replicated.app/app/id/here?license_id=456&release_id=789",
 			want: &Selector{
-				CustomerID:     "app/id/here",
-				InstallationID: "456",
-				ReleaseID:      "789",
-				ReleaseSemver:  "7.8.9",
+				AppSlug:   "app/id/here",
+				LicenseID: "456",
+				ReleaseID: "789",
+			},
+		},
+		{
+			name: "app slug with license id and release number",
+			url:  "replicated.app/app/id/here/?license_id=456&release_id=789",
+			want: &Selector{
+				AppSlug:   "app/id/here",
+				LicenseID: "456",
+				ReleaseID: "789",
 			},
 		},
 	}

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -110,6 +110,8 @@ func (m *MManager) SerializeAppMetadata(metadata api.ReleaseMetadata) error {
 		Version:         metadata.Semver,
 		CustomerID:      metadata.CustomerID,
 		InstallationID:  metadata.InstallationID,
+		LicenseID:       metadata.LicenseID,
+		AppSlug:         metadata.AppSlug,
 	}
 
 	return m.serializeAndWriteState(versionedState)

--- a/pkg/state/models.go
+++ b/pkg/state/models.go
@@ -98,6 +98,8 @@ type Metadata struct {
 	Version         string      `json:"version" yaml:"version" hcl:"version"`
 	CustomerID      string      `json:"customerID,omitempty" yaml:"customerID,omitempty" hcl:"customerID,omitempty"`
 	InstallationID  string      `json:"installationID,omitempty" yaml:"installationID,omitempty" hcl:"installationID,omitempty"`
+	LicenseID       string      `json:"licenseID,omitempty" yaml:"licenseID,omitempty" hcl:"licenseID,omitempty"`
+	AppSlug         string      `json:"appSlug,omitempty" yaml:"appSlug,omitempty" hcl:"appSlug,omitempty"`
 	Lists           []util.List `json:"lists,omitempty" yaml:"lists,omitempty" hcl:"lists,omitempty"`
 }
 


### PR DESCRIPTION
What I Did
------------
`replicated.app/app-slug/?license_id=ID` upstreams now use a new graphql query.

How I Did it
------------
A new code path has been added to use a different query if an app slug is provided and a channel ID is not.

How to verify it
------------
Look at the new init_app integration test, and at the code in `pkg/specs/replicatedapp/graphql.go`.

Description for the Changelog
------------
`replicated.app/app-slug/?license_id=ID` upstreams are supported.


Picture of a ~Boat~Ship (not required but encouraged)
------------


![USS Richard E. Kraus (DD-849)](https://upload.wikimedia.org/wikipedia/commons/e/e4/USS_Richard_E._Kraus_%28DD-849%29_underway_at_sea%2C_circa_in_1954.jpg "USS Richard E. Kraus (DD-849)")









<!-- (thanks https://github.com/docker/docker for this template) -->

