### PR TITLE
add template functions for app slug and license ID

### DIFF
--- a/pkg/templates/installation_context.go
+++ b/pkg/templates/installation_context.go
@@ -52,6 +52,10 @@ func (ctx *InstallationContext) FuncMap() template.FuncMap {
 				return ctx.Meta.InstallationID
 			case "release_notes":
 				return ctx.Meta.ReleaseNotes
+			case "app_slug":
+				return ctx.Meta.AppSlug
+			case "license_id":
+				return ctx.Meta.LicenseID
 			}
 			return ""
 		},

--- a/pkg/templates/installation_context_test.go
+++ b/pkg/templates/installation_context_test.go
@@ -114,6 +114,22 @@ func testCases() []TestInstallation {
 			Expected: `It's xyz`,
 		},
 		{
+			Name: "license_id",
+			Meta: api.ReleaseMetadata{
+				LicenseID: "myLicenseID",
+			},
+			Tpl:      `It's {{repl Installation "license_id" }}`,
+			Expected: `It's myLicenseID`,
+		},
+		{
+			Name: "app_slug",
+			Meta: api.ReleaseMetadata{
+				AppSlug: "my_app_slug",
+			},
+			Tpl:      `It's {{repl Installation "app_slug" }}`,
+			Expected: `It's my_app_slug`,
+		},
+		{
 			Name: "entitlement value",
 			Meta: api.ReleaseMetadata{
 				Entitlements: api.Entitlements{


### PR DESCRIPTION
What I Did
------------
Added template functions to retrieve the app slug (`{{repl Installation "app_slug" }}`) and license ID (`{{repl Installation "license_id" }}`)

How I Did it
------------
Added these properties to the existing function map

How to verify it
------------


Description for the Changelog
------------
Added template functions to retrieve the app slug (`{{repl Installation "app_slug" }}`) and license ID (`{{repl Installation "license_id" }}`)



Picture of a Ship (not required but encouraged)
------------


![USS Brownson (DD-868)](https://upload.wikimedia.org/wikipedia/commons/b/b6/USS_Brownson_%28DD-868%29_in_the_Atlantic_1964.jpg "USS Brownson (DD-868)")









<!-- (thanks https://github.com/docker/docker for this template) -->

