### PR TITLE
Labels, headings and bools respect when conditions

### DIFF
--- a/web/app/package.json
+++ b/web/app/package.json
@@ -10,7 +10,7 @@
     "react-dom": "^16.5.0"
   },
   "scripts": {
-    "start": "PORT=8800 react-scripts-replicated start",
+    "start": "PORT=8880 react-scripts-replicated start",
     "build": "react-scripts-replicated build",
     "test": "react-scripts-replicated test --env=jsdom",
     "eject": "react-scripts-replicated eject"

--- a/web/init/src/components/config_render/ConfigGroup.jsx
+++ b/web/init/src/components/config_render/ConfigGroup.jsx
@@ -60,6 +60,7 @@ export default class ConfigGroup extends React.Component {
               title={item.title}
               recommended={item.recommended}
               required={item.required}
+              hidden={item.hidden}
               name={item.name}
             />
           </div>
@@ -88,7 +89,7 @@ export default class ConfigGroup extends React.Component {
         );
       case "heading":
         return (
-          <div key={`${i}-${item.name}`} className="u-marginTop--40 u-marginBottom--15">
+          <div key={`${i}-${item.name}`} className={`u-marginTop--40 u-marginBottom--15 ${item.hidden ? "hidden" : ""}`}>
             <h3 className="header-color field-section-header">{item.title}</h3>
           </div>
         );

--- a/web/init/src/components/config_render/ConfigItemTitle.jsx
+++ b/web/init/src/components/config_render/ConfigItemTitle.jsx
@@ -10,7 +10,7 @@ export default class ConfigItemTitle extends React.Component {
     } = this.props;
 
     return (
-      <h4 className="sub-header-color field-section-sub-header">{title} {
+      <h4 className={`sub-header-color field-section-sub-header ${this.props.hidden ? "hidden" : ""}`}>{title} {
         required ? 
           <span className="field-label required">Required</span> :
           recommended ? 

--- a/web/init/src/scss/components/shared/StepNumbers.scss
+++ b/web/init/src/scss/components/shared/StepNumbers.scss
@@ -38,10 +38,6 @@
   .progress-base {
     background-color: #dfdfdf;
   }
-
-  .numbers-wrapper {
-    margin: 0;
-  }
 }
 
 .step-number {


### PR DESCRIPTION
What I Did
------------
Config headers, labels, and bools respect the `when` condition in ship YAML

How I Did it
------------
Added checks for if the item is hidden and apply classes appropriately

How to verify it
------------
Create a ship yaml that contains the following in your config section
`- name: test_fields
      title: testing label bools
      items:
        - name: toggle
          type: bool
          title: toggle me
        - name: heading-hide
          when: '{{repl ConfigOptionEquals "toggle" "1"}}'
          type: heading
          title: this is a heading
        - name: label-hide
          when: '{{repl ConfigOptionEquals "toggle" "1"}}'
          type: label
          title: this is a label
        - name: bool-hide
          when: '{{repl ConfigOptionEquals "toggle" "1"}}'
          type: bool
          title: this is a bool`

If the "toggle me" box is unchecked none of the three items below it should be shown. If it is checked they should be visible

Description for the Changelog
------------
Fixed some config items not respecting "when" condition from ship yaml


Picture of a Ship (not required but encouraged)
------------
![boat](https://www.thestar.com.my/~/media/online/2018/01/15/19/56/world_ni_1601_p24a_nurilyanna_1.ashx/?w=620&h=413&crop=1&hash=2383DFEC0B9304201FC7BD565F38F21AC65AD97F)











<!-- (thanks https://github.com/docker/docker for this template) -->

