### PR TITLE
support for passing readme in values yaml

### DIFF
--- a/integration/base/shipapp-helm-values/expected/.ship/release.yml
+++ b/integration/base/shipapp-helm-values/expected/.ship/release.yml
@@ -18,6 +18,9 @@ lifecycle:
                 strip_path: true
     - helmValues:
         path: installer/consul/values.yaml
+        readme:
+          contents: |
+            # Fake readme :)
     - render:
         root: ./
         assets:

--- a/integration/base/shipapp-helm-values/expected/.ship/state.json
+++ b/integration/base/shipapp-helm-values/expected/.ship/state.json
@@ -9,6 +9,6 @@
       "releaseNotes": "",
       "version": ""
     },
-    "contentSHA": "94917a42778f666eec3aa892f6baacc92d7fca0a6889a6831635c8e9026265d5"
+    "contentSHA": "ff137904f9274e6cc56f40a4962c90fd15b513a06e6b7a52e14d0a0cb0560eab"
   }
 }

--- a/integration/base/shipapp-helm-values/input/.ship/ship.yml
+++ b/integration/base/shipapp-helm-values/input/.ship/ship.yml
@@ -18,6 +18,9 @@ lifecycle:
                 strip_path: true
     - helmValues:
         path: installer/consul/values.yaml
+        readme:
+          contents: |
+            # Fake readme :)
     - render:
         root: ./
         assets:

--- a/pkg/api/lifecycle.go
+++ b/pkg/api/lifecycle.go
@@ -167,7 +167,16 @@ func (h *HelmIntro) ShortName() string   { return "helm-intro" }
 // and save user input changes to values.yaml
 type HelmValues struct {
 	StepShared `json:",inline" yaml:",inline" hcl:",inline"`
-	Path       string `json:"path,omitempty" yaml:"path,omitempty" hcl:"path,omitempty"`
+	Path       string                  `json:"path,omitempty" yaml:"path,omitempty" hcl:"path,omitempty"`
+	Readme     *HelmValuesReadmeSource `json:"readme,omitempty" yaml:"readme,omitempty" hcl:"readme,omitempty"`
+}
+
+// A HelmValuesReadmeSource tells ship how to populate the readme file for the helm values editor.
+// if not provided, ship will use the default behavior of pulling the readme from the
+// root of the default target chart
+type HelmValuesReadmeSource struct {
+	Contents string `json:"contents,omitempty" yaml:"contents,omitempty" hcl:"contents,omitempty"`
+	// someday we'll support file or something too
 }
 
 func (h *HelmValues) Shared() *StepShared { return &h.StepShared }

--- a/pkg/api/lifecycle_test.go
+++ b/pkg/api/lifecycle_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 func TestDeserializeLifecycle(t *testing.T) {
@@ -160,6 +160,26 @@ lifecycle:
 						Invalidates: []string{
 							"render",
 						},
+					},
+				},
+			},
+		},
+		{
+			name: "helm-values-readme",
+			yaml: `
+---
+lifecycle:
+  v1:
+    - helmValues:
+        path: ./consul/values.yaml
+        readme:
+          contents: super dope
+`,
+			expect: Step{
+				HelmValues: &HelmValues{
+					Path: "./consul/values.yaml",
+					Readme: &HelmValuesReadmeSource{
+						Contents: "super dope",
 					},
 				},
 			},

--- a/pkg/lifecycle/daemon/daemontypes/types.go
+++ b/pkg/lifecycle/daemon/daemontypes/types.go
@@ -145,6 +145,8 @@ type HelmValues struct {
 	ReleaseName   string `json:"helmName"`
 	Namespace     string `json:"namespace"`
 	Path          string `json:"path,omitempty" yaml:"path,omitempty" hcl:"path,omitempty"`
+	// If set, Readme will override the default readme from the /metadata endpoint
+	Readme string `json:"readme,omitempty" yaml:"readme,omitempty" hcl:"readme,omitempty"`
 }
 
 type Kustomize struct {

--- a/pkg/lifecycle/daemon/routes_navcycle_getstep.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_getstep.go
@@ -126,6 +126,11 @@ func (d *NavcycleRoutes) hydrateStep(step daemontypes.Step) (*daemontypes.StepRe
 		step.HelmValues.DefaultValues = vendorValues
 		step.HelmValues.ReleaseName = releaseName
 		step.HelmValues.Namespace = namespace
+
+		if step.Source.HelmValues.Readme != nil {
+			// someday we can support files, etc
+			step.HelmValues.Readme = step.Source.HelmValues.Readme.Contents
+		}
 	}
 
 	result := &daemontypes.StepResponse{

--- a/web/init/src/components/kustomize/HelmValuesEditor.jsx
+++ b/web/init/src/components/kustomize/HelmValuesEditor.jsx
@@ -238,7 +238,7 @@ export default class HelmValuesEditor extends React.Component {
                 />
               </div>
               <div className={`flex-auto flex-column console-wrapper u-width--third ${!this.state.showConsole ? "visible" : ""}`}>
-                <Linter errors={this.state.specErrors} spec={values} previewEnabled={true} readme={readme} />
+                <Linter errors={this.state.specErrors} spec={values} previewEnabled={true} readme={this.props.getStep.readme || readme} />
               </div>
             </div>
           </div>

--- a/web/init/src/components/shared/Linter.jsx
+++ b/web/init/src/components/shared/Linter.jsx
@@ -4,12 +4,13 @@ import get from "lodash/get";
 
 export default class Linter extends React.Component {
 
-  constructor() {
-    super();
-    this.state = {
-      showHelp: false,
-      showPreview: true
-    };
+  constructor(props) {
+    super(props);
+
+    // if there's a readme, default to readme tab. Else default to linter results.
+    const showHelp = !this.props.readme;
+    const showPreview = !showHelp;
+    this.state = { showHelp, showPreview };
   }
 
   maybeLineNumber = (error) => {


### PR DESCRIPTION
What I Did
------------

Allow app maintainers to override the readme shown in a `helmValues` step.


```yaml

lifeycle:
  v1:
    - render: {}
    - helmValues:
        path: installer/chart/valyes.yaml
        readme:
          contents: |
            ## Configuration guide for Some-Chart

            ...
```

Right now the UI reads this from the `/metadata` endpoint, but now a mantainer can override this.

How I Did it
------------

- add `readme.contents` as an optional field to `lifecycle.v1.helmValues`
- if `readme` is non null on the step, set the values of `daemontypes.HelmValues.Readme` when returning it down to the frontend.
- Frontend checks for a `readme` field on the step, otherwise uses a `readme` from the chart meta if present.

How to verify it
------------

Use a lifecycle like the following, and navigate to helm values step:


```yaml

lifeycle:
  v1:
    - render: {}
    - helmValues:
        path: installer/chart/valyes.yaml
        readme:
          contents: |
            ## Configuration guide for Some-Chart

            ...
```

Description for the Changelog
------------



Allow app maintainers to override the readme shown in a `helmValues` step.



:ship: