### PR TITLE
Adding template functions that provide access to metadata and entitlements

### DIFF
--- a/pkg/api/entitlements.go
+++ b/pkg/api/entitlements.go
@@ -12,10 +12,17 @@ type Meta struct {
 	CustomerID  string    `json:"customer_id"`
 }
 
-// EntitlementValue is a single entitlement value
-type EntitlementValue struct {
+// EntitlementLabel is a single entitlement label
+type EntitlementLabel struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
+}
+
+// EntitlementValue is a single entitlement value
+type EntitlementValue struct {
+	Key    string             `json:"key"`
+	Value  string             `json:"value"`
+	Labels []EntitlementLabel `json:"labels"`
 }
 
 // Utilization is a single utilization value

--- a/pkg/specs/replicatedapp/graphql.go
+++ b/pkg/specs/replicatedapp/graphql.go
@@ -47,6 +47,10 @@ query($semver: String) {
       values {
         key
         value
+        labels {
+          key
+          value
+        }
       }
       meta {
         customerID
@@ -86,6 +90,27 @@ query($appSlug: String!, $licenseID: String, $releaseID: String, $semver: String
         size
         data
       }
+    }
+    entitlements {
+      values {
+        key
+        value
+        labels {
+          key
+          value
+        }
+      }
+      utilizations {
+        key
+        value
+      }
+      meta {
+        lastUpdated
+        customerID
+        installationID
+      }
+      serialized
+      signature
     }
     created
     registrySecret

--- a/pkg/templates/installation_context.go
+++ b/pkg/templates/installation_context.go
@@ -8,6 +8,7 @@ import (
 	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/constants"
 	"github.com/spf13/viper"
+	yaml "gopkg.in/yaml.v2"
 )
 
 type InstallationContext struct {
@@ -32,8 +33,28 @@ func (ctx *InstallationContext) entitlementValue(name string) string {
 	return ""
 }
 
+func (ctx *InstallationContext) releaseMeta() string {
+	data, err := yaml.Marshal(ctx.Meta)
+	if err != nil {
+		level.Error(ctx.Logger).Log("msg", "unable to marshal release meta", "err", err)
+		return ""
+	}
+	return string(data)
+}
+
+func (ctx *InstallationContext) entitlementsYAML() string {
+	data, err := yaml.Marshal(ctx.Meta.Entitlements)
+	if err != nil {
+		level.Error(ctx.Logger).Log("msg", "unable to marshal entitlements", "err", err)
+		return ""
+	}
+	return string(data)
+}
+
 func (ctx *InstallationContext) FuncMap() template.FuncMap {
 	return template.FuncMap{
+		"ReleaseMeta":       ctx.releaseMeta,
+		"EntitlementsYAML":  ctx.entitlementsYAML,
 		"EntitlementValue":  ctx.entitlementValue,
 		"LicenseFieldValue": ctx.entitlementValue,
 		"Installation": func(name string) string {


### PR DESCRIPTION
What I Did
------------
Added template functions to access release metadata and entitlements.
Added labels to entitlement values

How I Did it
------------
Added template functions to installation context
Added GraphQL request parameters

How to verify it
------------
Create entitlements then use `ReleaseMeta` and `EntitlementsYAML` functions in Ship YAML and look at rendered output.

Description for the Changelog
------------
Added `ReleaseMeta` and `EntitlementsYAML` template functions.


Picture of a Ship (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

