### PR TITLE
finish writing to stepsCompleted before allowing next step to read it

### DIFF
--- a/pkg/lifecycle/daemon/routes_navcycle_completestep.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_completestep.go
@@ -48,6 +48,7 @@ func (d *NavcycleRoutes) completeStep(c *gin.Context) {
 		// hack, give it 10 ms in case its an instant step. Hydrate and send will read progress from the syncMap
 		time.Sleep(10 * time.Millisecond)
 
+		d.completeMut.Lock()
 		d.hydrateAndSend(step, c)
 		go d.handleAsync(errChan, debug, step, stepID)
 		return
@@ -56,6 +57,7 @@ func (d *NavcycleRoutes) completeStep(c *gin.Context) {
 }
 
 func (d *NavcycleRoutes) handleAsync(errChan chan error, debug log.Logger, step api.Step, stepID string) {
+	defer d.completeMut.Unlock()
 	if err := d.awaitAsyncStep(errChan, debug, step); err != nil {
 		debug.Log("event", "execute.fail", "err", err)
 

--- a/pkg/lifecycle/daemon/routes_navcycle_completestep.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_completestep.go
@@ -50,14 +50,16 @@ func (d *NavcycleRoutes) completeStep(c *gin.Context) {
 
 		d.completeMut.Lock()
 		d.hydrateAndSend(step, c)
-		go d.handleAsync(errChan, debug, step, stepID)
+		go func() {
+			defer d.completeMut.Unlock()
+			d.handleAsync(errChan, debug, step, stepID)
+		}()
 		return
 	}
 	d.errNotFound(c)
 }
 
 func (d *NavcycleRoutes) handleAsync(errChan chan error, debug log.Logger, step api.Step, stepID string) {
-	defer d.completeMut.Unlock()
 	if err := d.awaitAsyncStep(errChan, debug, step); err != nil {
 		debug.Log("event", "execute.fail", "err", err)
 


### PR DESCRIPTION
What I Did
------------
Resolved a race condition that could occur when moving to the next step after saving a config.

How I Did it
------------
Added a lock to the complete step management code to ensure that future steps do not attempt to determine what steps have been completed until the previous step has the opportunity to update the list of completed steps.


How to verify it
------------


Description for the Changelog
------------
Resolved a race condition that could occur when moving to the next step after saving a config.


Picture of a Ship (not required but encouraged)
------------

![USS Davis (DD-937)](https://upload.wikimedia.org/wikipedia/commons/4/4e/USS_Davis_%28DD-937%29_underway_on_28_February_1957.jpg "USS Davis (DD-937)")










<!-- (thanks https://github.com/docker/docker for this template) -->

