### PR TITLE
fix several races in unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,13 @@ lint: vet ineffassign .state/lint
 
 test: lint .state/test
 
+.state/race: $(SRC)
+	go test --race ./pkg/...
+	@mkdir -p .state
+	@touch .state/race
+
+race: lint .state/race
+
 .state/coverage.out: $(SRC)
 	@mkdir -p .state/
 	#the reduced parallelism here is to avoid hitting the memory limits - we consistently did so with two threads on a 4gb instance


### PR DESCRIPTION
What I Did
------------
Ensured that the daemon is actually closed before starting the next test

How I Did it
------------
After the daemon exits, the goroutine in question uses a channel to signal completion to the test

How to verify it
------------
Tests are less flaky

Description for the Changelog
------------



Picture of a Ship (not required but encouraged)
------------

![USS Farmington (PCE 894)](http://www.navsource.org/archives/12/120289407.jpg "USS Farmington (PCE 894)")










<!-- (thanks https://github.com/docker/docker for this template) -->

