### PR TITLE
Error with proxied images: No 'Authorization' header provided in request

### DIFF
--- a/pkg/lifecycle/render/docker/step.go
+++ b/pkg/lifecycle/render/docker/step.go
@@ -2,9 +2,11 @@ package docker
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -144,6 +146,14 @@ func (p *DefaultStep) Execute(
 
 		debug.Log("event", "execute.fail.withRegistrySecret", "err", saveError)
 		debug.Log("event", "execute.try.withInstallationID")
+
+		if strings.Contains(saveError.Error(), "not found") {
+			return errors.Wrap(saveError, "pull with RegistrySecret")
+		}
+
+		if meta.CustomerID == "" {
+			return fmt.Errorf("exhausted all authentication methods for %s", pullURL)
+		}
 
 		// next try with installationID for password
 		installationIDSaveOpts := images.SaveOpts{


### PR DESCRIPTION
What I Did
------------
Fixed error handling and error messaging for proxied private images when those images do not exist in the private registry.

How I Did it
------------
Added handling for "not found" error and removed the unauthenticated pull attempt.

How to verify it
------------
Add a bogus image to assets (linked registry must be setup properly for this), such as
```
    - docker:
        image: myorg/myimage:latestest
        source: gcr
        dest: docker/myimage:latestest.tar
```

Error should read
```
Error response from daemon: manifest for myimage:latestest not found
```

Instead of
```
unauthorized: No 'Authorization' header provided in request
```

Description for the Changelog
------------
Better user messaging when specified images do not exist in the private registry.


Picture of a Ship (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

