### PR TITLE
make the state manager safe to use in parallel

### DIFF
--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -92,12 +92,12 @@ func (m *MManager) StateUpdate(updater Update) (State, error) {
 
 	currentState, err := m.TryLoad()
 	if err != nil {
-		return VersionedState{}, errors.Wrap(err, "tryLoad in safe updater")
+		return nil, errors.Wrap(err, "tryLoad in safe updater")
 	}
 
 	updatedState, err := updater(currentState.Versioned())
 	if err != nil {
-		return VersionedState{}, errors.Wrap(err, "run state update function in safe updater")
+		return nil, errors.Wrap(err, "run state update function in safe updater")
 	}
 
 	return updatedState, errors.Wrap(m.serializeAndWriteState(updatedState), "write state in safe updater")

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -31,6 +32,8 @@ type Manager interface {
 		templateContext map[string]interface{},
 	) error
 	TryLoad() (State, error)
+	SafeStateUpdate(updater StateUpdate) error
+	SafeStateUpdateReturn(updater StateUpdate) (State, error)
 	RemoveStateFile() error
 	SaveKustomize(kustomize *Kustomize) error
 	SerializeUpstream(URL string) error
@@ -55,10 +58,17 @@ type MManager struct {
 	FS      afero.Afero
 	V       *viper.Viper
 	patcher patch.Patcher
+	mut     sync.Mutex
 }
 
 func (m *MManager) Save(v VersionedState) error {
-	return m.serializeAndWriteState(v)
+	debug := level.Debug(log.With(m.Logger, "method", "SerializeShipMetadata"))
+
+	debug.Log("event", "safeStateUpdate")
+	return m.SafeStateUpdate(func(state VersionedState) (VersionedState, error) {
+		state = v
+		return state, nil
+	})
 }
 
 func NewManager(
@@ -73,200 +83,179 @@ func NewManager(
 	}
 }
 
+type StateUpdate func(VersionedState) (VersionedState, error)
+
+// applies the provided updater to the current state. Returns error
+func (m *MManager) SafeStateUpdate(updater StateUpdate) error {
+	_, err := m.SafeStateUpdateReturn(updater)
+	return err
+}
+
+// applies the provided updater to the current state. Returns the new state and err
+func (m *MManager) SafeStateUpdateReturn(updater StateUpdate) (State, error) {
+	m.mut.Lock()
+	defer m.mut.Unlock()
+
+	currentState, err := m.TryLoad()
+	if err != nil {
+		return VersionedState{}, errors.Wrap(err, "tryLoad in safe updater")
+	}
+
+	updatedState, err := updater(currentState.Versioned())
+	if err != nil {
+		return VersionedState{}, errors.Wrap(err, "run state update function in safe updater")
+	}
+
+	return updatedState, errors.Wrap(m.serializeAndWriteState(updatedState), "write state in safe updater")
+}
+
 // SerializeShipMetadata is used by `ship init` to serialize metadata from ship applications to state file
 func (m *MManager) SerializeShipMetadata(metadata api.ShipAppMetadata, applicationType string) error {
 	debug := level.Debug(log.With(m.Logger, "method", "SerializeShipMetadata"))
 
-	debug.Log("event", "tryLoadState")
-	current, err := m.TryLoad()
-	if err != nil {
-		return errors.Wrap(err, "load state")
-	}
-
-	versionedState := current.Versioned()
-	versionedState.V1.Metadata = &Metadata{
-		ApplicationType: applicationType,
-		ReleaseNotes:    metadata.ReleaseNotes,
-		Version:         metadata.Version,
-		Icon:            metadata.Icon,
-		Name:            metadata.Name,
-	}
-
-	return m.serializeAndWriteState(versionedState)
+	debug.Log("event", "safeStateUpdate")
+	return m.SafeStateUpdate(func(state VersionedState) (VersionedState, error) {
+		state.V1.Metadata = &Metadata{
+			ApplicationType: applicationType,
+			ReleaseNotes:    metadata.ReleaseNotes,
+			Version:         metadata.Version,
+			Icon:            metadata.Icon,
+			Name:            metadata.Name,
+		}
+		return state, nil
+	})
 }
 
 // SerializeAppMetadata is used by `ship app` to serialize replicated app metadata to state file
 func (m *MManager) SerializeAppMetadata(metadata api.ReleaseMetadata) error {
 	debug := level.Debug(log.With(m.Logger, "method", "SerializeAppMetadata"))
 
-	debug.Log("event", "tryLoadState")
-	current, err := m.TryLoad()
-	if err != nil {
-		return errors.Wrap(err, "load state")
-	}
-
-	versionedState := current.Versioned()
-	versionedState.V1.Metadata = &Metadata{
-		ApplicationType: "replicated.app",
-		ReleaseNotes:    metadata.ReleaseNotes,
-		Version:         metadata.Semver,
-		CustomerID:      metadata.CustomerID,
-		InstallationID:  metadata.InstallationID,
-		LicenseID:       metadata.LicenseID,
-		AppSlug:         metadata.AppSlug,
-		License: License{
-			ID:        metadata.License.ID,
-			Assignee:  metadata.License.Assignee,
-			CreatedAt: metadata.License.CreatedAt,
-			ExpiresAt: metadata.License.ExpiresAt,
-			Type:      metadata.License.Type,
-		},
-	}
-
-	return m.serializeAndWriteState(versionedState)
+	debug.Log("event", "safeStateUpdate")
+	return m.SafeStateUpdate(func(state VersionedState) (VersionedState, error) {
+		state.V1.Metadata = &Metadata{
+			ApplicationType: "replicated.app",
+			ReleaseNotes:    metadata.ReleaseNotes,
+			Version:         metadata.Semver,
+			CustomerID:      metadata.CustomerID,
+			InstallationID:  metadata.InstallationID,
+			LicenseID:       metadata.LicenseID,
+			AppSlug:         metadata.AppSlug,
+			License: License{
+				ID:        metadata.License.ID,
+				Assignee:  metadata.License.Assignee,
+				CreatedAt: metadata.License.CreatedAt,
+				ExpiresAt: metadata.License.ExpiresAt,
+				Type:      metadata.License.Type,
+			},
+		}
+		return state, nil
+	})
 }
 
 // SerializeUpstream is used by `ship init` to serialize a state file with ChartURL to disk
 func (m *MManager) SerializeUpstream(upstream string) error {
 	debug := level.Debug(log.With(m.Logger, "method", "SerializeUpstream"))
 
-	current, err := m.TryLoad()
-	if err != nil {
-		return errors.Wrap(err, "load state")
-	}
-	debug.Log("event", "generateUpstreamURLState")
-
-	toSerialize := current.Versioned()
-	toSerialize.V1.Upstream = upstream
-
-	return m.serializeAndWriteState(toSerialize)
+	debug.Log("event", "safeStateUpdate")
+	return m.SafeStateUpdate(func(state VersionedState) (VersionedState, error) {
+		state.V1.Upstream = upstream
+		return state, nil
+	})
 }
 
 // SerializeContentSHA writes the contentSHA to the state file
 func (m *MManager) SerializeContentSHA(contentSHA string) error {
 	debug := level.Debug(log.With(m.Logger, "method", "SerializeContentSHA"))
 
-	debug.Log("event", "tryLoadState")
-	currentState, err := m.TryLoad()
-	if err != nil {
-		return errors.Wrap(err, "try load state")
-	}
-	versionedState := currentState.Versioned()
-	versionedState.V1.ContentSHA = contentSHA
-
-	return m.serializeAndWriteState(versionedState)
+	debug.Log("event", "safeStateUpdate")
+	return m.SafeStateUpdate(func(state VersionedState) (VersionedState, error) {
+		state.V1.ContentSHA = contentSHA
+		return state, nil
+	})
 }
 
 // SerializeHelmValues takes user input helm values and serializes a state file to disk
 func (m *MManager) SerializeHelmValues(values string, defaults string) error {
 	debug := level.Debug(log.With(m.Logger, "method", "serializeHelmValues"))
 
-	debug.Log("event", "tryLoadState")
-	currentState, err := m.TryLoad()
-	if err != nil {
-		return errors.Wrap(err, "try load state")
-	}
-	versionedState := currentState.Versioned()
-	versionedState.V1.HelmValues = values
-	versionedState.V1.HelmValuesDefaults = defaults
-
-	return m.serializeAndWriteState(versionedState)
+	debug.Log("event", "safeStateUpdate")
+	return m.SafeStateUpdate(func(state VersionedState) (VersionedState, error) {
+		state.V1.HelmValues = values
+		state.V1.HelmValuesDefaults = defaults
+		return state, nil
+	})
 }
 
 // SerializeReleaseName serializes to disk the name to use for helm template
 func (m *MManager) SerializeReleaseName(name string) error {
-	debug := level.Debug(log.With(m.Logger, "method", "serializeHelmValues"))
+	debug := level.Debug(log.With(m.Logger, "method", "serializeReleaseName"))
 
-	debug.Log("event", "tryLoadState")
-	currentState, err := m.TryLoad()
-	if err != nil {
-		return errors.Wrap(err, "try load state")
-	}
-	versionedState := currentState.Versioned()
-	versionedState.V1.ReleaseName = name
-
-	return m.serializeAndWriteState(versionedState)
+	debug.Log("event", "safeStateUpdate")
+	return m.SafeStateUpdate(func(state VersionedState) (VersionedState, error) {
+		state.V1.ReleaseName = name
+		return state, nil
+	})
 }
 
 // SerializeNamespace serializes to disk the namespace to use for helm template
 func (m *MManager) SerializeNamespace(namespace string) error {
-	debug := level.Debug(log.With(m.Logger, "method", "serializeHelmValues"))
+	debug := level.Debug(log.With(m.Logger, "method", "serializeNamespace"))
 
-	debug.Log("event", "tryLoadState")
-	currentState, err := m.TryLoad()
-	if err != nil {
-		return errors.Wrap(err, "try load state")
-	}
-	versionedState := currentState.Versioned()
-	versionedState.V1.Namespace = namespace
-
-	return m.serializeAndWriteState(versionedState)
+	debug.Log("event", "safeStateUpdate")
+	return m.SafeStateUpdate(func(state VersionedState) (VersionedState, error) {
+		state.V1.Namespace = namespace
+		return state, nil
+	})
 }
 
 // SerializeConfig takes the application data and input params and serializes a state file to disk
 func (m *MManager) SerializeConfig(assets []api.Asset, meta api.ReleaseMetadata, templateContext map[string]interface{}) error {
 	debug := level.Debug(log.With(m.Logger, "method", "serializeConfig"))
 
-	debug.Log("event", "tryLoadState")
-	currentState, err := m.TryLoad()
-	if err != nil {
-		return errors.Wrap(err, "try load state")
-	}
-	versionedState := currentState.Versioned()
-	versionedState.V1.Config = templateContext
-
-	return m.serializeAndWriteState(versionedState)
+	debug.Log("event", "safeStateUpdate")
+	return m.SafeStateUpdate(func(state VersionedState) (VersionedState, error) {
+		state.V1.Config = templateContext
+		return state, nil
+	})
 }
 
 func (m *MManager) SerializeListsMetadata(list util.List) error {
 	debug := level.Debug(log.With(m.Logger, "method", "serializeListMetadata"))
 
-	debug.Log("event", "tryLoadState")
-	currentState, err := m.TryLoad()
-	if err != nil {
-		return errors.Wrap(err, "try load state")
-	}
-
-	versionedState := currentState.Versioned()
-	if versionedState.V1.Metadata == nil {
-		versionedState.V1.Metadata = &Metadata{}
-	}
-	versionedState.V1.Metadata.Lists = append(versionedState.V1.Metadata.Lists, list)
-
-	return m.serializeAndWriteState(versionedState)
+	debug.Log("event", "safeStateUpdate")
+	return m.SafeStateUpdate(func(state VersionedState) (VersionedState, error) {
+		if state.V1.Metadata == nil {
+			state.V1.Metadata = &Metadata{}
+		}
+		state.V1.Metadata.Lists = append(state.V1.Metadata.Lists, list)
+		return state, nil
+	})
 }
 
 func (m *MManager) ClearListsMetadata() error {
-	debug := level.Debug(log.With(m.Logger, "method", "serializeListMetadata"))
+	debug := level.Debug(log.With(m.Logger, "method", "clearListMetadata"))
 
-	debug.Log("event", "tryLoadState")
-	currentState, err := m.TryLoad()
-	if err != nil {
-		return errors.Wrap(err, "try load state")
-	}
+	debug.Log("event", "safeStateUpdate")
+	return m.SafeStateUpdate(func(state VersionedState) (VersionedState, error) {
+		if state.V1.Metadata == nil {
+			return state, nil
+		}
 
-	versionedState := currentState.Versioned()
-	if versionedState.V1.Metadata == nil {
-		return nil
-	}
-	versionedState.V1.Metadata.Lists = []util.List{}
-
-	return m.serializeAndWriteState(versionedState)
+		state.V1.Metadata.Lists = []util.List{}
+		return state, nil
+	})
 }
 
 // SerializeConfig takes the application data and input params and serializes a state file to disk
 func (m *MManager) SerializeUpstreamContents(contents *UpstreamContents) error {
-	debug := level.Debug(log.With(m.Logger, "method", "serializeConfig"))
+	debug := level.Debug(log.With(m.Logger, "method", "serializeUpstreamContents"))
 
-	debug.Log("event", "tryLoadState")
-	currentState, err := m.TryLoad()
-	if err != nil {
-		return errors.Wrap(err, "try load state")
-	}
-	versionedState := currentState.Versioned()
-	versionedState.V1.UpstreamContents = contents
+	debug.Log("event", "safeStateUpdate")
+	return m.SafeStateUpdate(func(state VersionedState) (VersionedState, error) {
 
-	return m.serializeAndWriteState(versionedState)
+		state.V1.UpstreamContents = contents
+		return state, nil
+	})
 }
 
 // TryLoad will attempt to load a state file from disk, if present
@@ -294,15 +283,12 @@ func (m *MManager) TryLoad() (State, error) {
 func (m *MManager) ResetLifecycle() error {
 	debug := level.Debug(log.With(m.Logger, "method", "ResetLifecycle"))
 
-	debug.Log("event", "tryLoadState")
-	currentState, err := m.TryLoad()
-	if err != nil {
-		return errors.Wrap(err, "try load state")
-	}
-	versionedState := currentState.Versioned()
-	versionedState.V1.Lifecycle = nil
+	debug.Log("event", "safeStateUpdate")
+	return m.SafeStateUpdate(func(state VersionedState) (VersionedState, error) {
 
-	return m.serializeAndWriteState(versionedState)
+		state.V1.Lifecycle = nil
+		return state, nil
+	})
 }
 
 // tryLoadFromSecret will attempt to load the state from a secret
@@ -406,18 +392,14 @@ func (m *MManager) tryLoadFromFile() (State, error) {
 }
 
 func (m *MManager) SaveKustomize(kustomize *Kustomize) error {
-	currentState, err := m.TryLoad()
-	if err != nil {
-		return errors.Wrapf(err, "load state")
-	}
-	versionedState := currentState.Versioned()
-	versionedState.V1.Kustomize = kustomize
+	debug := level.Debug(log.With(m.Logger, "method", "SaveKustomize"))
 
-	if err := m.serializeAndWriteState(versionedState); err != nil {
-		return errors.Wrap(err, "write state")
-	}
+	debug.Log("event", "safeStateUpdate")
+	return m.SafeStateUpdate(func(state VersionedState) (VersionedState, error) {
 
-	return nil
+		state.V1.Kustomize = kustomize
+		return state, nil
+	})
 }
 
 // RemoveStateFile will attempt to remove the state file from disk
@@ -512,36 +494,35 @@ func (m *MManager) serializeAndWriteStateSecret(state VersionedState) error {
 }
 
 func (m *MManager) AddCert(name string, newCert util.CertType) error {
-	currentState, err := m.TryLoad()
-	if err != nil {
-		return errors.Wrapf(err, "load state")
-	}
-	versionedState := currentState.Versioned()
-	if versionedState.V1.Certs == nil {
-		versionedState.V1.Certs = make(map[string]util.CertType)
-	}
-	if _, ok := versionedState.V1.Certs[name]; ok {
-		return fmt.Errorf("cert with name %s already exists in state", name)
-	}
-	versionedState.V1.Certs[name] = newCert
+	debug := level.Debug(log.With(m.Logger, "method", "SaveKustomize"))
 
-	return errors.Wrap(m.serializeAndWriteState(versionedState), "write state")
+	debug.Log("event", "safeStateUpdate")
+	return m.SafeStateUpdate(func(state VersionedState) (VersionedState, error) {
+
+		if state.V1.Certs == nil {
+			state.V1.Certs = make(map[string]util.CertType)
+		}
+		if _, ok := state.V1.Certs[name]; ok {
+			return state, fmt.Errorf("cert with name %s already exists in state", name)
+		}
+		state.V1.Certs[name] = newCert
+		return state, nil
+	})
 }
 
 func (m *MManager) AddCA(name string, newCA util.CAType) error {
-	currentState, err := m.TryLoad()
-	if err != nil {
-		return errors.Wrapf(err, "load state")
-	}
-	versionedState := currentState.Versioned()
-	if versionedState.V1.CAs == nil {
-		versionedState.V1.CAs = make(map[string]util.CAType)
-	}
-	if _, ok := versionedState.V1.CAs[name]; ok {
-		return fmt.Errorf("cert with name %s already exists in state", name)
-	}
-	versionedState.V1.CAs[name] = newCA
+	debug := level.Debug(log.With(m.Logger, "method", "SaveKustomize"))
 
-	return errors.Wrap(m.serializeAndWriteState(versionedState), "write state")
+	debug.Log("event", "safeStateUpdate")
+	return m.SafeStateUpdate(func(state VersionedState) (VersionedState, error) {
 
+		if state.V1.CAs == nil {
+			state.V1.CAs = make(map[string]util.CAType)
+		}
+		if _, ok := state.V1.CAs[name]; ok {
+			return state, fmt.Errorf("cert with name %s already exists in state", name)
+		}
+		state.V1.CAs[name] = newCA
+		return state, nil
+	})
 }

--- a/pkg/state/manager_test.go
+++ b/pkg/state/manager_test.go
@@ -96,11 +96,7 @@ func TestLoadConfig(t *testing.T) {
 				req.NoError(err, "write existing state")
 			}
 
-			manager := &MManager{
-				Logger: &logger.TestLogger{T: t},
-				FS:     fs,
-				V:      viper.New(),
-			}
+			manager := NewManager(&logger.TestLogger{T: t}, fs, viper.New())
 
 			state, err := manager.TryLoad()
 			req.NoError(err)
@@ -158,11 +154,7 @@ func TestHelmValue(t *testing.T) {
 			req := require.New(t)
 			fs := afero.Afero{Fs: afero.NewMemMapFs()}
 
-			manager := &MManager{
-				Logger: &logger.TestLogger{T: t},
-				FS:     fs,
-				V:      viper.New(),
-			}
+			manager := NewManager(&logger.TestLogger{T: t}, fs, viper.New())
 
 			err := manager.SerializeHelmValues(test.userInputValues, test.chartValuesOnInit)
 			req.NoError(err)
@@ -235,7 +227,7 @@ func TestMManager_SerializeChartURL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
 			m := &MManager{
-				Logger: log.NewNopLogger(),
+				Logger: &logger.TestLogger{T: t},
 				FS:     afero.Afero{Fs: afero.NewMemMapFs()},
 				V:      viper.New(),
 			}
@@ -312,7 +304,7 @@ func TestMManager_SerializeContentSHA(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
 			m := &MManager{
-				Logger: log.NewNopLogger(),
+				Logger: &logger.TestLogger{T: t},
 				FS:     afero.Afero{Fs: afero.NewMemMapFs()},
 				V:      viper.New(),
 			}
@@ -390,7 +382,7 @@ func TestMManager_SerializeHelmValues(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
 			m := &MManager{
-				Logger: log.NewNopLogger(),
+				Logger: &logger.TestLogger{T: t},
 				FS:     afero.Afero{Fs: afero.NewMemMapFs()},
 				V:      viper.New(),
 			}
@@ -448,7 +440,7 @@ func TestMManager_SerializeShipMetadata(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
 			m := &MManager{
-				Logger: log.NewNopLogger(),
+				Logger: &logger.TestLogger{T: t},
 				FS:     afero.Afero{Fs: afero.NewMemMapFs()},
 				V:      viper.New(),
 			}
@@ -501,7 +493,7 @@ func TestMManager_ResetLifecycle(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
 			m := &MManager{
-				Logger: log.NewNopLogger(),
+				Logger: &logger.TestLogger{T: t},
 				FS:     afero.Afero{Fs: afero.NewMemMapFs()},
 				V:      viper.New(),
 			}
@@ -543,6 +535,79 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 			},
 		},
 		{
+			name: "emptied lists",
+			runners: []func(*MManager, *require.Assertions, *sync.WaitGroup){
+				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
+					err := m.ClearListsMetadata()
+					req.NoError(err)
+
+					// add the integers 1-20 to the list
+					for i := 1; i <= 20; i++ {
+						err := m.SerializeListsMetadata(util.List{APIVersion: fmt.Sprintf("%d", i)})
+						req.NoError(err)
+					}
+
+					err = m.ClearListsMetadata()
+					req.NoError(err)
+
+					group.Done()
+				},
+			},
+			validator: func(state VersionedState, req *require.Assertions) {
+				req.Len(state.V1.Metadata.Lists, 0)
+			},
+		},
+		{
+			name: "lists and app metadata",
+			runners: []func(*MManager, *require.Assertions, *sync.WaitGroup){
+				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
+					// add the integers 1-20 to the list
+					for i := 1; i <= 20; i++ {
+						err := m.SerializeListsMetadata(util.List{APIVersion: fmt.Sprintf("%d", i)})
+						req.NoError(err)
+					}
+					group.Done()
+				},
+				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
+					err := m.SerializeAppMetadata(api.ReleaseMetadata{Semver: "tested"})
+					req.NoError(err)
+					group.Done()
+				},
+			},
+			validator: func(state VersionedState, req *require.Assertions) {
+				req.Len(state.V1.Metadata.Lists, 20)
+				req.Equal("tested", state.V1.Metadata.Version)
+			},
+		},
+		{
+			name: "lists, release name and namespace",
+			runners: []func(*MManager, *require.Assertions, *sync.WaitGroup){
+				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
+					// add the integers 1-20 to the list
+					for i := 1; i <= 20; i++ {
+						err := m.SerializeListsMetadata(util.List{APIVersion: fmt.Sprintf("%d", i)})
+						req.NoError(err)
+					}
+					group.Done()
+				},
+				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
+					err := m.SerializeReleaseName("testedName")
+					req.NoError(err)
+					group.Done()
+				},
+				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
+					err := m.SerializeNamespace("testedNS")
+					req.NoError(err)
+					group.Done()
+				},
+			},
+			validator: func(state VersionedState, req *require.Assertions) {
+				req.Len(state.V1.Metadata.Lists, 20)
+				req.Equal("testedName", state.CurrentReleaseName())
+				req.Equal("testedNS", state.CurrentNamespace())
+			},
+		},
+		{
 			name: "lists and upstream",
 			runners: []func(*MManager, *require.Assertions, *sync.WaitGroup){
 				// lists
@@ -558,7 +623,7 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
 					// append the integers 1-200 to the upstream
 					for i := 1; i <= 200; i++ {
-						err := m.SafeStateUpdate(func(state VersionedState) (VersionedState, error) {
+						err := m.StateUpdate(func(state VersionedState) (VersionedState, error) {
 							state.V1.Upstream += fmt.Sprintf(" a:%d ", i)
 							return state, nil
 						})
@@ -570,7 +635,7 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
 					// append the integers 1-200 to the upstream
 					for i := 1; i <= 200; i++ {
-						err := m.SafeStateUpdate(func(state VersionedState) (VersionedState, error) {
+						err := m.StateUpdate(func(state VersionedState) (VersionedState, error) {
 							state.V1.Upstream += fmt.Sprintf(" b:%d ", i)
 							return state, nil
 						})
@@ -582,7 +647,7 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
 					// append the integers 1-200 to the upstream
 					for i := 1; i <= 200; i++ {
-						err := m.SafeStateUpdate(func(state VersionedState) (VersionedState, error) {
+						err := m.StateUpdate(func(state VersionedState) (VersionedState, error) {
 							state.V1.Upstream += fmt.Sprintf(" c:%d ", i)
 							return state, nil
 						})
@@ -594,7 +659,7 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
 					// append the integers 1-200 to the upstream
 					for i := 1; i <= 200; i++ {
-						err := m.SafeStateUpdate(func(state VersionedState) (VersionedState, error) {
+						err := m.StateUpdate(func(state VersionedState) (VersionedState, error) {
 							state.V1.Upstream += fmt.Sprintf(" d:%d ", i)
 							return state, nil
 						})
@@ -606,7 +671,7 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
 					// append the integers 1-200 to the upstream
 					for i := 1; i <= 200; i++ {
-						err := m.SafeStateUpdate(func(state VersionedState) (VersionedState, error) {
+						err := m.StateUpdate(func(state VersionedState) (VersionedState, error) {
 							state.V1.Upstream += fmt.Sprintf(" e:%d ", i)
 							return state, nil
 						})
@@ -626,6 +691,70 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "certs and keys",
+			runners: []func(*MManager, *require.Assertions, *sync.WaitGroup){
+				// first cert mutator
+				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
+					// append 100 certs to the cert list
+					for i := 1; i <= 100; i++ {
+						err := m.AddCert(fmt.Sprintf(" a:%d ", i), util.CertType{})
+						req.NoError(err)
+					}
+					group.Done()
+				},
+				// second cert mutator
+				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
+					// append 100 certs to the cert list
+					for i := 1; i <= 100; i++ {
+						err := m.AddCert(fmt.Sprintf(" b:%d ", i), util.CertType{})
+						req.NoError(err)
+					}
+					group.Done()
+				},
+				// third cert mutator
+				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
+					// append 100 certs to the cert list
+					for i := 1; i <= 100; i++ {
+						err := m.AddCert(fmt.Sprintf(" c:%d ", i), util.CertType{})
+						req.NoError(err)
+					}
+					group.Done()
+				},
+				// first ca mutator
+				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
+					// append 100 CAs to the CA list
+					for i := 1; i <= 100; i++ {
+						err := m.AddCA(fmt.Sprintf(" a:%d ", i), util.CAType{})
+						req.NoError(err)
+					}
+					group.Done()
+				},
+				// second ca mutator
+				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
+					// append 100 CAs to the CA list
+					for i := 1; i <= 100; i++ {
+						err := m.AddCA(fmt.Sprintf(" b:%d ", i), util.CAType{})
+						req.NoError(err)
+					}
+					group.Done()
+				},
+			},
+			validator: func(state VersionedState, req *require.Assertions) {
+				totalCAs := state.CurrentCAs()
+				for _, str := range []string{"a", "b"} {
+					for i := 1; i <= 100; i++ {
+						req.Contains(totalCAs, fmt.Sprintf(" %s:%d ", str, i))
+					}
+				}
+				totalCerts := state.CurrentCerts()
+				for _, str := range []string{"a", "b", "c"} {
+					for i := 1; i <= 100; i++ {
+						req.Contains(totalCerts, fmt.Sprintf(" %s:%d ", str, i))
+					}
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -633,7 +762,7 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 
 			req := require.New(t)
 			m := &MManager{
-				Logger: log.NewNopLogger(),
+				Logger: &logger.TestLogger{T: t},
 				FS:     afero.Afero{Fs: afero.NewMemMapFs()},
 				V:      viper.New(),
 			}
@@ -657,5 +786,202 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 			tt.validator(actualState.Versioned(), req)
 		})
 	}
+}
 
+func TestMManager_AddCA(t *testing.T) {
+	tests := []struct {
+		name     string
+		caName   string
+		newCA    util.CAType
+		wantErr  bool
+		before   VersionedState
+		expected VersionedState
+	}{
+		{
+			name:   "basic test",
+			caName: "aCA",
+			newCA:  util.CAType{Cert: "aCert", Key: "aKey"},
+			before: VersionedState{
+				V1: &V1{
+					Upstream: "abc123",
+				},
+			},
+			expected: VersionedState{
+				V1: &V1{
+					Upstream: "abc123",
+					CAs: map[string]util.CAType{
+						"aCA": {Cert: "aCert", Key: "aKey"},
+					},
+				},
+			},
+		},
+		{
+			name:   "add to existing",
+			caName: "bCA",
+			newCA:  util.CAType{Cert: "bCert", Key: "bKey"},
+			before: VersionedState{
+				V1: &V1{
+					Upstream: "abc123",
+					CAs: map[string]util.CAType{
+						"aCA": {Cert: "aCert", Key: "aKey"},
+					},
+				},
+			},
+			expected: VersionedState{
+				V1: &V1{
+					Upstream: "abc123",
+					CAs: map[string]util.CAType{
+						"aCA": {Cert: "aCert", Key: "aKey"},
+						"bCA": {Cert: "bCert", Key: "bKey"},
+					},
+				},
+			},
+		},
+		{
+			name:    "colliding ca names",
+			wantErr: true,
+			caName:  "aCA",
+			newCA:   util.CAType{Cert: "aCert", Key: "aKey"},
+			before: VersionedState{
+				V1: &V1{
+					Upstream: "abc123",
+					CAs: map[string]util.CAType{
+						"aCA": {Cert: "aCert", Key: "aKey"},
+					},
+				},
+			},
+			expected: VersionedState{
+				V1: &V1{
+					Upstream: "abc123",
+					CAs: map[string]util.CAType{
+						"aCA": {Cert: "aCert", Key: "aKey"},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+			m := &MManager{
+				Logger: &logger.TestLogger{T: t},
+				FS:     afero.Afero{Fs: afero.NewMemMapFs()},
+				V:      viper.New(),
+			}
+
+			err := m.serializeAndWriteState(tt.before)
+			req.NoError(err)
+
+			err = m.AddCA(tt.caName, tt.newCA)
+			if !tt.wantErr {
+				req.NoError(err, "MManager.AddCA() error = %v", err)
+			} else {
+				req.Error(err)
+			}
+
+			actualState, err := m.TryLoad()
+			req.NoError(err)
+
+			req.Equal(tt.expected, actualState)
+		})
+	}
+}
+
+func TestMManager_AddCert(t *testing.T) {
+	tests := []struct {
+		name     string
+		certName string
+		newCert  util.CertType
+		wantErr  bool
+		before   VersionedState
+		expected VersionedState
+	}{
+		{
+			name:     "basic test",
+			certName: "aCert",
+			newCert:  util.CertType{Cert: "aCert", Key: "aKey"},
+			before: VersionedState{
+				V1: &V1{
+					Upstream: "abc123",
+				},
+			},
+			expected: VersionedState{
+				V1: &V1{
+					Upstream: "abc123",
+					Certs: map[string]util.CertType{
+						"aCert": {Cert: "aCert", Key: "aKey"},
+					},
+				},
+			},
+		},
+		{
+			name:     "add to existing",
+			certName: "bCert",
+			newCert:  util.CertType{Cert: "bCert", Key: "bKey"},
+			before: VersionedState{
+				V1: &V1{
+					Upstream: "abc123",
+					Certs: map[string]util.CertType{
+						"aCert": {Cert: "aCert", Key: "aKey"},
+					},
+				},
+			},
+			expected: VersionedState{
+				V1: &V1{
+					Upstream: "abc123",
+					Certs: map[string]util.CertType{
+						"aCert": {Cert: "aCert", Key: "aKey"},
+						"bCert": {Cert: "bCert", Key: "bKey"},
+					},
+				},
+			},
+		},
+		{
+			name:     "colliding ca names",
+			wantErr:  true,
+			certName: "aCert",
+			newCert:  util.CertType{Cert: "aCert", Key: "aKey"},
+			before: VersionedState{
+				V1: &V1{
+					Upstream: "abc123",
+					Certs: map[string]util.CertType{
+						"aCert": {Cert: "aCert", Key: "aKey"},
+					},
+				},
+			},
+			expected: VersionedState{
+				V1: &V1{
+					Upstream: "abc123",
+					Certs: map[string]util.CertType{
+						"aCert": {Cert: "aCert", Key: "aKey"},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+			m := &MManager{
+				Logger: &logger.TestLogger{T: t},
+				FS:     afero.Afero{Fs: afero.NewMemMapFs()},
+				V:      viper.New(),
+			}
+
+			err := m.serializeAndWriteState(tt.before)
+			req.NoError(err)
+
+			err = m.AddCert(tt.certName, tt.newCert)
+			if !tt.wantErr {
+				req.NoError(err, "MManager.AddCert() error = %v", err)
+			} else {
+				req.Error(err)
+			}
+
+			actualState, err := m.TryLoad()
+			req.NoError(err)
+
+			req.Equal(tt.expected, actualState)
+		})
+	}
 }

--- a/pkg/state/manager_test.go
+++ b/pkg/state/manager_test.go
@@ -623,7 +623,7 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
 					// append the integers 1-200 to the upstream
 					for i := 1; i <= 200; i++ {
-						err := m.StateUpdate(func(state VersionedState) (VersionedState, error) {
+						_, err := m.StateUpdate(func(state VersionedState) (VersionedState, error) {
 							state.V1.Upstream += fmt.Sprintf(" a:%d ", i)
 							return state, nil
 						})
@@ -635,7 +635,7 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
 					// append the integers 1-200 to the upstream
 					for i := 1; i <= 200; i++ {
-						err := m.StateUpdate(func(state VersionedState) (VersionedState, error) {
+						_, err := m.StateUpdate(func(state VersionedState) (VersionedState, error) {
 							state.V1.Upstream += fmt.Sprintf(" b:%d ", i)
 							return state, nil
 						})
@@ -647,7 +647,7 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
 					// append the integers 1-200 to the upstream
 					for i := 1; i <= 200; i++ {
-						err := m.StateUpdate(func(state VersionedState) (VersionedState, error) {
+						_, err := m.StateUpdate(func(state VersionedState) (VersionedState, error) {
 							state.V1.Upstream += fmt.Sprintf(" c:%d ", i)
 							return state, nil
 						})
@@ -659,7 +659,7 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
 					// append the integers 1-200 to the upstream
 					for i := 1; i <= 200; i++ {
-						err := m.StateUpdate(func(state VersionedState) (VersionedState, error) {
+						_, err := m.StateUpdate(func(state VersionedState) (VersionedState, error) {
 							state.V1.Upstream += fmt.Sprintf(" d:%d ", i)
 							return state, nil
 						})
@@ -671,7 +671,7 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
 					// append the integers 1-200 to the upstream
 					for i := 1; i <= 200; i++ {
-						err := m.StateUpdate(func(state VersionedState) (VersionedState, error) {
+						_, err := m.StateUpdate(func(state VersionedState) (VersionedState, error) {
 							state.V1.Upstream += fmt.Sprintf(" e:%d ", i)
 							return state, nil
 						})

--- a/pkg/test-mocks/state/manager_mock.go
+++ b/pkg/test-mocks/state/manager_mock.go
@@ -96,6 +96,31 @@ func (mr *MockManagerMockRecorder) ResetLifecycle() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetLifecycle", reflect.TypeOf((*MockManager)(nil).ResetLifecycle))
 }
 
+// SafeStateUpdate mocks base method
+func (m *MockManager) SafeStateUpdate(arg0 state.StateUpdate) error {
+	ret := m.ctrl.Call(m, "SafeStateUpdate", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SafeStateUpdate indicates an expected call of SafeStateUpdate
+func (mr *MockManagerMockRecorder) SafeStateUpdate(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SafeStateUpdate", reflect.TypeOf((*MockManager)(nil).SafeStateUpdate), arg0)
+}
+
+// SafeStateUpdateReturn mocks base method
+func (m *MockManager) SafeStateUpdateReturn(arg0 state.StateUpdate) (state.State, error) {
+	ret := m.ctrl.Call(m, "SafeStateUpdateReturn", arg0)
+	ret0, _ := ret[0].(state.State)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SafeStateUpdateReturn indicates an expected call of SafeStateUpdateReturn
+func (mr *MockManagerMockRecorder) SafeStateUpdateReturn(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SafeStateUpdateReturn", reflect.TypeOf((*MockManager)(nil).SafeStateUpdateReturn), arg0)
+}
+
 // Save mocks base method
 func (m *MockManager) Save(arg0 state.VersionedState) error {
 	ret := m.ctrl.Call(m, "Save", arg0)

--- a/pkg/test-mocks/state/manager_mock.go
+++ b/pkg/test-mocks/state/manager_mock.go
@@ -96,29 +96,29 @@ func (mr *MockManagerMockRecorder) ResetLifecycle() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetLifecycle", reflect.TypeOf((*MockManager)(nil).ResetLifecycle))
 }
 
-// SafeStateUpdate mocks base method
-func (m *MockManager) SafeStateUpdate(arg0 state.StateUpdate) error {
-	ret := m.ctrl.Call(m, "SafeStateUpdate", arg0)
+// StateUpdate mocks base method
+func (m *MockManager) StateUpdate(arg0 state.Update) error {
+	ret := m.ctrl.Call(m, "StateUpdate", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SafeStateUpdate indicates an expected call of SafeStateUpdate
+// StateUpdate indicates an expected call of StateUpdate
 func (mr *MockManagerMockRecorder) SafeStateUpdate(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SafeStateUpdate", reflect.TypeOf((*MockManager)(nil).SafeStateUpdate), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateUpdate", reflect.TypeOf((*MockManager)(nil).StateUpdate), arg0)
 }
 
-// SafeStateUpdateReturn mocks base method
-func (m *MockManager) SafeStateUpdateReturn(arg0 state.StateUpdate) (state.State, error) {
-	ret := m.ctrl.Call(m, "SafeStateUpdateReturn", arg0)
+// StateUpdateReturn mocks base method
+func (m *MockManager) StateUpdateReturn(arg0 state.Update) (state.State, error) {
+	ret := m.ctrl.Call(m, "StateUpdateReturn", arg0)
 	ret0, _ := ret[0].(state.State)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// SafeStateUpdateReturn indicates an expected call of SafeStateUpdateReturn
+// StateUpdateReturn indicates an expected call of StateUpdateReturn
 func (mr *MockManagerMockRecorder) SafeStateUpdateReturn(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SafeStateUpdateReturn", reflect.TypeOf((*MockManager)(nil).SafeStateUpdateReturn), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateUpdateReturn", reflect.TypeOf((*MockManager)(nil).StateUpdateReturn), arg0)
 }
 
 // Save mocks base method

--- a/pkg/test-mocks/state/manager_mock.go
+++ b/pkg/test-mocks/state/manager_mock.go
@@ -96,31 +96,6 @@ func (mr *MockManagerMockRecorder) ResetLifecycle() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetLifecycle", reflect.TypeOf((*MockManager)(nil).ResetLifecycle))
 }
 
-// StateUpdate mocks base method
-func (m *MockManager) StateUpdate(arg0 state.Update) error {
-	ret := m.ctrl.Call(m, "StateUpdate", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// StateUpdate indicates an expected call of StateUpdate
-func (mr *MockManagerMockRecorder) SafeStateUpdate(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateUpdate", reflect.TypeOf((*MockManager)(nil).StateUpdate), arg0)
-}
-
-// StateUpdateReturn mocks base method
-func (m *MockManager) StateUpdateReturn(arg0 state.Update) (state.State, error) {
-	ret := m.ctrl.Call(m, "StateUpdateReturn", arg0)
-	ret0, _ := ret[0].(state.State)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// StateUpdateReturn indicates an expected call of StateUpdateReturn
-func (mr *MockManagerMockRecorder) SafeStateUpdateReturn(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateUpdateReturn", reflect.TypeOf((*MockManager)(nil).StateUpdateReturn), arg0)
-}
-
 // Save mocks base method
 func (m *MockManager) Save(arg0 state.VersionedState) error {
 	ret := m.ctrl.Call(m, "Save", arg0)
@@ -263,6 +238,19 @@ func (m *MockManager) SerializeUpstreamContents(arg0 *state.UpstreamContents) er
 // SerializeUpstreamContents indicates an expected call of SerializeUpstreamContents
 func (mr *MockManagerMockRecorder) SerializeUpstreamContents(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SerializeUpstreamContents", reflect.TypeOf((*MockManager)(nil).SerializeUpstreamContents), arg0)
+}
+
+// StateUpdate mocks base method
+func (m *MockManager) StateUpdate(arg0 state.Update) (state.State, error) {
+	ret := m.ctrl.Call(m, "StateUpdate", arg0)
+	ret0, _ := ret[0].(state.State)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StateUpdate indicates an expected call of StateUpdate
+func (mr *MockManagerMockRecorder) StateUpdate(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateUpdate", reflect.TypeOf((*MockManager)(nil).StateUpdate), arg0)
 }
 
 // TryLoad mocks base method


### PR DESCRIPTION


What I Did
------------
make the state manager safe to use in parallel 

How I Did it
------------
All state updates are now protected by locks.

How to verify it
------------
Look at the unit test that attempts to create a race condition by hammering one field of the state in parallel

Description for the Changelog
------------
Fixed a race condition in ship state updates


Picture of a Ship (not required but encouraged)
------------

![USS John Paul Jones (DD-932)](https://upload.wikimedia.org/wikipedia/commons/f/f8/USS_John_Paul_Jones_%28DD-932%29_underway.jpg "USS John Paul Jones (DD-932)")










<!-- (thanks https://github.com/docker/docker for this template) -->

