### PR TITLE
templating: fallbacks to ease migration from console-flavored ship

### DIFF
--- a/pkg/templates/installation_context_test.go
+++ b/pkg/templates/installation_context_test.go
@@ -114,11 +114,27 @@ func testCases() []TestInstallation {
 			Expected: `It's xyz`,
 		},
 		{
+			Name: "installation_id == license_id",
+			Meta: api.ReleaseMetadata{
+				InstallationID: "xyz",
+			},
+			Tpl:      `It's {{repl Installation "license_id" }}`,
+			Expected: `It's xyz`,
+		},
+		{
 			Name: "license_id",
 			Meta: api.ReleaseMetadata{
 				LicenseID: "myLicenseID",
 			},
 			Tpl:      `It's {{repl Installation "license_id" }}`,
+			Expected: `It's myLicenseID`,
+		},
+		{
+			Name: "license_id == installation_id",
+			Meta: api.ReleaseMetadata{
+				LicenseID: "myLicenseID",
+			},
+			Tpl:      `It's {{repl Installation "installation_id" }}`,
 			Expected: `It's myLicenseID`,
 		},
 		{
@@ -141,6 +157,20 @@ func testCases() []TestInstallation {
 					},
 				}},
 			Tpl:      `You get {{repl EntitlementValue "num_seats" }} seats`,
+			Expected: `You get 3 seats`,
+		},
+		{
+			Name: "entitlement value == license field value",
+			Meta: api.ReleaseMetadata{
+				Entitlements: api.Entitlements{
+					Values: []api.EntitlementValue{
+						{
+							Key:   "num_seats",
+							Value: "3",
+						},
+					},
+				}},
+			Tpl:      `You get {{repl LicenseFieldValue "num_seats" }} seats`,
 			Expected: `You get 3 seats`,
 		},
 		{


### PR DESCRIPTION
What I Did
------------

- In `{{repl Installation "installation_id"}}`, if `license_id` was used to fetch, template in the license id value
- In `{{repl Installation "license_id"}}`, if `installation_id` was used to fetch, template in the installation id value
- Add `{{repl LicenseFieldValue "FIELD_KEY"}}` as an alias for `{{repl EntitlementValue "FIELD_KEY"}}

How to verify it
------------

- ship init replicated.app/slug?license_id=..., ensure `{{repl
Installation "installation_id"}} emits the given license ID.

and so on

Description for the Changelog
------------

- In `{{repl Installation "installation_id"}}`, if `license_id` was used to fetch, template in the license id value
- In `{{repl Installation "license_id"}}`, if `installation_id` was used to fetch, template in the installation id value
- Add `{{repl LicenseFieldValue "FIELD_KEY"}}` as an alias for `{{repl EntitlementValue "FIELD_KEY"}}



![migrate the vendors](https://www.fairplanet.org/wp-content/uploads/2015/04/boats.1429693580.jpg)