### PR TITLE
include some vendored dependencies in ship version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ DOCKER_REPO ?= replicated
 VERSION_PACKAGE = github.com/replicatedhq/ship/pkg/version
 VERSION ?=`git describe --tags`
 DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
-HELMV = 2.13.0
-KUSTOMIZEV = 2.0.2
+HELMV = v2.13.0
+KUSTOMIZEV = v2.0.2
 TERRAFORMV = v0.11.13
 
 GIT_TREE = $(shell git rev-parse --is-inside-work-tree 2>/dev/null)

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ DOCKER_REPO ?= replicated
 VERSION_PACKAGE = github.com/replicatedhq/ship/pkg/version
 VERSION ?=`git describe --tags`
 DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
+HELMV = 2.13.0
+KUSTOMIZEV = 2.0.2
+TERRAFORMV = v0.11.13
 
 GIT_TREE = $(shell git rev-parse --is-inside-work-tree 2>/dev/null)
 ifneq "$(GIT_TREE)" ""
@@ -36,6 +39,9 @@ define LDFLAGS
 	-X ${VERSION_PACKAGE}.version=${VERSION} \
 	-X ${VERSION_PACKAGE}.gitSHA=${GIT_SHA} \
 	-X ${VERSION_PACKAGE}.buildTime=${DATE} \
+	-X ${VERSION_PACKAGE}.helm=${HELMV} \
+	-X ${VERSION_PACKAGE}.kustomize=${KUSTOMIZEV} \
+	-X ${VERSION_PACKAGE}.terraform=${TERRAFORMV} \
 "
 endef
 

--- a/deploy/.goreleaser.unstable.yml
+++ b/deploy/.goreleaser.unstable.yml
@@ -27,8 +27,8 @@ builds:
     -X github.com/replicatedhq/ship/pkg/version.version={{.Version}}
     -X github.com/replicatedhq/ship/pkg/version.gitSHA={{.Commit}}
     -X github.com/replicatedhq/ship/pkg/version.buildTime={{.Date}}
-    -X github.com/replicatedhq/ship/pkg/version.helm=2.13.0
-    -X github.com/replicatedhq/ship/pkg/version.kustomize=2.0.2
+    -X github.com/replicatedhq/ship/pkg/version.helm=v2.13.0
+    -X github.com/replicatedhq/ship/pkg/version.kustomize=v2.0.2
     -X github.com/replicatedhq/ship/pkg/version.terraform=v0.11.13
     -extldflags "-static"
   flags: -tags netgo -installsuffix netgo

--- a/deploy/.goreleaser.unstable.yml
+++ b/deploy/.goreleaser.unstable.yml
@@ -27,6 +27,9 @@ builds:
     -X github.com/replicatedhq/ship/pkg/version.version={{.Version}}
     -X github.com/replicatedhq/ship/pkg/version.gitSHA={{.Commit}}
     -X github.com/replicatedhq/ship/pkg/version.buildTime={{.Date}}
+    -X github.com/replicatedhq/ship/pkg/version.helm=2.13.0
+    -X github.com/replicatedhq/ship/pkg/version.kustomize=2.0.2
+    -X github.com/replicatedhq/ship/pkg/version.terraform=v0.11.13
     -extldflags "-static"
   flags: -tags netgo -installsuffix netgo
   binary: ship

--- a/deploy/.goreleaser.yml
+++ b/deploy/.goreleaser.yml
@@ -27,8 +27,8 @@ builds:
     -X github.com/replicatedhq/ship/pkg/version.version={{.Version}}
     -X github.com/replicatedhq/ship/pkg/version.gitSHA={{.Commit}}
     -X github.com/replicatedhq/ship/pkg/version.buildTime={{.Date}}
-    -X github.com/replicatedhq/ship/pkg/version.helm=2.13.0
-    -X github.com/replicatedhq/ship/pkg/version.kustomize=2.0.2
+    -X github.com/replicatedhq/ship/pkg/version.helm=v2.13.0
+    -X github.com/replicatedhq/ship/pkg/version.kustomize=v2.0.2
     -X github.com/replicatedhq/ship/pkg/version.terraform=v0.11.13
     -extldflags "-static"
   flags: -tags netgo -installsuffix netgo

--- a/deploy/.goreleaser.yml
+++ b/deploy/.goreleaser.yml
@@ -27,6 +27,9 @@ builds:
     -X github.com/replicatedhq/ship/pkg/version.version={{.Version}}
     -X github.com/replicatedhq/ship/pkg/version.gitSHA={{.Commit}}
     -X github.com/replicatedhq/ship/pkg/version.buildTime={{.Date}}
+    -X github.com/replicatedhq/ship/pkg/version.helm=2.13.0
+    -X github.com/replicatedhq/ship/pkg/version.kustomize=2.0.2
+    -X github.com/replicatedhq/ship/pkg/version.terraform=v0.11.13
     -extldflags "-static"
   flags: -tags netgo -installsuffix netgo
   binary: ship

--- a/pkg/version/build.go
+++ b/pkg/version/build.go
@@ -4,4 +4,5 @@ package version
 
 var (
 	version, gitSHA, buildTime string
+	helm, kustomize, terraform string
 )

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,10 +8,17 @@ var (
 
 // Build holds details about this build of the Ship binary
 type Build struct {
-	Version      string    `json:"version,omitempty"`
-	GitSHA       string    `json:"git,omitempty"`
-	BuildTime    time.Time `json:"buildTime,omitempty"`
-	TimeFallback string    `json:"buildTimeFallback,omitempty"`
+	Version      string            `json:"version,omitempty"`
+	GitSHA       string            `json:"git,omitempty"`
+	BuildTime    time.Time         `json:"buildTime,omitempty"`
+	TimeFallback string            `json:"buildTimeFallback,omitempty"`
+	Dependencies BuildDependencies `json:"dependencies,omitempty"`
+}
+
+type BuildDependencies struct {
+	Helm      string `json:"helm,omitempty"`
+	Kustomize string `json:"kustomize,omitempty"`
+	Terraform string `json:"terraform,omitempty"`
 }
 
 // Init sets up the version info from build args
@@ -25,6 +32,13 @@ func Init() {
 	if err != nil {
 		build.TimeFallback = buildTime
 	}
+
+	deps := BuildDependencies{
+		Helm:      helm,
+		Kustomize: kustomize,
+		Terraform: terraform,
+	}
+	build.Dependencies = deps
 }
 
 // GetBuild gets the build


### PR DESCRIPTION
What I Did
------------
Added helm, kustomize and terraform versions to the `ship version` command - see #915 

How I Did it
------------
For now, these versions are hardcoded as part of the build scripts - this should be updated in the future

How to verify it
------------
run `ship version` and observe the output:
```
{
    "version": "v0.40.0-10-gf22ebeeb",
    "git": "f22ebee",
    "buildTime": "2019-04-19T18:24:38Z",
    "dependencies": {
        "helm": "v2.13.0",
        "kustomize": "v2.0.2",
        "terraform": "v0.11.13"
    }
}
```

Description for the Changelog
------------
`ship version` includes the versions of some dependencies


Picture of a Ship (not required but encouraged)
------------

![USS LST-916](https://upload.wikimedia.org/wikipedia/commons/8/8b/USS_LST-916_Philippines_1946.jpg "USS LST-916")










<!-- (thanks https://github.com/docker/docker for this template) -->

