### PR TITLE
Fix randomstring config chaining

### DIFF
--- a/pkg/lifecycle/render/config/daemonresolver.go
+++ b/pkg/lifecycle/render/config/daemonresolver.go
@@ -66,6 +66,9 @@ func (d *DaemonResolver) awaitConfigSaved(ctx context.Context, daemonExitedChan 
 			return d.Daemon.GetCurrentConfig(), nil
 		case <-time.After(10 * time.Second):
 			debug.Log("waitingFor", "config.saved")
+		case <-ctx.Done():
+			debug.Log("event", "ctx.done")
+			return nil, ctx.Err()
 		}
 	}
 }

--- a/pkg/lifecycle/render/config/daemonresolver_test.go
+++ b/pkg/lifecycle/render/config/daemonresolver_test.go
@@ -13,8 +13,13 @@ import (
 
 	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/lifecycle/daemon"
+	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/headless"
 	"github.com/replicatedhq/ship/pkg/lifecycle/kustomize"
+	"github.com/replicatedhq/ship/pkg/lifecycle/render/config/resolve"
+	"github.com/replicatedhq/ship/pkg/state"
+	templates "github.com/replicatedhq/ship/pkg/templates"
 	"github.com/replicatedhq/ship/pkg/testing/logger"
+	"github.com/replicatedhq/ship/pkg/ui"
 )
 
 type daemonResolverTestCase struct {
@@ -129,6 +134,7 @@ func TestDaemonResolver(t *testing.T) {
 			viper.Set("api-port", 0)
 			fs := afero.Afero{Fs: afero.NewMemMapFs()}
 			log := &logger.TestLogger{T: t}
+
 			daemon := &daemon.ShipDaemon{
 				Logger:       log,
 				WebUIFactory: daemon.WebUIFactoryFactory(log),
@@ -175,6 +181,174 @@ func TestDaemonResolver(t *testing.T) {
 			//	req.True(ok, "Expected to find key %s in resolved config", key)
 			//	req.Equal(expected, actual)
 			//}
+		})
+	}
+}
+
+func TestHeadlessResolver(t *testing.T) {
+	tests := []daemonResolverTestCase{
+		{
+			name: "test_resolve_noitems",
+			release: &api.Release{
+				Spec: api.Spec{
+					Lifecycle: api.Lifecycle{
+						V1: []api.Step{
+							{
+								Render: &api.Render{},
+							},
+						},
+					},
+					Config: api.Config{
+						V1: []libyaml.ConfigGroup{},
+					},
+				},
+			},
+			inputContext: map[string]interface{}{
+				"foo": "bar",
+			},
+			expect: func(t *testing.T, config map[string]interface{}, e error) {
+				req := require.New(t)
+				req.NoError(e)
+				actual, ok := config["foo"]
+				req.True(ok, "Expected to find key %s in resolved config", "foo")
+				req.Equal("bar", actual)
+			},
+		},
+		{
+			name: "test_config_item",
+			release: &api.Release{
+				Spec: api.Spec{
+					Lifecycle: api.Lifecycle{
+						V1: []api.Step{
+							{
+								Render: &api.Render{},
+							},
+						},
+					},
+					Config: api.Config{
+						V1: []libyaml.ConfigGroup{
+							{
+								Items: []*libyaml.ConfigItem{
+									{
+										Name:     "out",
+										Type:     "text",
+										ReadOnly: true,
+										Value:    `{{repl ConfigOption "foo"}}`,
+									},
+								},
+							},
+							{
+								Items: []*libyaml.ConfigItem{
+									{
+										Name:     "foo",
+										Type:     "text",
+										ReadOnly: false,
+										Value:    ``,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			inputContext: map[string]interface{}{
+				"foo": "bar",
+			},
+			expect: func(t *testing.T, i map[string]interface{}, e error) {
+				req := require.New(t)
+				req.NoError(e)
+
+				expectContext := map[string]interface{}{
+					"foo": "bar",
+					"out": "bar",
+				}
+
+				req.Equal(expectContext, i)
+			},
+		},
+		{
+			name: "test_random_chain",
+			release: &api.Release{
+				Spec: api.Spec{
+					Lifecycle: api.Lifecycle{
+						V1: []api.Step{
+							{
+								Render: &api.Render{},
+							},
+						},
+					},
+					Config: api.Config{
+						V1: []libyaml.ConfigGroup{
+							{
+								Items: []*libyaml.ConfigItem{
+									{
+										Name:     "random_1",
+										Type:     "text",
+										ReadOnly: true,
+										Value:    `{{repl RandomString 32}}`,
+									},
+								},
+							},
+							{
+								Items: []*libyaml.ConfigItem{
+									{
+										Name:     "random_dependent",
+										Type:     "text",
+										ReadOnly: true,
+										Value:    `{{repl ConfigOption "random_1"}}`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			inputContext: map[string]interface{}{},
+			expect: func(t *testing.T, i map[string]interface{}, e error) {
+				req := require.New(t)
+				req.NoError(e)
+
+				random1, exists := i["random_1"]
+				req.True(exists, "'random_1' should exist")
+
+				randomDependent, exists := i["random_dependent"]
+				req.True(exists, "'random_dependent' should exist")
+
+				req.Equal(randomDependent, random1)
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			v := viper.New()
+
+			viper.Set("api-port", 0)
+			fs := afero.Afero{Fs: afero.NewMemMapFs()}
+			log := &logger.TestLogger{T: t}
+
+			manager := state.NewManager(log, fs, v)
+
+			builderBuilder := templates.NewBuilderBuilder(log, v, manager)
+
+			renderer := resolve.NewRenderer(log, v, builderBuilder)
+
+			headlessDaemon := headless.HeadlessDaemon{
+				StateManager:      manager,
+				Logger:            log,
+				UI:                ui.FromViper(v),
+				ConfigRenderer:    renderer,
+				FS:                fs,
+				ResolvedConfig:    test.inputContext,
+				YesApplyTerraform: false,
+			}
+
+			resolver := &DaemonResolver{log, &headlessDaemon}
+
+			resolveContext, _ := context.WithTimeout(context.Background(), 1*time.Second)
+
+			config, err := resolver.ResolveConfig(resolveContext, test.release, test.inputContext)
+
+			test.expect(t, config, err)
 		})
 	}
 }


### PR DESCRIPTION
What I Did
------------
Fix `{{repl ConfigOption "abc"}}` where `abc` was an ephemeral RandomString

How I Did it
------------
When rendering the final template values for a config option, the existing value from the config chain generation is used .

How to verify it
------------
The new 'random chain' set of headless daemonresolver tests pass.

Description for the Changelog
------------

Fix `{{repl ConfigOption "abc"}}` where `abc` was an ephemeral RandomString


Picture of a Ship (not required but encouraged)
------------

![USS Mahoning County (LST-914)](https://upload.wikimedia.org/wikipedia/commons/7/7d/USS_LST-914_Wonsan_2_November_1950.jpg "USS Mahoning County (LST-914)")










<!-- (thanks https://github.com/docker/docker for this template) -->

