### PR TITLE
continue upgrading terraform from 0.11.10 to 0.11.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,10 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
   apt-get install -y nodejs
 
-ENV TERRAFORM_VERSION=0.11.10
+ENV TERRAFORM_VERSION=0.11.13
 ENV TERRAFORM_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
 ENV TERRAFORM_ZIP="terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
-ENV TERRAFORM_SHA256SUM=43543a0e56e31b0952ea3623521917e060f2718ab06fe2b2d506cfaa14d54527
+ENV TERRAFORM_SHA256SUM=5925cd4d81e7d8f42a0054df2aafd66e2ab7408dbed2bd748f0022cfe592f8d2
 
 RUN curl -fsSLO "$TERRAFORM_URL" \
 	&& echo "${TERRAFORM_SHA256SUM}  ${TERRAFORM_ZIP}" | sha256sum -c - \

--- a/hack/get_run_deps.sh
+++ b/hack/get_run_deps.sh
@@ -4,10 +4,10 @@
 # used in circle
 set -ex
 
-TERRAFORM_VERSION=0.11.10
+TERRAFORM_VERSION=0.11.13
 TERRAFORM_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
 TERRAFORM_ZIP="terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
-TERRAFORM_SHA256SUM=43543a0e56e31b0952ea3623521917e060f2718ab06fe2b2d506cfaa14d54527
+TERRAFORM_SHA256SUM=5925cd4d81e7d8f42a0054df2aafd66e2ab7408dbed2bd748f0022cfe592f8d2
 
 KUBECTL_VERSION=v1.11.1
 KUBECTL_URL=https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl

--- a/integration/base/terraform/expected/.ship/state.json
+++ b/integration/base/terraform/expected/.ship/state.json
@@ -4,10 +4,10 @@
       "id_length": "1"
     },
     "terraform": {
-      "rawState": "{\n    \"version\": 3,\n    \"terraform_version\": \"0.11.10\",\n    \"serial\": 5,\n    \"lineage\": \"9c4547a4-c042-5ef9-01de-12509401b810\",\n    \"modules\": [\n        {\n            \"path\": [\n                \"root\"\n            ],\n            \"outputs\": {},\n            \"resources\": {\n                \"local_file.foo\": {\n                    \"type\": \"local_file\",\n                    \"depends_on\": [],\n                    \"primary\": {\n                        \"id\": \"356a192b7913b04c54574d18c28d46e6395428ab\",\n                        \"attributes\": {\n                            \"content\": \"1\",\n                            \"filename\": \"/tmp/foo.bar\",\n                            \"id\": \"356a192b7913b04c54574d18c28d46e6395428ab\"\n                        },\n                        \"meta\": {},\n                        \"tainted\": false\n                    },\n                    \"deposed\": [],\n                    \"provider\": \"provider.local\"\n                }\n            },\n            \"depends_on\": []\n        }\n    ]\n}\n",
+      "rawState": "{\n    \"version\": 3,\n    \"terraform_version\": \"0.11.13\",\n    \"serial\": 5,\n    \"lineage\": \"9c4547a4-c042-5ef9-01de-12509401b810\",\n    \"modules\": [\n        {\n            \"path\": [\n                \"root\"\n            ],\n            \"outputs\": {},\n            \"resources\": {\n                \"local_file.foo\": {\n                    \"type\": \"local_file\",\n                    \"depends_on\": [],\n                    \"primary\": {\n                        \"id\": \"356a192b7913b04c54574d18c28d46e6395428ab\",\n                        \"attributes\": {\n                            \"content\": \"1\",\n                            \"filename\": \"/tmp/foo.bar\",\n                            \"id\": \"356a192b7913b04c54574d18c28d46e6395428ab\"\n                        },\n                        \"meta\": {},\n                        \"tainted\": false\n                    },\n                    \"deposed\": [],\n                    \"provider\": \"provider.local\"\n                }\n            },\n            \"depends_on\": []\n        }\n    ]\n}\n",
       "state": {
         "version": 3,
-        "terraform_version": "0.11.10",
+        "terraform_version": "0.11.13",
         "serial": 5,
         "lineage": "9c4547a4-c042-5ef9-01de-12509401b810",
         "modules": [

--- a/integration/base/terraform/expected/installer/terraform/terraform.tfstate
+++ b/integration/base/terraform/expected/installer/terraform/terraform.tfstate
@@ -1,6 +1,6 @@
 {
     "version": 3,
-    "terraform_version": "0.11.10",
+    "terraform_version": "0.11.13",
     "serial": 5,
     "lineage": "9c4547a4-c042-5ef9-01de-12509401b810",
     "modules": [

--- a/integration/base/terraform/metadata.yaml
+++ b/integration/base/terraform/metadata.yaml
@@ -2,5 +2,5 @@ customer_id: "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G"
 installation_id: "lZk73HnLmatQ-s1nk7l3Q3QKA45orDFi"
 release_version: "0.0.5"
 set_channel_name: "terraform"
-skip_cleanup: true
+skip_cleanup: false
 disable_online: true


### PR DESCRIPTION
What I Did
------------
Updated the version of terraform installed by our dependency resolution scripts. I've searched for `0.11.10` now, so this should be the last of these PRs. See #860, #861, #862 

How I Did it
------------


How to verify it
------------
Terraform updated from v0.11.10 to v0.11.13

Description for the Changelog
------------

![USS Steinaker (DD-863)](https://upload.wikimedia.org/wikipedia/commons/c/c8/USS_Steinaker_%28DD-863%29_in_the_North_Atlantic_1951.jpg "USS Steinaker (DD-863)")

Picture of a Ship (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

