### PR TITLE
Showing selected files on ship update

### DIFF
--- a/web/init/package.json
+++ b/web/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replicatedhq/ship-init",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Shared component that contains the Ship Init app",
   "author": "Replicated, Inc.",
   "license": "Apache-2.0",

--- a/web/init/src/components/config_render/ConfigFileInput.jsx
+++ b/web/init/src/components/config_render/ConfigFileInput.jsx
@@ -48,6 +48,7 @@ export default class ConfigFileInput extends React.Component {
                 ref={(file) => this.file = file}
                 name={this.props.name}
                 title={this.props.title}
+                value={this.props.value}
                 readOnly={this.props.readonly}
                 disabled={this.props.readonly}
                 multiple={this.props.multiple}

--- a/web/init/src/components/config_render/FileInput.jsx
+++ b/web/init/src/components/config_render/FileInput.jsx
@@ -65,7 +65,7 @@ export default class FileInput extends React.Component {
         <div className={`${this.props.readonly ? "readonly" : ""} ${this.props.disabled ? "disabled" : ""}`}>
           <p className="sub-header-color field-section-sub-header u-marginTop--small u-marginBottom--small u-marginTop--15">{label}</p>
           <div className="flex flex-row">
-            <div className={`${this.state.fileAdded ? "file-uploaded" : "custom-file-upload"}`}>
+            <div className={`${this.state.fileAdded || this.props.value ? "file-uploaded" : "custom-file-upload"}`}>
               <input
                 ref={(file) => this.file = file}
                 type="file"
@@ -74,15 +74,15 @@ export default class FileInput extends React.Component {
                 id={`${this.props.name} selector`}
                 onChange={this.handleOnChange}
                 readOnly={this.props.readOnly}
-                multiple={true}
+                multiple={this.props.multiple}
                 disabled={this.props.disabled}
               />
               <label htmlFor={`${this.props.name} selector`} className="u-position--relative">
-                <span className={`icon clickable ${this.state.fileAdded ? "u-smallCheckGreen" : "u-ovalIcon"} u-marginRight--normal u-top--3`}></span>
-                {this.state.fileAdded ? `${this.props.title} file selected` : `Browse files for ${this.props.title}`}
+                <span className={`icon clickable ${this.state.fileAdded || this.props.value ? "u-smallCheckGreen" : "u-ovalIcon"} u-marginRight--normal u-top--3`}></span>
+                {this.state.fileAdded || this.props.value ? `${this.props.title} file selected` : `Browse files for ${this.props.title}`}
               </label>
             </div>
-            {this.state.fileAdded ?
+            {this.state.fileAdded || this.props.value ?
               <div className="u-color--tuna u-marginLeft--normal"> File uploaded:
               <p className="Form-label-subtext"> {this.props.multiple ? this.state.fileNames.join(",") : this.state.fileName} </p>
                 <p className="Form-label-subtext"> {this.props.getFilenamesText} </p>


### PR DESCRIPTION
What I Did
------------
Config item type file showing selected files on ship update 

How I Did it
------------
Using value from props which is showing that file was previously selected.

How to verify it
------------
In your ship yaml into the config section add:
` - name: tls_cert
    title: TLS Cert
    type: file
    required: true`
Run ship init step.
When that's done run ship update. On config step you should see selected files

Description for the Changelog
------------
Config item type file showing selected files on ship update 


Picture of a Ship (not required but encouraged)
------------
![image](https://user-images.githubusercontent.com/25138806/56683636-c9dd0e80-6682-11e9-8231-ce67eee5e88f.png)











<!-- (thanks https://github.com/docker/docker for this template) -->

