### PR TITLE
clean paths before comparison

### DIFF
--- a/pkg/patch/patcher.go
+++ b/pkg/patch/patcher.go
@@ -244,7 +244,7 @@ func (p *ShipPatcher) writeTempKustomization(step api.Kustomize, resource string
 
 	if len(tempBaseKustomization.Resources) == 0 {
 		level.Error(p.Logger).Log("event", "unable to find", "resource", resource)
-		return fmt.Errorf("temp base directory is empty - base resource not found in %s", step.Base)
+		return fmt.Errorf("temp base directory is empty - base resource %s not found in %s", resource, step.Base)
 	}
 
 	marshalled, err := yaml.Marshal(tempBaseKustomization)

--- a/pkg/patch/patcher.go
+++ b/pkg/patch/patcher.go
@@ -2,6 +2,7 @@ package patch
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -232,7 +233,7 @@ func (p *ShipPatcher) writeTempKustomization(step api.Kustomize, resource string
 				return errors.Wrap(err, "failed to get relative path")
 			}
 
-			if targetPath == resource {
+			if filepath.Clean(targetPath) == filepath.Clean(resource) {
 				tempBaseKustomization.Resources = append(tempBaseKustomization.Resources, relativePath)
 			}
 			return nil
@@ -243,7 +244,7 @@ func (p *ShipPatcher) writeTempKustomization(step api.Kustomize, resource string
 
 	if len(tempBaseKustomization.Resources) == 0 {
 		level.Error(p.Logger).Log("event", "unable to find", "resource", resource)
-		return errors.New("Temp base directory is empty - base resource not found")
+		return fmt.Errorf("temp base directory is empty - base resource not found in %s", step.Base)
 	}
 
 	marshalled, err := yaml.Marshal(tempBaseKustomization)


### PR DESCRIPTION
What I Did
------------
Fixes #831 by cleaning the paths to the patches before comparing them.

How I Did it
------------

We didn’t handle comparing `./path/to/resource.yaml` with `path/to/resource.yaml` as part of the k8s patch comparison process. Now we run `filepath.Clean` on those paths before the comparison.

How to verify it
------------


Description for the Changelog
------------
Fixed an issue that could prevent kustomize patches from being saved.


Picture of a Ship (not required but encouraged)
------------




![USS Stribling (DD-867)](https://upload.wikimedia.org/wikipedia/commons/c/c2/USS_Stribling_%28DD-867%29_in_1945.jpg "USS Stribling (DD-867)")







<!-- (thanks https://github.com/docker/docker for this template) -->

