### PR TITLE
include the gin logs in the debug.log file

### DIFF
--- a/pkg/lifecycle/daemon/daemon.go
+++ b/pkg/lifecycle/daemon/daemon.go
@@ -65,8 +65,7 @@ func (d *ShipDaemon) Serve(ctx context.Context, release *api.Release) error {
 
 	g := gin.New()
 
-	ginLogger := level.Debug(log.With(d.Logger, "gin", "serve"))
-	logWriter := loggerWriter(ginLogger)
+	logWriter := loggerWriter(d.Logger)
 	g.Use(gin.LoggerWithWriter(logWriter))
 
 	g.Use(cors.New(config))
@@ -173,9 +172,9 @@ func loggerWriter(ginLog log.Logger) *io.PipeWriter {
 	go func(bufReader *bufio.Reader, ginLog log.Logger) {
 		for {
 			line, err := bufReader.ReadString('\n')
-			ginLog.Log(line)
+			level.Info(ginLog).Log("event", "gin.log", line, "line")
 			if err != nil {
-				ginLog.Log(err.Error())
+				level.Error(ginLog).Log("event", "gin.log", err, "err")
 				return
 			}
 		}


### PR DESCRIPTION
What I Did
------------
Included the logs produced by gin in the `debug.log` file

How I Did it
------------
By providing a custom logging destination to the gin logging middleware

How to verify it
------------


Description for the Changelog
------------
`.ship/debug.log` includes gin logs


Picture of a Ship (not required but encouraged)
------------
![USS LST-918](https://upload.wikimedia.org/wikipedia/commons/e/ed/USS_LST-918.jpg "USS LST-918")











<!-- (thanks https://github.com/docker/docker for this template) -->

