### PR TITLE
remove empty and v0 state types, leaving only versioned state

### DIFF
--- a/pkg/filetree/loader_test.go
+++ b/pkg/filetree/loader_test.go
@@ -76,7 +76,7 @@ func TestAferoLoader(t *testing.T) {
 				testResources[resource.Key.(string)] = resource.Value.(string)
 			}
 
-			mockState.EXPECT().TryLoad().Return(state.VersionedState{
+			mockState.EXPECT().TryLoad().Return(state.State{
 				V1: &state.V1{
 					Kustomize: &state.Kustomize{
 						Overlays: map[string]state.Overlay{

--- a/pkg/lifecycle/daemon/headless/daemon_test.go
+++ b/pkg/lifecycle/daemon/headless/daemon_test.go
@@ -44,7 +44,7 @@ func TestHeadlessDaemon(t *testing.T) {
 		},
 		{
 			Name:  "one group one item, not required, no value",
-			State: []byte(`{"alpha": ""}`),
+			State: []byte(`{"v1":{"config":{"alpha":""}}}`),
 			Release: &api.Release{
 				Spec: api.Spec{
 					Config: api.Config{
@@ -68,7 +68,7 @@ func TestHeadlessDaemon(t *testing.T) {
 		},
 		{
 			Name:  "one group one item, required, no value",
-			State: []byte(`{"alpha": ""}`),
+			State: []byte(`{"v1":{"config":{"alpha":""}}}`),
 			Release: &api.Release{
 				Spec: api.Spec{
 					Config: api.Config{
@@ -188,7 +188,7 @@ func TestHeadlessDaemon(t *testing.T) {
 		},
 		{
 			Name:  "one group one item, required, value, not hidden",
-			State: []byte(`{"alpha": "100"}`),
+			State: []byte(`{"v1":{"config":{"alpha": "100"}}}`),
 			Release: &api.Release{
 				Spec: api.Spec{
 					Config: api.Config{
@@ -212,7 +212,7 @@ func TestHeadlessDaemon(t *testing.T) {
 		},
 		{
 			Name:  "one group one item, not required, no value, not hidden",
-			State: []byte(`{"alpha": ""}`),
+			State: []byte(`{"v1":{"config":{"alpha": ""}}}`),
 			Release: &api.Release{
 				Spec: api.Spec{
 					Config: api.Config{
@@ -260,7 +260,7 @@ func TestHeadlessDaemon(t *testing.T) {
 		},
 		{
 			Name:  "one group two items, neither required, neither present",
-			State: []byte(`{"alpha": "", "beta": ""}`),
+			State: []byte(`{"v1":{"config":{"alpha": "", "beta": ""}}}`),
 			Release: &api.Release{
 				Spec: api.Spec{
 					Config: api.Config{
@@ -291,7 +291,7 @@ func TestHeadlessDaemon(t *testing.T) {
 		},
 		{
 			Name:  "one group two items, both required, neither present",
-			State: []byte(`{"alpha": "", "beta": ""}`),
+			State: []byte(`{"v1":{"config":{"alpha": "", "beta": ""}}}`),
 			Release: &api.Release{
 				Spec: api.Spec{
 					Config: api.Config{
@@ -322,7 +322,7 @@ func TestHeadlessDaemon(t *testing.T) {
 		},
 		{
 			Name:  "one group two items, both required, one present",
-			State: []byte(`{"alpha":"", "beta": ""}`),
+			State: []byte(`{"v1":{"config":{"alpha":"", "beta": ""}}}`),
 			Release: &api.Release{
 				Spec: api.Spec{
 					Config: api.Config{
@@ -384,7 +384,7 @@ func TestHeadlessDaemon(t *testing.T) {
 		},
 		{
 			Name:  "beta value resolves to alpha value",
-			State: []byte(`{"alpha": "101"}`),
+			State: []byte(`{"v1":{"config":{"alpha": "101"}}}`),
 			Release: &api.Release{
 				Spec: api.Spec{
 					Config: api.Config{
@@ -415,7 +415,7 @@ func TestHeadlessDaemon(t *testing.T) {
 		},
 		{
 			Name:  "beta value resolves to alpha value when wrong beta value is presented",
-			State: []byte(`{"alpha": "101", "beta":"abc"}`),
+			State: []byte(`{"v1":{"config":{"alpha": "101", "beta":"abc"}}}`),
 			Release: &api.Release{
 				Spec: api.Spec{
 					Config: api.Config{
@@ -446,7 +446,7 @@ func TestHeadlessDaemon(t *testing.T) {
 		},
 		{
 			Name:  "charlie value resolves to beta value resolves to alpha value",
-			State: []byte(`{"alpha": "100"}`),
+			State: []byte(`{"v1":{"config":{"alpha":"100"}}}`),
 			Release: &api.Release{
 				Spec: api.Spec{
 					Config: api.Config{

--- a/pkg/lifecycle/daemon/routes_navcycle.go
+++ b/pkg/lifecycle/daemon/routes_navcycle.go
@@ -156,7 +156,8 @@ func (d *NavcycleRoutes) getRequiredButIncompleteStepFor(requires []string) (str
 	if err != nil {
 		return "", errors.Wrap(err, "load state")
 	}
-	if currentState.Versioned().V1.Lifecycle != nil &&
+	if currentState.Versioned().V1 != nil &&
+		currentState.Versioned().V1.Lifecycle != nil &&
 		currentState.Versioned().V1.Lifecycle.StepsCompleted != nil {
 		stepsCompleted = currentState.Versioned().V1.Lifecycle.StepsCompleted
 		debug.Log("event", "steps.notEmpty", "completed", fmt.Sprintf("%v", stepsCompleted))

--- a/pkg/lifecycle/daemon/routes_navcycle_completestep.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_completestep.go
@@ -72,7 +72,7 @@ func (d *NavcycleRoutes) handleAsync(errChan chan error, debug log.Logger, step 
 		return
 	}
 
-	_, err := d.StateManager.StateUpdate(func(currentState state.VersionedState) (state.VersionedState, error) {
+	_, err := d.StateManager.StateUpdate(func(currentState state.State) (state.State, error) {
 		return currentState.WithCompletedStep(step), nil
 	})
 	if err != nil {

--- a/pkg/lifecycle/daemon/routes_navcycle_completestep_test.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_completestep_test.go
@@ -116,7 +116,7 @@ func TestV2CompleteStep(t *testing.T) {
 					ExpectState: &matchers.Is{
 						Describe: "saved state has step foo completed",
 						Test: func(v interface{}) bool {
-							if versioned, ok := v.(state2.VersionedState); ok {
+							if versioned, ok := v.(state2.State); ok {
 								_, ok := versioned.V1.Lifecycle.StepsCompleted["foo"]
 								return ok
 							}
@@ -168,7 +168,7 @@ func TestV2CompleteStep(t *testing.T) {
 					ExpectState: &matchers.Is{
 						Describe: "saved state has step foo completed and bar uncompleted",
 						Test: func(v interface{}) bool {
-							if versioned, ok := v.(state2.VersionedState); ok {
+							if versioned, ok := v.(state2.State); ok {
 								_, fooOk := versioned.V1.Lifecycle.StepsCompleted["foo"]
 								_, barOk := versioned.V1.Lifecycle.StepsCompleted["bar"]
 								return fooOk && !barOk
@@ -197,7 +197,7 @@ func TestV2CompleteStep(t *testing.T) {
 					ExpectState: &matchers.Is{
 						Describe: "saved state has step foo and bar completed",
 						Test: func(v interface{}) bool {
-							if versioned, ok := v.(state2.VersionedState); ok {
+							if versioned, ok := v.(state2.State); ok {
 								_, fooOk := versioned.V1.Lifecycle.StepsCompleted["foo"]
 								_, barOk := versioned.V1.Lifecycle.StepsCompleted["bar"]
 								return fooOk && barOk
@@ -226,7 +226,7 @@ func TestV2CompleteStep(t *testing.T) {
 					ExpectState: &matchers.Is{
 						Describe: "saved state has step foo completed and step bar invalidated",
 						Test: func(v interface{}) bool {
-							if versioned, ok := v.(state2.VersionedState); ok {
+							if versioned, ok := v.(state2.State); ok {
 								_, fooOk := versioned.V1.Lifecycle.StepsCompleted["foo"]
 								_, barOk := versioned.V1.Lifecycle.StepsCompleted["bar"]
 								return fooOk && !barOk
@@ -299,7 +299,7 @@ func TestV2CompleteStep(t *testing.T) {
 					ExpectState: &matchers.Is{
 						Describe: "saved state has step make-the-things completed",
 						Test: func(v interface{}) bool {
-							if versioned, ok := v.(state2.VersionedState); ok {
+							if versioned, ok := v.(state2.State); ok {
 								_, ok := versioned.V1.Lifecycle.StepsCompleted["make-the-things"]
 								return ok
 							}

--- a/pkg/lifecycle/daemon/routes_navcycle_getstep_test.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_getstep_test.go
@@ -227,7 +227,7 @@ func TestV2GetStep(t *testing.T) {
 				StepProgress:   progressmap,
 			}
 
-			fakeState.EXPECT().TryLoad().Return(state2.VersionedState{
+			fakeState.EXPECT().TryLoad().Return(state2.State{
 				V1: &state2.V1{
 					Lifecycle: test.State,
 				},
@@ -442,7 +442,7 @@ func TestHydrateStep(t *testing.T) {
 					},
 				},
 			},
-			state: state2.V0{},
+			state: state2.State{V1: &state2.V1{}},
 			want: &daemontypes.StepResponse{
 				CurrentStep: daemontypes.Step{
 					Source: api.Step{
@@ -492,7 +492,7 @@ func TestHydrateStep(t *testing.T) {
 				},
 				Spec: api.Spec{},
 			},
-			state: state2.VersionedState{
+			state: state2.State{
 				V1: &state2.V1{
 					HelmValues:         "fake: values",
 					ReleaseName:        "fake-releasename",
@@ -563,7 +563,7 @@ func TestHydrateStep(t *testing.T) {
 			mockFs := afero.Afero{Fs: afero.NewMemMapFs()}
 			mockState := state.NewMockManager(mc)
 
-			if test.state != nil {
+			if !test.state.IsEmpty() {
 				mockState.EXPECT().TryLoad().Return(test.state, nil)
 				mockState.EXPECT().TryLoad().Return(test.state, nil)
 			}
@@ -636,7 +636,7 @@ func TestHydrateTemplatedKustomizeStep(t *testing.T) {
 					},
 				},
 			},
-			state: state2.V0{},
+			state: state2.State{V1: &state2.V1{}},
 			want: &daemontypes.StepResponse{
 				CurrentStep: daemontypes.Step{
 					Source: api.Step{
@@ -696,7 +696,7 @@ func TestHydrateTemplatedKustomizeStep(t *testing.T) {
 			progressmap := &daemontypes.ProgressMap{}
 			mockFs := afero.Afero{Fs: afero.NewMemMapFs()}
 			mockState := state.NewMockManager(mc)
-			if test.state != nil {
+			if !test.state.IsEmpty() {
 				mockState.EXPECT().TryLoad().Return(test.state, nil)
 				mockState.EXPECT().TryLoad().Return(test.state, nil)
 				mockState.EXPECT().TryLoad().Return(test.state, nil)

--- a/pkg/lifecycle/daemon/routes_navcycle_kustomize_test.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_kustomize_test.go
@@ -147,7 +147,7 @@ func TestV2KustomizeSaveFile(t *testing.T) {
 				StepProgress: progressmap,
 			}
 
-			fakeState.EXPECT().TryLoad().Return(state.VersionedState{
+			fakeState.EXPECT().TryLoad().Return(state.State{
 				V1: &test.InState,
 			}, nil).AnyTimes()
 
@@ -269,7 +269,7 @@ func TestV2KustomizeDeleteFile(t *testing.T) {
 				StepProgress: progressmap,
 			}
 
-			fakeState.EXPECT().TryLoad().Return(state.VersionedState{
+			fakeState.EXPECT().TryLoad().Return(state.State{
 				V1: &test.InState,
 			}, nil).AnyTimes()
 

--- a/pkg/lifecycle/kustomize/kustomizer_test.go
+++ b/pkg/lifecycle/kustomize/kustomizer_test.go
@@ -329,7 +329,7 @@ resources:
 			mockDaemon := daemon2.NewMockDaemon(mc)
 			mockState := state2.NewMockManager(mc)
 
-			mockState.EXPECT().TryLoad().Return(state.VersionedState{
+			mockState.EXPECT().TryLoad().Return(state.State{
 				V1: &state.V1{
 					Kustomize: &state.Kustomize{
 						Overlays: map[string]state.Overlay{
@@ -508,7 +508,7 @@ resources:
 				BasePath: constants.KustomizeBasePath,
 			})
 			mockDaemon.EXPECT().KustomizeSavedChan().Return(saveChan)
-			mockState.EXPECT().TryLoad().Return(state.VersionedState{V1: &state.V1{
+			mockState.EXPECT().TryLoad().Return(state.State{V1: &state.V1{
 				Kustomize: test.kustomize,
 			}}, nil).Times(2)
 

--- a/pkg/lifecycle/kustomize/patch.go
+++ b/pkg/lifecycle/kustomize/patch.go
@@ -79,7 +79,7 @@ func (l *Kustomizer) generateTillerPatches(step api.Kustomize) error {
 	if err != nil {
 		return errors.Wrap(err, "load state")
 	}
-	if state != nil && state.CurrentKustomize() != nil {
+	if state.V1 != nil && state.CurrentKustomize() != nil {
 		excludedBases = state.CurrentKustomize().Ship().ExcludedBases
 	}
 

--- a/pkg/lifecycle/kustomize/patch_test.go
+++ b/pkg/lifecycle/kustomize/patch_test.go
@@ -173,7 +173,7 @@ metadata:
 
 			stateManager := state.NewManager(log.NewNopLogger(), mockFs, viper.New())
 
-			err := stateManager.Save(state.VersionedState{V1: &state.V1{Kustomize: &state.Kustomize{}}})
+			err := stateManager.Save(state.State{V1: &state.V1{Kustomize: &state.Kustomize{}}})
 			req.NoError(err)
 
 			l := &Kustomizer{

--- a/pkg/lifecycle/kustomize/pre_kustomize_test.go
+++ b/pkg/lifecycle/kustomize/pre_kustomize_test.go
@@ -392,7 +392,7 @@ spec:
 			req.NoError(err)
 
 			actualLists := make([]util.List, 0)
-			if currentState.Versioned().V1.Metadata != nil {
+			if currentState.V1 != nil && currentState.V1.Metadata != nil {
 				actualLists = currentState.Versioned().V1.Metadata.Lists
 			}
 

--- a/pkg/lifecycle/render/helm/template_test.go
+++ b/pkg/lifecycle/render/helm/template_test.go
@@ -38,7 +38,7 @@ func TestLocalTemplater(t *testing.T) {
 		expectedChannelName string
 		expectHelmOpts      *matchers.Is
 		ontemplate          func(req *require.Assertions, mockFs afero.Afero) func(chartRoot string, args []string) error
-		state               *state2.VersionedState
+		state               *state2.State
 		requirements        *chartutil.Requirements
 		repoAdd             []string
 		namespace           string
@@ -130,7 +130,7 @@ func TestLocalTemplater(t *testing.T) {
 			name:        "helm template with namespace in state",
 			describe:    "template uses namespace from state",
 			expectError: "",
-			state: &state2.VersionedState{
+			state: &state2.State{
 				V1: &state2.V1{
 					Namespace: "test-namespace",
 				},
@@ -172,7 +172,7 @@ func TestLocalTemplater(t *testing.T) {
 			}
 
 			if test.state == nil {
-				mockState.EXPECT().TryLoad().Return(state2.VersionedState{
+				mockState.EXPECT().TryLoad().Return(state2.State{
 					V1: &state2.V1{
 						HelmValues:  "we fake",
 						ReleaseName: channelName,
@@ -787,7 +787,7 @@ something: maybe
 			err := mockFs.WriteFile(tt.defaultValuesPath, []byte(tt.defaultValuesContent), 0755)
 			req.NoError(err)
 
-			mockState.EXPECT().TryLoad().Return(state2.VersionedState{V1: &state2.V1{}}, nil)
+			mockState.EXPECT().TryLoad().Return(state2.State{V1: &state2.V1{}}, nil)
 			f := &LocalTemplater{
 				Logger:       &logger.TestLogger{T: t},
 				FS:           mockFs,

--- a/pkg/lifecycle/render/noconfig_test.go
+++ b/pkg/lifecycle/render/noconfig_test.go
@@ -26,7 +26,7 @@ func TestRenderNoConfig(t *testing.T) {
 
 	tests := loadTestCases(t, filepath.Join("test-cases", "render-inline.yaml"))
 
-	for _, test := range tests[:1] {
+	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			mc := gomock.NewController(t)
 
@@ -57,10 +57,15 @@ func TestRenderNoConfig(t *testing.T) {
 			func() {
 				defer mc.Finish()
 
-				mockState.EXPECT().TryLoad().Return(state.V0(test.ViperConfig), nil)
+				mockState.EXPECT().TryLoad().Return(state.State{V1: &state.V1{Config: test.ViperConfig}}, nil)
+
+				expectedConfig := test.ViperConfig
+				if expectedConfig == nil {
+					expectedConfig = make(map[string]interface{})
+				}
 
 				p.EXPECT().
-					Build("testdir", test.Spec.Assets.V1, test.Spec.Config.V1, gomock.Any(), test.ViperConfig).
+					Build("testdir", test.Spec.Assets.V1, test.Spec.Config.V1, gomock.Any(), expectedConfig).
 					Return(planner.Plan{}, nil)
 
 				p.EXPECT().

--- a/pkg/lifecycle/terraform/state_test.go
+++ b/pkg/lifecycle/terraform/state_test.go
@@ -21,8 +21,8 @@ func TestPersistState(t *testing.T) {
 	tests := []struct {
 		name     string
 		state    string
-		instate  state.VersionedState
-		outstate state.VersionedState
+		instate  state.State
+		outstate state.State
 	}{
 		{
 			name: "post-delete state, mostly empty",
@@ -43,10 +43,10 @@ func TestPersistState(t *testing.T) {
     ]
 }
 `,
-			instate: state.VersionedState{
+			instate: state.State{
 				V1: &state.V1{},
 			},
-			outstate: state.VersionedState{
+			outstate: state.State{
 				V1: &state.V1{
 					Terraform: &state.Terraform{
 						RawState: `{
@@ -98,10 +98,10 @@ func TestPersistState(t *testing.T) {
 			err := mockFs.WriteFile("installer/terraform.tfstate", []byte(test.state), 0644)
 			req.NoError(err)
 
-			statemanager.EXPECT().TryLoad().Return(&test.instate, nil)
+			statemanager.EXPECT().TryLoad().Return(test.instate, nil)
 			statemanager.EXPECT().Save(&matchers.Is{
 				Test: func(v interface{}) bool {
-					vstate := v.(state.VersionedState)
+					vstate := v.(state.State)
 					diff := deep.Equal(*vstate.V1.Terraform, *test.outstate.V1.Terraform)
 					t.Log(strings.Join(diff, "\n"))
 					return len(diff) == 0
@@ -121,7 +121,7 @@ func TestPersistState(t *testing.T) {
 func TestRestoreState(t *testing.T) {
 	tests := []struct {
 		name       string
-		instate    state.VersionedState
+		instate    state.State
 		expectFile string
 	}{
 		{
@@ -143,7 +143,7 @@ func TestRestoreState(t *testing.T) {
     ]
 }
 `,
-			instate: state.VersionedState{
+			instate: state.State{
 				V1: &state.V1{
 					Terraform: &state.Terraform{
 						RawState: `{
@@ -192,7 +192,7 @@ func TestRestoreState(t *testing.T) {
 			mockFs := afero.Afero{Fs: afero.NewMemMapFs()}
 			statemanager := state2.NewMockManager(mc)
 
-			statemanager.EXPECT().TryLoad().Return(&test.instate, nil)
+			statemanager.EXPECT().TryLoad().Return(test.instate, nil)
 
 			err := restoreState(debug, mockFs, statemanager, "installer")
 			req.NoError(err)

--- a/pkg/lifecycle/terraform/when_test.go
+++ b/pkg/lifecycle/terraform/when_test.go
@@ -14,56 +14,56 @@ import (
 func TestEvaluateWhen(t *testing.T) {
 	tests := []struct {
 		name    string
-		State   state.VersionedState
+		State   state.State
 		when    string
 		release api.Release
 		want    bool
 	}{
 		{
 			name:    "no when",
-			State:   state.VersionedState{V1: &state.V1{}},
+			State:   state.State{V1: &state.V1{}},
 			when:    "",
 			release: api.Release{Metadata: api.ReleaseMetadata{}},
 			want:    true,
 		},
 		{
 			name:    "true when",
-			State:   state.VersionedState{V1: &state.V1{}},
+			State:   state.State{V1: &state.V1{}},
 			when:    "true",
 			release: api.Release{Metadata: api.ReleaseMetadata{}},
 			want:    true,
 		},
 		{
 			name:    "false when",
-			State:   state.VersionedState{V1: &state.V1{}},
+			State:   state.State{V1: &state.V1{}},
 			when:    "false",
 			release: api.Release{Metadata: api.ReleaseMetadata{}},
 			want:    false,
 		},
 		{
 			name:    "trivial template when true",
-			State:   state.VersionedState{V1: &state.V1{}},
+			State:   state.State{V1: &state.V1{}},
 			when:    "{{repl eq 1 1}}",
 			release: api.Release{Metadata: api.ReleaseMetadata{}},
 			want:    true,
 		},
 		{
 			name:    "trivial template when false",
-			State:   state.VersionedState{V1: &state.V1{}},
+			State:   state.State{V1: &state.V1{}},
 			when:    "{{repl eq 1 2}}",
 			release: api.Release{Metadata: api.ReleaseMetadata{}},
 			want:    false,
 		},
 		{
 			name:    "configOption template when true",
-			State:   state.VersionedState{V1: &state.V1{Config: map[string]interface{}{"theOption": "hello_world"}}},
+			State:   state.State{V1: &state.V1{Config: map[string]interface{}{"theOption": "hello_world"}}},
 			when:    `{{repl ConfigOptionEquals "theOption" "hello_world"}}`,
 			release: api.Release{Metadata: api.ReleaseMetadata{}},
 			want:    true,
 		},
 		{
 			name:    "configOption template when false",
-			State:   state.VersionedState{V1: &state.V1{Config: map[string]interface{}{"theOption": "hello_world"}}},
+			State:   state.State{V1: &state.V1{Config: map[string]interface{}{"theOption": "hello_world"}}},
 			when:    `{{repl ConfigOptionEquals "theOption" "something else"}}`,
 			release: api.Release{Metadata: api.ReleaseMetadata{}},
 			want:    false,

--- a/pkg/ship/unfork.go
+++ b/pkg/ship/unfork.go
@@ -23,19 +23,17 @@ func (s *Ship) Unfork(ctx context.Context) error {
 	defer s.Shutdown(cancelFunc)
 
 	existingState, _ := s.State.TryLoad()
-	if existingState != nil {
-		if !existingState.IsEmpty() {
-			debug.Log("event", "existing.state")
+	if !existingState.IsEmpty() {
+		debug.Log("event", "existing.state")
 
-			if s.Viper.GetString("state-from") != "file" {
-				debug.Log("event", "existing.state", "state-from", "not file")
-				return warnings.WarnCannotRemoveState
-			}
+		if s.Viper.GetString("state-from") != "file" {
+			debug.Log("event", "existing.state", "state-from", "not file")
+			return warnings.WarnCannotRemoveState
+		}
 
-			if err := s.promptToRemoveState(); err != nil {
-				debug.Log("event", "state.remove.prompt.fail")
-				return err
-			}
+		if err := s.promptToRemoveState(); err != nil {
+			debug.Log("event", "state.remove.prompt.fail")
+			return err
 		}
 	}
 

--- a/pkg/ship/update.go
+++ b/pkg/ship/update.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/ship/pkg/constants"
 	"github.com/replicatedhq/ship/pkg/lifecycle/daemon/daemontypes"
-	"github.com/replicatedhq/ship/pkg/state"
 )
 
 func (s *Ship) UpdateAndMaybeExit(ctx context.Context) error {
@@ -38,7 +37,7 @@ func (s *Ship) Update(ctx context.Context) error {
 		uiPrintableStatePath = constants.StatePath
 	}
 
-	if _, noExistingState := existingState.(state.Empty); noExistingState {
+	if existingState.Versioned().V1 == nil {
 		debug.Log("event", "state.missing")
 		return errors.Errorf(`No state file found at %s please run "ship init"`, uiPrintableStatePath)
 	}

--- a/pkg/ship/watch.go
+++ b/pkg/ship/watch.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/ship/pkg/constants"
-	"github.com/replicatedhq/ship/pkg/state"
 )
 
 func (s *Ship) WatchAndExit(ctx context.Context) error {
@@ -37,7 +36,7 @@ func (s *Ship) Watch(ctx context.Context) error {
 			uiPrintableStatePath = constants.StatePath
 		}
 
-		if _, noExistingState := existingState.(state.Empty); noExistingState {
+		if existingState.Versioned().V1 == nil {
 			debug.Log("event", "state.missing")
 			return errors.Errorf(`No state found at %s, please run "ship init"`, uiPrintableStatePath)
 		}

--- a/pkg/specs/interface_test.go
+++ b/pkg/specs/interface_test.go
@@ -102,7 +102,7 @@ icon: https://kfbr.392/x5.png
 				}, "helm").After(inOrder)
 				inOrder = mockUi.EXPECT().Info("Looking for ship.yaml ...").After(inOrder)
 				inOrder = mockUi.EXPECT().Info("ship.yaml not found in upstream, generating default lifecycle for application ...").After(inOrder)
-				inOrder = mockState.EXPECT().TryLoad().Return(state2.VersionedState{}, nil).After(inOrder)
+				inOrder = mockState.EXPECT().TryLoad().Return(state2.State{}, nil).After(inOrder)
 				mockState.EXPECT().SerializeReleaseName("i-know-what-the-x5-is").After(inOrder)
 
 			},
@@ -205,7 +205,7 @@ icon: https://kfbr.392/x5.png
 				inOrder = mockState.EXPECT().SerializeContentSHA("abcdef1234567890").After(inOrder)
 				inOrder = mockUi.EXPECT().Info("Looking for ship.yaml ...").After(inOrder)
 				inOrder = mockUi.EXPECT().Info("ship.yaml not found in upstream, generating default lifecycle for application ...").After(inOrder)
-				inOrder = mockState.EXPECT().TryLoad().Return(state2.VersionedState{}, nil).After(inOrder)
+				inOrder = mockState.EXPECT().TryLoad().Return(state2.State{}, nil).After(inOrder)
 				mockState.EXPECT().SerializeReleaseName("ship").After(inOrder)
 			},
 			expectRelease: &api.Release{

--- a/pkg/specs/upstream_test.go
+++ b/pkg/specs/upstream_test.go
@@ -37,7 +37,7 @@ func TestResolver_MaybeResolveVersionedUpstream(t *testing.T) {
 		{
 			name:     "versioned upstream has an update available",
 			upstream: "github.com/o/r/tree/_latest_",
-			currentState: &state.VersionedState{
+			currentState: state.State{
 				V1: &state.V1{
 					Metadata: &state.Metadata{
 						Version: "1.1.0",
@@ -49,7 +49,7 @@ func TestResolver_MaybeResolveVersionedUpstream(t *testing.T) {
 		{
 			name:     "version upstream is above latest",
 			upstream: "github.com/o/r/tree/_latest_",
-			currentState: &state.VersionedState{
+			currentState: state.State{
 				V1: &state.V1{
 					Metadata: &state.Metadata{
 						Version: "1.2.1",
@@ -62,7 +62,7 @@ func TestResolver_MaybeResolveVersionedUpstream(t *testing.T) {
 		{
 			name:     "commit sha upstream",
 			upstream: "github.com/o/r/tree/d3eed9a347ad02f0b79e3f92330878f88953cf64/path",
-			currentState: &state.VersionedState{
+			currentState: state.State{
 				V1: &state.V1{
 					Metadata: &state.Metadata{
 						Version: "1.2.0",
@@ -74,7 +74,7 @@ func TestResolver_MaybeResolveVersionedUpstream(t *testing.T) {
 		{
 			name:     "ref upstream",
 			upstream: "github.com/o/r/tree/abcedfg/path",
-			currentState: &state.VersionedState{
+			currentState: state.State{
 				V1: &state.V1{
 					Metadata: &state.Metadata{
 						Version: "1.2.0",
@@ -86,7 +86,7 @@ func TestResolver_MaybeResolveVersionedUpstream(t *testing.T) {
 		{
 			name:     "versioned upstream with no latest release",
 			upstream: "github.com/a/b/tree/_latest_",
-			currentState: &state.VersionedState{
+			currentState: state.State{
 				V1: &state.V1{
 					Metadata: &state.Metadata{
 						Version: "1.2.0",
@@ -99,7 +99,7 @@ func TestResolver_MaybeResolveVersionedUpstream(t *testing.T) {
 		{
 			name:     "versioned upstream with no version in state",
 			upstream: "github.com/o/r/tree/_latest_",
-			currentState: &state.VersionedState{
+			currentState: state.State{
 				V1: &state.V1{
 					Metadata: &state.Metadata{},
 				},
@@ -109,7 +109,7 @@ func TestResolver_MaybeResolveVersionedUpstream(t *testing.T) {
 		{
 			name:     "ref upstream with no version in state",
 			upstream: "github.com/o/r/tree/abranch",
-			currentState: &state.VersionedState{
+			currentState: state.State{
 				V1: &state.V1{
 					Metadata: &state.Metadata{},
 				},
@@ -119,7 +119,7 @@ func TestResolver_MaybeResolveVersionedUpstream(t *testing.T) {
 		{
 			name:     "not a github url",
 			upstream: "notgithub.com/o/r/tree/_latest_",
-			currentState: &state.VersionedState{
+			currentState: state.State{
 				V1: &state.V1{
 					Metadata: &state.Metadata{},
 				},

--- a/pkg/state/manager_test.go
+++ b/pkg/state/manager_test.go
@@ -51,13 +51,6 @@ func TestLoadConfig(t *testing.T) {
 			expectConfig: make(map[string]interface{}),
 		},
 		{
-			name:     "v0 single item",
-			contents: `{"foo": "bar"}`,
-			expectConfig: map[string]interface{}{
-				"foo": "bar",
-			},
-		},
-		{
 			name:     "v1 single item",
 			contents: `{"v1": {"config": {"foo": "bar"}}}`,
 			expectConfig: map[string]interface{}{
@@ -177,16 +170,16 @@ func TestMManager_SerializeChartURL(t *testing.T) {
 		name     string
 		URL      string
 		wantErr  bool
-		before   VersionedState
-		expected VersionedState
+		before   State
+		expected State
 	}{
 		{
 			name: "basic test",
 			URL:  "abc123",
-			before: VersionedState{
+			before: State{
 				V1: &V1{},
 			},
-			expected: VersionedState{
+			expected: State{
 				V1: &V1{
 					Upstream: "abc123",
 				},
@@ -195,12 +188,12 @@ func TestMManager_SerializeChartURL(t *testing.T) {
 		{
 			name: "no wipe",
 			URL:  "abc123",
-			before: VersionedState{
+			before: State{
 				V1: &V1{
 					ChartRepoURL: "abc123_",
 				},
 			},
-			expected: VersionedState{
+			expected: State{
 				V1: &V1{
 					Upstream:     "abc123",
 					ChartRepoURL: "abc123_",
@@ -210,12 +203,12 @@ func TestMManager_SerializeChartURL(t *testing.T) {
 		{
 			name: "no wipe, but still override",
 			URL:  "xyz789",
-			before: VersionedState{
+			before: State{
 				V1: &V1{
 					ChartURL: "abc123",
 				},
 			},
-			expected: VersionedState{
+			expected: State{
 				V1: &V1{
 					Upstream: "xyz789",
 				},
@@ -254,16 +247,16 @@ func TestMManager_SerializeContentSHA(t *testing.T) {
 		name       string
 		ContentSHA string
 		wantErr    bool
-		before     VersionedState
-		expected   VersionedState
+		before     State
+		expected   State
 	}{
 		{
 			name:       "basic test",
 			ContentSHA: "abc123",
-			before: VersionedState{
+			before: State{
 				V1: &V1{},
 			},
-			expected: VersionedState{
+			expected: State{
 				V1: &V1{
 					ContentSHA: "abc123",
 				},
@@ -272,12 +265,12 @@ func TestMManager_SerializeContentSHA(t *testing.T) {
 		{
 			name:       "no wipe",
 			ContentSHA: "abc123",
-			before: VersionedState{
+			before: State{
 				V1: &V1{
 					ChartRepoURL: "abc123_",
 				},
 			},
-			expected: VersionedState{
+			expected: State{
 				V1: &V1{
 					ContentSHA:   "abc123",
 					ChartRepoURL: "abc123_",
@@ -287,12 +280,12 @@ func TestMManager_SerializeContentSHA(t *testing.T) {
 		{
 			name:       "no wipe, but still override",
 			ContentSHA: "xyz789",
-			before: VersionedState{
+			before: State{
 				V1: &V1{
 					ContentSHA: "abc123",
 				},
 			},
-			expected: VersionedState{
+			expected: State{
 				V1: &V1{
 					ContentSHA: "xyz789",
 				},
@@ -332,16 +325,16 @@ func TestMManager_SerializeHelmValues(t *testing.T) {
 		HelmValues   string
 		HelmDefaults string // is discarded by the function
 		wantErr      bool
-		before       VersionedState
-		expected     VersionedState
+		before       State
+		expected     State
 	}{
 		{
 			name:       "basic test",
 			HelmValues: "abc123",
-			before: VersionedState{
+			before: State{
 				V1: &V1{},
 			},
-			expected: VersionedState{
+			expected: State{
 				V1: &V1{
 					HelmValues: "abc123",
 				},
@@ -350,12 +343,12 @@ func TestMManager_SerializeHelmValues(t *testing.T) {
 		{
 			name:       "no wipe",
 			HelmValues: "abc123",
-			before: VersionedState{
+			before: State{
 				V1: &V1{
 					ChartRepoURL: "abc123_",
 				},
 			},
-			expected: VersionedState{
+			expected: State{
 				V1: &V1{
 					HelmValues:   "abc123",
 					ChartRepoURL: "abc123_",
@@ -365,12 +358,12 @@ func TestMManager_SerializeHelmValues(t *testing.T) {
 		{
 			name:       "no wipe, but still override",
 			HelmValues: "xyz789",
-			before: VersionedState{
+			before: State{
 				V1: &V1{
 					HelmValues: "abc123",
 				},
 			},
-			expected: VersionedState{
+			expected: State{
 				V1: &V1{
 					HelmValues: "xyz789",
 				},
@@ -409,8 +402,8 @@ func TestMManager_SerializeShipMetadata(t *testing.T) {
 		name     string
 		Metadata api.ShipAppMetadata
 		wantErr  bool
-		before   VersionedState
-		expected VersionedState
+		before   State
+		expected State
 	}{
 		{
 			name: "basic test",
@@ -419,10 +412,10 @@ func TestMManager_SerializeShipMetadata(t *testing.T) {
 				Icon:    "test icon",
 				Name:    "test name",
 			},
-			before: VersionedState{
+			before: State{
 				V1: &V1{},
 			},
-			expected: VersionedState{
+			expected: State{
 				V1: &V1{
 					Metadata: &Metadata{
 						ApplicationType: "mock application type",
@@ -465,12 +458,12 @@ func TestMManager_SerializeShipMetadata(t *testing.T) {
 func TestMManager_ResetLifecycle(t *testing.T) {
 	tests := []struct {
 		name     string
-		before   VersionedState
-		expected VersionedState
+		before   State
+		expected State
 	}{
 		{
 			name: "basic test",
-			before: VersionedState{
+			before: State{
 				V1: &V1{
 					Lifecycle: &Lifeycle{
 						StepsCompleted: map[string]interface{}{
@@ -481,7 +474,7 @@ func TestMManager_ResetLifecycle(t *testing.T) {
 					},
 				},
 			},
-			expected: VersionedState{
+			expected: State{
 				V1: &V1{
 					Lifecycle: nil,
 				},
@@ -515,7 +508,7 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 	tests := []struct {
 		name      string
 		runners   []func(*MManager, *require.Assertions, *sync.WaitGroup)
-		validator func(VersionedState, *require.Assertions)
+		validator func(State, *require.Assertions)
 	}{
 		{
 			name: "lists",
@@ -529,7 +522,7 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 					group.Done()
 				},
 			},
-			validator: func(state VersionedState, req *require.Assertions) {
+			validator: func(state State, req *require.Assertions) {
 				req.Len(state.V1.Metadata.Lists, 20)
 			},
 		},
@@ -552,7 +545,7 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 					group.Done()
 				},
 			},
-			validator: func(state VersionedState, req *require.Assertions) {
+			validator: func(state State, req *require.Assertions) {
 				req.Len(state.V1.Metadata.Lists, 0)
 			},
 		},
@@ -573,7 +566,7 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 					group.Done()
 				},
 			},
-			validator: func(state VersionedState, req *require.Assertions) {
+			validator: func(state State, req *require.Assertions) {
 				req.Len(state.V1.Metadata.Lists, 20)
 				req.Equal("tested", state.V1.Metadata.Version)
 			},
@@ -600,7 +593,7 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 					group.Done()
 				},
 			},
-			validator: func(state VersionedState, req *require.Assertions) {
+			validator: func(state State, req *require.Assertions) {
 				req.Len(state.V1.Metadata.Lists, 20)
 				req.Equal("testedName", state.CurrentReleaseName())
 				req.Equal("testedNS", state.CurrentNamespace())
@@ -622,7 +615,7 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
 					// append the integers 1-200 to the upstream
 					for i := 1; i <= 200; i++ {
-						_, err := m.StateUpdate(func(state VersionedState) (VersionedState, error) {
+						_, err := m.StateUpdate(func(state State) (State, error) {
 							state.V1.Upstream += fmt.Sprintf(" a:%d ", i)
 							return state, nil
 						})
@@ -634,7 +627,7 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
 					// append the integers 1-200 to the upstream
 					for i := 1; i <= 200; i++ {
-						_, err := m.StateUpdate(func(state VersionedState) (VersionedState, error) {
+						_, err := m.StateUpdate(func(state State) (State, error) {
 							state.V1.Upstream += fmt.Sprintf(" b:%d ", i)
 							return state, nil
 						})
@@ -646,7 +639,7 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
 					// append the integers 1-200 to the upstream
 					for i := 1; i <= 200; i++ {
-						_, err := m.StateUpdate(func(state VersionedState) (VersionedState, error) {
+						_, err := m.StateUpdate(func(state State) (State, error) {
 							state.V1.Upstream += fmt.Sprintf(" c:%d ", i)
 							return state, nil
 						})
@@ -658,7 +651,7 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
 					// append the integers 1-200 to the upstream
 					for i := 1; i <= 200; i++ {
-						_, err := m.StateUpdate(func(state VersionedState) (VersionedState, error) {
+						_, err := m.StateUpdate(func(state State) (State, error) {
 							state.V1.Upstream += fmt.Sprintf(" d:%d ", i)
 							return state, nil
 						})
@@ -670,7 +663,7 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 				func(m *MManager, req *require.Assertions, group *sync.WaitGroup) {
 					// append the integers 1-200 to the upstream
 					for i := 1; i <= 200; i++ {
-						_, err := m.StateUpdate(func(state VersionedState) (VersionedState, error) {
+						_, err := m.StateUpdate(func(state State) (State, error) {
 							state.V1.Upstream += fmt.Sprintf(" e:%d ", i)
 							return state, nil
 						})
@@ -679,7 +672,7 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 					group.Done()
 				},
 			},
-			validator: func(state VersionedState, req *require.Assertions) {
+			validator: func(state State, req *require.Assertions) {
 				req.Len(state.V1.Metadata.Lists, 20)
 
 				totalUpstream := state.Upstream()
@@ -739,7 +732,7 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 					group.Done()
 				},
 			},
-			validator: func(state VersionedState, req *require.Assertions) {
+			validator: func(state State, req *require.Assertions) {
 				totalCAs := state.CurrentCAs()
 				for _, str := range []string{"a", "b"} {
 					for i := 1; i <= 100; i++ {
@@ -766,7 +759,7 @@ func TestMManager_ParallelUpdates(t *testing.T) {
 				V:      viper.New(),
 			}
 
-			initialState := VersionedState{V1: &V1{Lifecycle: nil}}
+			initialState := State{V1: &V1{Lifecycle: nil}}
 
 			group := sync.WaitGroup{}
 
@@ -793,19 +786,19 @@ func TestMManager_AddCA(t *testing.T) {
 		caName   string
 		newCA    util.CAType
 		wantErr  bool
-		before   VersionedState
-		expected VersionedState
+		before   State
+		expected State
 	}{
 		{
 			name:   "basic test",
 			caName: "aCA",
 			newCA:  util.CAType{Cert: "aCert", Key: "aKey"},
-			before: VersionedState{
+			before: State{
 				V1: &V1{
 					Upstream: "abc123",
 				},
 			},
-			expected: VersionedState{
+			expected: State{
 				V1: &V1{
 					Upstream: "abc123",
 					CAs: map[string]util.CAType{
@@ -818,7 +811,7 @@ func TestMManager_AddCA(t *testing.T) {
 			name:   "add to existing",
 			caName: "bCA",
 			newCA:  util.CAType{Cert: "bCert", Key: "bKey"},
-			before: VersionedState{
+			before: State{
 				V1: &V1{
 					Upstream: "abc123",
 					CAs: map[string]util.CAType{
@@ -826,7 +819,7 @@ func TestMManager_AddCA(t *testing.T) {
 					},
 				},
 			},
-			expected: VersionedState{
+			expected: State{
 				V1: &V1{
 					Upstream: "abc123",
 					CAs: map[string]util.CAType{
@@ -841,7 +834,7 @@ func TestMManager_AddCA(t *testing.T) {
 			wantErr: true,
 			caName:  "aCA",
 			newCA:   util.CAType{Cert: "aCert", Key: "aKey"},
-			before: VersionedState{
+			before: State{
 				V1: &V1{
 					Upstream: "abc123",
 					CAs: map[string]util.CAType{
@@ -849,7 +842,7 @@ func TestMManager_AddCA(t *testing.T) {
 					},
 				},
 			},
-			expected: VersionedState{
+			expected: State{
 				V1: &V1{
 					Upstream: "abc123",
 					CAs: map[string]util.CAType{
@@ -892,19 +885,19 @@ func TestMManager_AddCert(t *testing.T) {
 		certName string
 		newCert  util.CertType
 		wantErr  bool
-		before   VersionedState
-		expected VersionedState
+		before   State
+		expected State
 	}{
 		{
 			name:     "basic test",
 			certName: "aCert",
 			newCert:  util.CertType{Cert: "aCert", Key: "aKey"},
-			before: VersionedState{
+			before: State{
 				V1: &V1{
 					Upstream: "abc123",
 				},
 			},
-			expected: VersionedState{
+			expected: State{
 				V1: &V1{
 					Upstream: "abc123",
 					Certs: map[string]util.CertType{
@@ -917,7 +910,7 @@ func TestMManager_AddCert(t *testing.T) {
 			name:     "add to existing",
 			certName: "bCert",
 			newCert:  util.CertType{Cert: "bCert", Key: "bKey"},
-			before: VersionedState{
+			before: State{
 				V1: &V1{
 					Upstream: "abc123",
 					Certs: map[string]util.CertType{
@@ -925,7 +918,7 @@ func TestMManager_AddCert(t *testing.T) {
 					},
 				},
 			},
-			expected: VersionedState{
+			expected: State{
 				V1: &V1{
 					Upstream: "abc123",
 					Certs: map[string]util.CertType{
@@ -940,7 +933,7 @@ func TestMManager_AddCert(t *testing.T) {
 			wantErr:  true,
 			certName: "aCert",
 			newCert:  util.CertType{Cert: "aCert", Key: "aKey"},
-			before: VersionedState{
+			before: State{
 				V1: &V1{
 					Upstream: "abc123",
 					Certs: map[string]util.CertType{
@@ -948,7 +941,7 @@ func TestMManager_AddCert(t *testing.T) {
 					},
 				},
 			},
-			expected: VersionedState{
+			expected: State{
 				V1: &V1{
 					Upstream: "abc123",
 					Certs: map[string]util.CertType{

--- a/pkg/test-mocks/state/manager_mock.go
+++ b/pkg/test-mocks/state/manager_mock.go
@@ -97,7 +97,7 @@ func (mr *MockManagerMockRecorder) ResetLifecycle() *gomock.Call {
 }
 
 // Save mocks base method
-func (m *MockManager) Save(arg0 state.VersionedState) error {
+func (m *MockManager) Save(arg0 state.State) error {
 	ret := m.ctrl.Call(m, "Save", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0


### PR DESCRIPTION
What I Did
------------
Refactored our state storage mechanisms to no longer support 'empty' and 'v0' state types, significantly simplifying that code

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Ship (not required but encouraged)
------------



![USS Manley (DD-940)](https://upload.wikimedia.org/wikipedia/commons/e/e5/USS_Manley_%28DD-940%29_1975.jpg "USS Manley (DD-940)")








<!-- (thanks https://github.com/docker/docker for this template) -->

