### PR TITLE
flip gin log key/val ordering

### DIFF
--- a/pkg/lifecycle/daemon/daemon.go
+++ b/pkg/lifecycle/daemon/daemon.go
@@ -172,9 +172,9 @@ func loggerWriter(ginLog log.Logger) *io.PipeWriter {
 	go func(bufReader *bufio.Reader, ginLog log.Logger) {
 		for {
 			line, err := bufReader.ReadString('\n')
-			level.Info(ginLog).Log("event", "gin.log", line, "line")
+			level.Info(ginLog).Log("event", "gin.log", "line", line)
 			if err != nil {
-				level.Error(ginLog).Log("event", "gin.log", err, "err")
+				level.Error(ginLog).Log("event", "gin.log", "err", err)
 				return
 			}
 		}


### PR DESCRIPTION
What I Did
------------
Previously, log lines from gin would be stored like this:
```
{
  "[GIN] 2019/05/13 - 15:26:01 | 200 \u001b[0m|   11.030168ms |             ::1 |  POST \u001b[0m /api/v1/navcycle/step/kustomize-intro\n": "line",
  "caller": "github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemon.go",
  "event": "gin.log",
  "level": "info",
  "struct": "daemon",
  "ts": "2019-05-13T20:26:01.128921Z"
}
```
Now they are stored in the correct order:
```
{
  "line": "[GIN] 2019/05/13 - 15:26:01 | 200 \u001b[0m|   11.030168ms |             ::1 |  POST \u001b[0m /api/v1/navcycle/step/kustomize-intro\n",
  "caller": "github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemon.go",
  "event": "gin.log",
  "level": "info",
  "struct": "daemon",
  "ts": "2019-05-13T20:26:01.128921Z"
}
```

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Ship (not required but encouraged)
------------





![T35 August 1945 (as DD-935)](https://upload.wikimedia.org/wikipedia/commons/thumb/6/61/T_35_August_1945_as_DD_395.jpg/1280px-T_35_August_1945_as_DD_395.jpg "T35 August 1945 (as DD-935)")






<!-- (thanks https://github.com/docker/docker for this template) -->

