### PR TITLE
Add releasename fallback

### DIFF
--- a/pkg/api/spec.go
+++ b/pkg/api/spec.go
@@ -103,6 +103,10 @@ func (r ReleaseMetadata) ReleaseName() string {
 		releaseName = r.ShipAppMetadata.Name
 	}
 
+	if releaseName == "" && r.AppSlug != "" {
+		releaseName = r.AppSlug
+	}
+
 	if len(releaseName) == 0 {
 		return "ship"
 	}

--- a/pkg/api/spec_test.go
+++ b/pkg/api/spec_test.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReleaseMetadata_ReleaseName(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata ReleaseMetadata
+		want     string
+	}{
+		{
+			name:     "basic",
+			metadata: ReleaseMetadata{},
+			want:     "ship",
+		},
+		{
+			name: "channelName",
+			metadata: ReleaseMetadata{
+				ChannelName: "channel name here",
+			},
+			want: "channel-name-here",
+		},
+		{
+			name: "metadataName",
+			metadata: ReleaseMetadata{
+				ShipAppMetadata: ShipAppMetadata{
+					Name: "metadata name here",
+				},
+			},
+			want: "metadata-name-here",
+		},
+		{
+			name: "appSlug",
+			metadata: ReleaseMetadata{
+				AppSlug: "app slug here",
+			},
+			want: "app-slug-here",
+		},
+		{
+			name: "uppercase",
+			metadata: ReleaseMetadata{
+				ShipAppMetadata: ShipAppMetadata{
+					Name: "UPPERCASE",
+				},
+			},
+			want: "uppercase",
+		},
+		{
+			name: "specials",
+			metadata: ReleaseMetadata{
+				ShipAppMetadata: ShipAppMetadata{
+					Name: "special.characters!aren't+allowed",
+				},
+			},
+			want: "special-characters-aren-t-allowed",
+		},
+		{
+			name: "metadata name overrides channel name",
+			metadata: ReleaseMetadata{
+				ShipAppMetadata: ShipAppMetadata{
+					Name: "metadata",
+				},
+				ChannelName: "channel",
+			},
+			want: "metadata",
+		},
+		{
+			name: "channel name overrides app slug",
+			metadata: ReleaseMetadata{
+				AppSlug:     "appslug",
+				ChannelName: "channel",
+			},
+			want: "channel",
+		},
+		{
+			name: "metadata name overrides app slug",
+			metadata: ReleaseMetadata{
+				ShipAppMetadata: ShipAppMetadata{
+					Name: "metadata",
+				},
+				AppSlug: "appslug",
+			},
+			want: "metadata",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			got := tt.metadata.ReleaseName()
+			req.Equal(tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
What I Did
------------
Minor enhancement - use the app slug as a release name if no other option is present

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------


Picture of a Ship (not required but encouraged)
------------


![USS Stickell (DD-888)](https://upload.wikimedia.org/wikipedia/commons/9/99/USS_Stickell_%28DD-888%29_underway%2C_circa_in_the_1960s.jpg "USS Stickell (DD-888)")









<!-- (thanks https://github.com/docker/docker for this template) -->

