### PR TITLE
update cfssl to remove override for certificate-transparency-go

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -218,7 +218,8 @@
   revision = "bf70f2a70fb1b1f36d90d671a72795984eab0fcb"
 
 [[projects]]
-  digest = "1:742890ab4bf0fd5346b79dfad96362117c6b28e3624491b399c6fe1f1e2869fe"
+  branch = "master"
+  digest = "1:10d0fab9d03b437ed7a33273b12ebbb4597eadac3daa7ebf07e6ff8bf778779b"
   name = "github.com/cloudflare/cfssl"
   packages = [
     "auth",
@@ -237,8 +238,7 @@
     "signer/local",
   ]
   pruneopts = "UT"
-  revision = "5d63dbd981b5c408effbb58c442d54761ff94fbd"
-  version = "1.3.2"
+  revision = "ea569c5aa1be8442fc8c98cb55948bad20bcabed"
 
 [[projects]]
   digest = "1:ec66ad050342a3573ed2f5a4337d51b4c6d5d2a717cc6c9ecf86b081235a5759"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -129,7 +129,7 @@ ignored = [
 
 [[constraint]]
   name = "github.com/cloudflare/cfssl"
-  version = "1.0.0"
+  branch = "master"
 
 [[constraint]]
   branch = "master"
@@ -138,7 +138,3 @@ ignored = [
 [[override]]
   name = "gopkg.in/fsnotify.v1"
   source = "https://github.com/fsnotify/fsnotify.git"
-
-[[override]]
-  name = "github.com/google/certificate-transparency-go"
-  version = "v1.0.21"

--- a/vendor/github.com/cloudflare/cfssl/auth/auth.go
+++ b/vendor/github.com/cloudflare/cfssl/auth/auth.go
@@ -56,7 +56,7 @@ func New(key string, ad []byte) (*Standard, error) {
 			if err != nil {
 				return nil, err
 			}
-			key = string(data)
+			key = strings.TrimSpace(string(data))
 		default:
 			return nil, fmt.Errorf("unknown key prefix: %s", splitKey[0])
 		}

--- a/vendor/github.com/cloudflare/cfssl/config/config.go
+++ b/vendor/github.com/cloudflare/cfssl/config/config.go
@@ -32,7 +32,7 @@ import (
 // mechanism.
 type CSRWhitelist struct {
 	Subject, PublicKeyAlgorithm, PublicKey, SignatureAlgorithm bool
-	DNSNames, IPAddresses, EmailAddresses                      bool
+	DNSNames, IPAddresses, EmailAddresses, URIs                bool
 }
 
 // OID is our own version of asn1's ObjectIdentifier, so we can define a custom

--- a/vendor/github.com/cloudflare/cfssl/csr/csr.go
+++ b/vendor/github.com/cloudflare/cfssl/csr/csr.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"net"
 	"net/mail"
+	"net/url"
 	"strings"
 
 	cferr "github.com/cloudflare/cfssl/errors"
@@ -268,6 +269,9 @@ func getHosts(cert *x509.Certificate) []string {
 	for _, email := range cert.EmailAddresses {
 		hosts = append(hosts, email)
 	}
+	for _, uri := range cert.URIs {
+		hosts = append(hosts, uri.String())
+	}
 
 	return hosts
 }
@@ -379,6 +383,8 @@ func Generate(priv crypto.Signer, req *CertificateRequest) (csr []byte, err erro
 			tpl.IPAddresses = append(tpl.IPAddresses, ip)
 		} else if email, err := mail.ParseAddress(req.Hosts[i]); err == nil && email != nil {
 			tpl.EmailAddresses = append(tpl.EmailAddresses, email.Address)
+		} else if uri, err := url.ParseRequestURI(req.Hosts[i]); err == nil && uri != nil {
+			tpl.URIs = append(tpl.URIs, uri)
 		} else {
 			tpl.DNSNames = append(tpl.DNSNames, req.Hosts[i])
 		}

--- a/vendor/github.com/cloudflare/cfssl/helpers/derhelpers/derhelpers.go
+++ b/vendor/github.com/cloudflare/cfssl/helpers/derhelpers/derhelpers.go
@@ -9,10 +9,11 @@ import (
 	"crypto/x509"
 
 	cferr "github.com/cloudflare/cfssl/errors"
+	"golang.org/x/crypto/ed25519"
 )
 
-// ParsePrivateKeyDER parses a PKCS #1, PKCS #8, or elliptic curve
-// DER-encoded private key. The key must not be in PEM format.
+// ParsePrivateKeyDER parses a PKCS #1, PKCS #8, ECDSA, or Ed25519 DER-encoded
+// private key. The key must not be in PEM format.
 func ParsePrivateKeyDER(keyDER []byte) (key crypto.Signer, err error) {
 	generalKey, err := x509.ParsePKCS8PrivateKey(keyDER)
 	if err != nil {
@@ -20,12 +21,15 @@ func ParsePrivateKeyDER(keyDER []byte) (key crypto.Signer, err error) {
 		if err != nil {
 			generalKey, err = x509.ParseECPrivateKey(keyDER)
 			if err != nil {
-				// We don't include the actual error into
-				// the final error. The reason might be
-				// we don't want to leak any info about
-				// the private key.
-				return nil, cferr.New(cferr.PrivateKeyError,
-					cferr.ParseFailed)
+				generalKey, err = ParseEd25519PrivateKey(keyDER)
+				if err != nil {
+					// We don't include the actual error into
+					// the final error. The reason might be
+					// we don't want to leak any info about
+					// the private key.
+					return nil, cferr.New(cferr.PrivateKeyError,
+						cferr.ParseFailed)
+				}
 			}
 		}
 	}
@@ -35,6 +39,8 @@ func ParsePrivateKeyDER(keyDER []byte) (key crypto.Signer, err error) {
 		return generalKey.(*rsa.PrivateKey), nil
 	case *ecdsa.PrivateKey:
 		return generalKey.(*ecdsa.PrivateKey), nil
+	case ed25519.PrivateKey:
+		return generalKey.(ed25519.PrivateKey), nil
 	}
 
 	// should never reach here

--- a/vendor/github.com/cloudflare/cfssl/helpers/derhelpers/ed25519.go
+++ b/vendor/github.com/cloudflare/cfssl/helpers/derhelpers/ed25519.go
@@ -1,0 +1,133 @@
+package derhelpers
+
+import (
+	"crypto"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"errors"
+
+	"golang.org/x/crypto/ed25519"
+)
+
+var errEd25519WrongID = errors.New("incorrect object identifier")
+var errEd25519WrongKeyType = errors.New("incorrect key type")
+
+// ed25519OID is the OID for the Ed25519 signature scheme: see
+// https://datatracker.ietf.org/doc/draft-ietf-curdle-pkix-04.
+var ed25519OID = asn1.ObjectIdentifier{1, 3, 101, 112}
+
+// subjectPublicKeyInfo reflects the ASN.1 object defined in the X.509 standard.
+//
+// This is defined in crypto/x509 as "publicKeyInfo".
+type subjectPublicKeyInfo struct {
+	Algorithm pkix.AlgorithmIdentifier
+	PublicKey asn1.BitString
+}
+
+// MarshalEd25519PublicKey creates a DER-encoded SubjectPublicKeyInfo for an
+// ed25519 public key, as defined in
+// https://tools.ietf.org/html/draft-ietf-curdle-pkix-04. This is analagous to
+// MarshalPKIXPublicKey in crypto/x509, which doesn't currently support Ed25519.
+func MarshalEd25519PublicKey(pk crypto.PublicKey) ([]byte, error) {
+	pub, ok := pk.(ed25519.PublicKey)
+	if !ok {
+		return nil, errEd25519WrongKeyType
+	}
+
+	spki := subjectPublicKeyInfo{
+		Algorithm: pkix.AlgorithmIdentifier{
+			Algorithm: ed25519OID,
+		},
+		PublicKey: asn1.BitString{
+			BitLength: len(pub) * 8,
+			Bytes:     pub,
+		},
+	}
+
+	return asn1.Marshal(spki)
+}
+
+// ParseEd25519PublicKey returns the Ed25519 public key encoded by the input.
+func ParseEd25519PublicKey(der []byte) (crypto.PublicKey, error) {
+	var spki subjectPublicKeyInfo
+	if rest, err := asn1.Unmarshal(der, &spki); err != nil {
+		return nil, err
+	} else if len(rest) > 0 {
+		return nil, errors.New("SubjectPublicKeyInfo too long")
+	}
+
+	if !spki.Algorithm.Algorithm.Equal(ed25519OID) {
+		return nil, errEd25519WrongID
+	}
+
+	if spki.PublicKey.BitLength != ed25519.PublicKeySize*8 {
+		return nil, errors.New("SubjectPublicKeyInfo PublicKey length mismatch")
+	}
+
+	return ed25519.PublicKey(spki.PublicKey.Bytes), nil
+}
+
+// oneAsymmetricKey reflects the ASN.1 structure for storing private keys in
+// https://tools.ietf.org/html/draft-ietf-curdle-pkix-04, excluding the optional
+// fields, which we don't use here.
+//
+// This is identical to pkcs8 in crypto/x509.
+type oneAsymmetricKey struct {
+	Version    int
+	Algorithm  pkix.AlgorithmIdentifier
+	PrivateKey []byte
+}
+
+// curvePrivateKey is the innter type of the PrivateKey field of
+// oneAsymmetricKey.
+type curvePrivateKey []byte
+
+// MarshalEd25519PrivateKey returns a DER encdoing of the input private key as
+// specified in https://tools.ietf.org/html/draft-ietf-curdle-pkix-04.
+func MarshalEd25519PrivateKey(sk crypto.PrivateKey) ([]byte, error) {
+	priv, ok := sk.(ed25519.PrivateKey)
+	if !ok {
+		return nil, errEd25519WrongKeyType
+	}
+
+	// Marshal the innter CurvePrivateKey.
+	curvePrivateKey, err := asn1.Marshal(priv.Seed())
+	if err != nil {
+		return nil, err
+	}
+
+	// Marshal the OneAsymmetricKey.
+	asym := oneAsymmetricKey{
+		Version: 0,
+		Algorithm: pkix.AlgorithmIdentifier{
+			Algorithm: ed25519OID,
+		},
+		PrivateKey: curvePrivateKey,
+	}
+	return asn1.Marshal(asym)
+}
+
+// ParseEd25519PrivateKey returns the Ed25519 private key encoded by the input.
+func ParseEd25519PrivateKey(der []byte) (crypto.PrivateKey, error) {
+	asym := new(oneAsymmetricKey)
+	if rest, err := asn1.Unmarshal(der, asym); err != nil {
+		return nil, err
+	} else if len(rest) > 0 {
+		return nil, errors.New("OneAsymmetricKey too long")
+	}
+
+	// Check that the key type is correct.
+	if !asym.Algorithm.Algorithm.Equal(ed25519OID) {
+		return nil, errEd25519WrongID
+	}
+
+	// Unmarshal the inner CurvePrivateKey.
+	seed := new(curvePrivateKey)
+	if rest, err := asn1.Unmarshal(asym.PrivateKey, seed); err != nil {
+		return nil, err
+	} else if len(rest) > 0 {
+		return nil, errors.New("CurvePrivateKey too long")
+	}
+
+	return ed25519.NewKeyFromSeed(*seed), nil
+}

--- a/vendor/github.com/cloudflare/cfssl/helpers/helpers.go
+++ b/vendor/github.com/cloudflare/cfssl/helpers/helpers.go
@@ -184,6 +184,19 @@ func HashAlgoString(alg x509.SignatureAlgorithm) string {
 	}
 }
 
+// StringTLSVersion returns underlying enum values from human names for TLS
+// versions, defaults to current golang default of TLS 1.0
+func StringTLSVersion(version string) uint16 {
+	switch version {
+	case "1.2":
+		return tls.VersionTLS12
+	case "1.1":
+		return tls.VersionTLS11
+	default:
+		return tls.VersionTLS10
+	}
+}
+
 // EncodeCertificatesPEM encodes a number of x509 certificates to PEM
 func EncodeCertificatesPEM(certs []*x509.Certificate) []byte {
 	var buffer bytes.Buffer

--- a/vendor/github.com/cloudflare/cfssl/signer/signer.go
+++ b/vendor/github.com/cloudflare/cfssl/signer/signer.go
@@ -192,6 +192,7 @@ func ParseCertificateRequest(s Signer, csrBytes []byte) (template *x509.Certific
 		DNSNames:           csrv.DNSNames,
 		IPAddresses:        csrv.IPAddresses,
 		EmailAddresses:     csrv.EmailAddresses,
+		URIs:               csrv.URIs,
 	}
 
 	for _, val := range csrv.Extensions {
@@ -320,6 +321,7 @@ func FillTemplate(template *x509.Certificate, defaultProfile, profile *config.Si
 		}
 		template.DNSNames = nil
 		template.EmailAddresses = nil
+		template.URIs = nil
 	}
 	template.SubjectKeyId = ski
 


### PR DESCRIPTION
What I Did
------------
Use the latest version of `cfssl` to remove the version override of `certificate-transparency-go` required to build for windows.

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Ship (not required but encouraged)
------------


![PCE(C)-896](http://www.navsource.org/archives/12/120289606.jpg "PCE(C)-896")









<!-- (thanks https://github.com/docker/docker for this template) -->

