### PR TITLE
Use golang 1.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
             - ship/web/app/build
   build_binary:
     docker:
-      - image: circleci/golang:1.10
+      - image: circleci/golang:1.12
     environment:
       GOCACHE: "/tmp/go/cache"
     working_directory: /go/src/github.com/replicatedhq/ship
@@ -145,7 +145,7 @@ jobs:
 
   test:
     docker:
-      - image: circleci/golang:1.10
+      - image: circleci/golang:1.12
     environment:
       GOCACHE: "/tmp/go/cache"
     working_directory: /go/src/github.com/replicatedhq/ship
@@ -180,7 +180,7 @@ jobs:
     working_directory: /home/circleci/go/src/github.com/replicatedhq/ship
     environment:
       GOPATH: /home/circleci/go
-      GO_SHA256SUM: fa04efdb17a275a0c6e137f969a1c4eb878939e91e1da16060ce42f02c2ec5ec
+      GO_SHA256SUM: 2a3fdabf665496a0db5f41ec6af7a9b15a49fbe71a85a50ca38b1f13a103aeec
       GO: /usr/local/go/bin/go
       GOCACHE: "/tmp/go/cache"
     steps:
@@ -189,7 +189,7 @@ jobs:
           keys:
             - ship-integration-test-build-cache-base
       - run: |
-          export GO_DOWNLOAD_URL=https://dl.google.com/go/go1.10.4.linux-amd64.tar.gz
+          export GO_DOWNLOAD_URL=https://dl.google.com/go/go1.12.1.linux-amd64.tar.gz
           export GOROOT=/usr/local/go
           export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
           sudo apt update --fix-missing
@@ -220,7 +220,7 @@ jobs:
     working_directory: /home/circleci/go/src/github.com/replicatedhq/ship
     environment:
       GOPATH: /home/circleci/go
-      GO_SHA256SUM: fa04efdb17a275a0c6e137f969a1c4eb878939e91e1da16060ce42f02c2ec5ec
+      GO_SHA256SUM: 2a3fdabf665496a0db5f41ec6af7a9b15a49fbe71a85a50ca38b1f13a103aeec
       GO: /usr/local/go/bin/go
       GOCACHE: "/tmp/go/cache"
     steps:
@@ -229,7 +229,7 @@ jobs:
         keys:
         - ship-integration-test-build-cache-init
     - run: |
-        export GO_DOWNLOAD_URL=https://dl.google.com/go/go1.10.4.linux-amd64.tar.gz
+        export GO_DOWNLOAD_URL=https://dl.google.com/go/go1.12.1.linux-amd64.tar.gz
         export GOROOT=/usr/local/go
         export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
         sudo apt update --fix-missing
@@ -260,7 +260,7 @@ jobs:
     working_directory: /home/circleci/go/src/github.com/replicatedhq/ship
     environment:
       GOPATH: /home/circleci/go
-      GO_SHA256SUM: fa04efdb17a275a0c6e137f969a1c4eb878939e91e1da16060ce42f02c2ec5ec
+      GO_SHA256SUM: 2a3fdabf665496a0db5f41ec6af7a9b15a49fbe71a85a50ca38b1f13a103aeec
       GO: /usr/local/go/bin/go
       GOCACHE: "/tmp/go/cache"
     steps:
@@ -269,7 +269,7 @@ jobs:
         keys:
         - ship-integration-test-build-cache-unfork
     - run: |
-        export GO_DOWNLOAD_URL=https://dl.google.com/go/go1.10.4.linux-amd64.tar.gz
+        export GO_DOWNLOAD_URL=https://dl.google.com/go/go1.12.1.linux-amd64.tar.gz
         export GOROOT=/usr/local/go
         export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
         sudo apt update --fix-missing
@@ -302,7 +302,7 @@ jobs:
     working_directory: /home/circleci/go/src/github.com/replicatedhq/ship
     environment:
       GOPATH: /home/circleci/go
-      GO_SHA256SUM: fa04efdb17a275a0c6e137f969a1c4eb878939e91e1da16060ce42f02c2ec5ec
+      GO_SHA256SUM: 2a3fdabf665496a0db5f41ec6af7a9b15a49fbe71a85a50ca38b1f13a103aeec
       GO: /usr/local/go/bin/go
       GOCACHE: "/tmp/go/cache"
     steps:
@@ -311,7 +311,7 @@ jobs:
         keys:
         - ship-integration-test-build-cache-init-app
     - run: |
-        export GO_DOWNLOAD_URL=https://dl.google.com/go/go1.10.4.linux-amd64.tar.gz
+        export GO_DOWNLOAD_URL=https://dl.google.com/go/go1.12.1.linux-amd64.tar.gz
         export GOROOT=/usr/local/go
         export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
         sudo apt update --fix-missing
@@ -344,7 +344,7 @@ jobs:
     working_directory: /home/circleci/go/src/github.com/replicatedhq/ship
     environment:
       GOPATH: /home/circleci/go
-      GO_SHA256SUM: fa04efdb17a275a0c6e137f969a1c4eb878939e91e1da16060ce42f02c2ec5ec
+      GO_SHA256SUM: 2a3fdabf665496a0db5f41ec6af7a9b15a49fbe71a85a50ca38b1f13a103aeec
       GO: /usr/local/go/bin/go
       GOCACHE: "/tmp/go/cache"
     steps:
@@ -353,7 +353,7 @@ jobs:
         keys:
         - ship-integration-test-build-cache-update
     - run: |
-        export GO_DOWNLOAD_URL=https://dl.google.com/go/go1.10.4.linux-amd64.tar.gz
+        export GO_DOWNLOAD_URL=https://dl.google.com/go/go1.12.1.linux-amd64.tar.gz
         export GOROOT=/usr/local/go
         export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
         sudo apt update --fix-missing
@@ -428,7 +428,7 @@ jobs:
 
   deploy_unstable:
     docker:
-      - image: circleci/golang:1.10
+      - image: circleci/golang:1.12
     working_directory: /go/src/github.com/replicatedhq/ship
     steps:
       - checkout
@@ -452,7 +452,7 @@ jobs:
 
   deploy_integration:
     docker:
-      - image: circleci/golang:1.10
+      - image: circleci/golang:1.12
     working_directory: /go/src/github.com/replicatedhq/ship
     steps:
       - checkout
@@ -468,7 +468,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/golang:1.10
+      - image: circleci/golang:1.12
     working_directory: /go/src/github.com/replicatedhq/ship
     steps:
       - checkout
@@ -494,7 +494,7 @@ jobs:
 
   is_upstream:
     docker:
-      - image: circleci/golang:1.10
+      - image: circleci/golang:1.12
     working_directory: /go/src/github.com/replicatedhq/ship
     steps:
       - run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ The specified version are recommended.
 
 - `yarn` version 1.12
 - `node` version 8.11
-- `go` version 1.10
+- `go` version 1.12
 - `dep` version 0.5 (https://github.com/golang/dep#installation)
 
 ### First time build


### PR DESCRIPTION
What I Did
------------
Update Ship to build & test with go 1.12

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------
Update CI to build with Go 1.12


Picture of a Ship (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

