### PR TITLE
FIx a typo in root.go

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -61,7 +61,7 @@ func RootCmd() *cobra.Command {
 	cmd.PersistentFlags().String("state-from", "file", "type of resource to use when loading/saving state (currently supported values: 'file', 'secret'")
 	cmd.PersistentFlags().String("state-file", "", fmt.Sprintf("path to the state file to read from, defaults to %s", constants.StatePath))
 	cmd.PersistentFlags().String("secret-namespace", "default", "namespace containing the state secret")
-	cmd.PersistentFlags().String("secret-name", "", "name of the secret to laod state from")
+	cmd.PersistentFlags().String("secret-name", "", "name of the secret to load state from")
 	cmd.PersistentFlags().String("secret-key", "", "name of the key in the secret containing state")
 
 	cmd.PersistentFlags().String("upload-assets-to", "", "URL to upload assets to via HTTP PUT request. NOTE: this will cause the entire working directory to be uploaded to the specified URL, use with caution.")


### PR DESCRIPTION
What I Did
------------

Fix a typo in the `ship`'s help output, that is `laod` changed to `load` according to the context.

How I Did it
------------

Edited the root.go in GitHub :)

How to verify it
------------

Rebuild and run `ship` from the branch.

Description for the Changelog
------------

Fixed a typo in `ship`'s help output

Picture of a Ship (not required but encouraged)
------------

![image](https://user-images.githubusercontent.com/22009/54799509-f3300680-4ca0-11e9-8bbd-e0792842d932.png)
