### PR TITLE
Use license ID for authenticating with private registry

### DIFF
--- a/integration/base/shipapp-helm-values/expected/installer/base/consul-statefulset.yaml
+++ b/integration/base/shipapp-helm-values/expected/installer/base/consul-statefulset.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        chart: consul-3.5.3
+        chart: consul-3.6.0
         component: ship-consul
         heritage: Tiller
         release: ship

--- a/integration/base/shipapp-helm-values/expected/installer/consul-rendered.yaml
+++ b/integration/base/shipapp-helm-values/expected/installer/consul-rendered.yaml
@@ -93,7 +93,7 @@ spec:
   template:
     metadata:
       labels:
-        chart: consul-3.5.3
+        chart: consul-3.6.0
         component: ship-consul
         heritage: Tiller
         release: ship

--- a/integration/base/shipapp-helm-values/expected/installer/consul/Chart.yaml
+++ b/integration/base/shipapp-helm-values/expected/installer/consul/Chart.yaml
@@ -1,6 +1,6 @@
 name: consul
 home: https://github.com/hashicorp/consul
-version: 3.5.3
+version: 3.6.0
 appVersion: 1.0.0
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/integration/base/shipapp-helm-values/expected/installer/consul/templates/consul-statefulset.yaml
+++ b/integration/base/shipapp-helm-values/expected/installer/consul/templates/consul-statefulset.yaml
@@ -139,7 +139,7 @@ spec:
             {{- range .Values.ConsulConfig }}
               -config-dir /etc/consul/userconfig/{{ .name }} \
             {{- end}}
-            {{- if .Values.uiService.enabled }}
+            {{- if .Values.ui.enabled }}
               -ui \
             {{- end }}
             {{- if .Values.DisableHostNodeId }}

--- a/pkg/lifecycle/render/docker/step.go
+++ b/pkg/lifecycle/render/docker/step.go
@@ -116,11 +116,15 @@ func (p *DefaultStep) Execute(
 
 		// first try with registry secret
 		// TODO remove this once registry is updated to read installation ID
+		userName := meta.CustomerID
+		if userName == "" {
+			userName = meta.LicenseID
+		}
 		registrySecretSaveOpts := images.SaveOpts{
 			PullURL:   pullURL,
 			SaveURL:   asset.Image,
 			IsPrivate: asset.Source != "public" && asset.Source != "",
-			Username:  meta.CustomerID,
+			Username:  userName,
 			Password:  meta.RegistrySecret,
 		}
 

--- a/pkg/specs/replicatedapp/graphql.go
+++ b/pkg/specs/replicatedapp/graphql.go
@@ -242,7 +242,7 @@ func (c *GraphQLClient) GetRelease(selector *Selector) (*ShipRelease, error) {
 	}
 
 	ci := callInfo{
-		username: selector.CustomerID,
+		username: selector.GetBasicAuthUsername(),
 		password: selector.InstallationID,
 		request:  requestObj,
 		upstream: selector.Upstream,
@@ -278,6 +278,8 @@ func (c *GraphQLClient) GetSlugRelease(selector *Selector) (*ShipRelease, error)
 	}
 
 	ci := callInfo{
+		username: selector.GetBasicAuthUsername(),
+		password: selector.InstallationID,
 		request:  requestObj,
 		upstream: selector.Upstream,
 	}

--- a/pkg/specs/replicatedapp/resolver.go
+++ b/pkg/specs/replicatedapp/resolver.go
@@ -238,7 +238,7 @@ func (r *resolver) RegisterInstall(ctx context.Context, selector Selector, relea
 
 	debug.Log("phase", "register", "with", "gql", "addr", r.Client.GQLServer.String())
 
-	err := r.Client.RegisterInstall(selector.CustomerID, "", release.Metadata.ChannelID, release.Metadata.ReleaseID)
+	err := r.Client.RegisterInstall(selector.GetBasicAuthUsername(), "", release.Metadata.ChannelID, release.Metadata.ReleaseID)
 	if err != nil {
 		return err
 	}

--- a/pkg/specs/replicatedapp/selector.go
+++ b/pkg/specs/replicatedapp/selector.go
@@ -71,3 +71,10 @@ func (s *Selector) UnmarshalFrom(url *url.URL) *Selector {
 	}
 	return s
 }
+
+func (s *Selector) GetBasicAuthUsername() string {
+	if s.CustomerID != "" {
+		return s.CustomerID
+	}
+	return s.LicenseID
+}


### PR DESCRIPTION
What I Did
------------
Fixed authentication with private registry.

How I Did it
------------
Use license ID for authentication because customer ID is no longer a thing

How to verify it
------------
push an image to private registry
make a pod that uses the private image and license ID for authentication
generate and apply k8s yaml
image should be pulled successfully and the container should be created

Description for the Changelog
------------
Fixed authentication with private registry.


Picture of a Ship (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

