### PR TITLE
update ship version in readme and include 'z' flag for tar

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ The output of the `init` and `unfork` modes will result in the creation of a dir
 Ship is packaged as a single binary, and Linux and MacOS versions are distributed:
 - To download the latest Linux build, run:
 ```shell
-curl -sSL https://github.com/replicatedhq/ship/releases/download/v0.39.0/ship_0.39.0_linux_amd64.tar.gz | tar xv && sudo mv ship /usr/local/bin
+curl -sSL https://github.com/replicatedhq/ship/releases/download/v0.40.0/ship_0.40.0_linux_amd64.tar.gz | tar zxv && sudo mv ship /usr/local/bin
 ```
 
 - To download the latest MacOS build, you can either run:
 ```shell
-curl -sSL https://github.com/replicatedhq/ship/releases/download/v0.39.0/ship_0.39.0_darwin_amd64.tar.gz | tar xv && sudo mv ship /usr/local/bin
+curl -sSL https://github.com/replicatedhq/ship/releases/download/v0.40.0/ship_0.40.0_darwin_amd64.tar.gz | tar zxv && sudo mv ship /usr/local/bin
 ```
 
 - ... or you can install with [Homebrew](https://brew.sh/):


### PR DESCRIPTION
What I Did
------------
Updated the version of ship used in the readme to `v0.40.0` and included a `z` flag in the tar command in order to decompress the archive

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Ship (not required but encouraged)
------------



![USCGC Legare (WMEC-912)](https://upload.wikimedia.org/wikipedia/commons/thumb/5/5d/USCGC_Legare_WMEC-912.jpg/1280px-USCGC_Legare_WMEC-912.jpg "USCGC Legare (WMEC-912)")








<!-- (thanks https://github.com/docker/docker for this template) -->

