### PR TITLE
fix 'ship edit' for replicated.app upstreams

### DIFF
--- a/pkg/lifecycle/daemon/routes_navcycle_getmetadata.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_getmetadata.go
@@ -2,6 +2,9 @@ package daemon
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+
 	"github.com/replicatedhq/ship/pkg/api"
 )
 
@@ -23,6 +26,9 @@ func (d *NavcycleRoutes) getMetadata(release *api.Release) gin.HandlerFunc {
 				"icon": release.Metadata.ChannelIcon,
 			})
 			return
+		default:
+			errorLog := level.Error(log.With(d.Logger, "method", "getMetadata"))
+			errorLog.Log("error", "release metadata type not recognized", "release.Metadata.Type", release.Metadata.Type)
 		}
 	}
 }

--- a/pkg/specs/replicatedapp/resolver.go
+++ b/pkg/specs/replicatedapp/resolver.go
@@ -141,6 +141,12 @@ func (r *resolver) ResolveEditRelease(ctx context.Context) (*api.Release, error)
 		Metadata: *stateData.ReleaseMetadata(),
 	}
 
+	if r.Runbook == "" {
+		result.Metadata.Type = "replicated.app"
+	} else {
+		result.Metadata.Type = "runbook.replicated.app"
+	}
+
 	if err = yaml.Unmarshal([]byte(stateData.UpstreamContents().AppRelease.Spec), &result.Spec); err != nil {
 		return nil, errors.Wrapf(err, "decode spec from persisted release")
 	}


### PR DESCRIPTION
What I Did
------------
Fix `ship edit` for `replicated.app` upstreams

How I Did it
------------
Include the app type in the metadata so that the `/api/v1/metadata` endpoint returns successfully


How to verify it
------------
running `ship edit` completes successfully in headed mode for `replicated.app` upstreams

Description for the Changelog
------------
fix 'ship edit' for replicated.app upstreams


Picture of a Ship (not required but encouraged)
------------


![USS Jonas Ingram (DD-938)](https://upload.wikimedia.org/wikipedia/commons/thumb/7/73/USS_Jonas_Ingram_%28DD-938%29_underway_in_June_1957.jpg/1280px-USS_Jonas_Ingram_%28DD-938%29_underway_in_June_1957.jpg "USS Jonas Ingram (DD-938)")









<!-- (thanks https://github.com/docker/docker for this template) -->

