### PR TITLE
add a flag to disable web assets

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -69,6 +69,8 @@ func RootCmd() *cobra.Command {
 	cmd.PersistentFlags().String("terraform-exec-path", "terraform", "Path to a terraform executable on the system.")
 	cmd.PersistentFlags().Bool("terraform-apply-yes", false, "Automatically apply terraform steps in headless mode. By default, terraform will be skipped when ship is running in automation.")
 
+	cmd.PersistentFlags().Bool("no-web", false, "Disable web assets")
+
 	cmd.PersistentFlags().String("resource-type", "", "upstream application resource type")
 	cmd.PersistentFlags().BoolP("prefer-git", "", false, "prefer the git protocol instead of using http apis")
 

--- a/pkg/lifecycle/render/web/step.go
+++ b/pkg/lifecycle/render/web/step.go
@@ -77,6 +77,10 @@ func (p *DefaultStep) Execute(
 	return func(ctx context.Context) error {
 		debug.Log("event", "execute")
 
+		if p.Viper.GetBool("no-web") {
+			return errors.New("web assets are disabled when no-web is set")
+		}
+
 		built, err := p.buildAsset(asset, meta, configGroups, templateContext)
 		if err != nil {
 			debug.Log("event", "build.fail", "err", err)


### PR DESCRIPTION
What I Did
------------
Added a flag, `--no-web`, that fails the render step upon encountering a web asset.

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------
Added a flag, `--no-web`, that fails the render step upon encountering a web asset.


Picture of a Ship (not required but encouraged)
------------

![USS Newman K Perry (DDR-883)](https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/USS_Newman_K_Perry_%28DDR-883%29_underway.jpeg/1600px-USS_Newman_K_Perry_%28DDR-883%29_underway.jpeg "USS Newman K Perry (DDR-883)")










<!-- (thanks https://github.com/docker/docker for this template) -->

