### PR TITLE
include ship version in state file

### DIFF
--- a/integration/base/integration_test.go
+++ b/integration/base/integration_test.go
@@ -114,7 +114,7 @@ var _ = Describe("ship app", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					ignoreUpstreamContents := map[string][]string{
-						".ship/state.json": {"v1.upstreamContents"},
+						".ship/state.json": {"v1.upstreamContents", "v1.shipVersion"},
 					}
 
 					//compare the files in the temporary directory with those in the "expected" directory
@@ -151,7 +151,7 @@ var _ = Describe("ship app", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					ignoreUpstreamContents := map[string][]string{
-						".ship/state.json": {"v1.upstreamContents"},
+						".ship/state.json": {"v1.upstreamContents", "v1.shipVersion"},
 					}
 
 					//compare the files in the temporary directory with those in the "expected" directory

--- a/integration/init/integration_test.go
+++ b/integration/init/integration_test.go
@@ -121,8 +121,12 @@ var _ = Describe("ship init with arbitrary upstream", func() {
 					err := cmd.Execute()
 					Expect(err).NotTo(HaveOccurred())
 
+					ignoreShipVersion := map[string][]string{
+						".ship/state.json": {"v1.shipVersion"},
+					}
+
 					// compare the files in the temporary directory with those in the "expected" directory
-					result, err := integration.CompareDir(path.Join(testPath, "expected"), testOutputPath, replacements, []string{}, map[string][]string{})
+					result, err := integration.CompareDir(path.Join(testPath, "expected"), testOutputPath, replacements, []string{}, ignoreShipVersion)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result).To(BeTrue())
 
@@ -204,8 +208,12 @@ var _ = Describe("ship init with arbitrary upstream", func() {
 					err = editCmd.Execute()
 					Expect(err).NotTo(HaveOccurred())
 
+					ignoreShipVersion := map[string][]string{
+						".ship/state.json": {"v1.shipVersion"},
+					}
+
 					// compare the files in the temporary directory with those in the "expected" directory
-					result, err := integration.CompareDir(path.Join(testPath, "expected"), testOutputPath, replacements, []string{}, map[string][]string{})
+					result, err := integration.CompareDir(path.Join(testPath, "expected"), testOutputPath, replacements, []string{}, ignoreShipVersion)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result).To(BeTrue())
 				}, 60)

--- a/integration/init_app/integration_test.go
+++ b/integration/init_app/integration_test.go
@@ -141,6 +141,7 @@ var _ = Describe("ship init replicated.app/...", func() {
 						".ship/state.json": {
 							"v1.upstreamContents.appRelease.entitlements",
 							"v1.upstreamContents.appRelease.registrySecret",
+							"v1.shipVersion",
 						},
 					}
 
@@ -238,6 +239,7 @@ var _ = Describe("ship init replicated.app/...", func() {
 						".ship/state.json": {
 							"v1.upstreamContents.appRelease.entitlements",
 							"v1.upstreamContents.appRelease.registrySecret",
+							"v1.shipVersion",
 						},
 					}
 

--- a/integration/unfork/integration_test.go
+++ b/integration/unfork/integration_test.go
@@ -102,6 +102,15 @@ var _ = Describe("ship unfork", func() {
 					err := cmd.Execute()
 					Expect(err).NotTo(HaveOccurred())
 
+					if testMetadata.IgnoredKeys == nil {
+						testMetadata.IgnoredKeys = make(map[string][]string)
+					}
+					if _, ok := testMetadata.IgnoredKeys[".ship/state.json"]; ok {
+						testMetadata.IgnoredKeys[".ship/state.json"] = append(testMetadata.IgnoredKeys[".ship/state.json"], "v1.shipVersion")
+					} else {
+						testMetadata.IgnoredKeys[".ship/state.json"] = []string{"v1.shipVersion"}
+					}
+
 					// compare the files in the temporary directory with those in the "expected" directory
 					result, err := integration.CompareDir(path.Join(testPath, "expected"), testOutputPath, replacements, testMetadata.IgnoredFiles, testMetadata.IgnoredKeys)
 					Expect(err).NotTo(HaveOccurred())

--- a/integration/update/integration_test.go
+++ b/integration/update/integration_test.go
@@ -117,6 +117,7 @@ var _ = Describe("ship update", func() {
 						".ship/state.json": {
 							"v1.upstreamContents.appRelease.entitlements",
 							"v1.upstreamContents.appRelease.registrySecret",
+							"v1.shipVersion",
 						},
 					}
 

--- a/pkg/ship/kustomize.go
+++ b/pkg/ship/kustomize.go
@@ -88,6 +88,8 @@ func (s *Ship) Init(ctx context.Context) error {
 		}
 	}
 
+	s.State.UpdateVersion()
+
 	// we already check in the CMD, but no harm in being extra safe here
 	target := s.Viper.GetString("upstream")
 	if target == "" {

--- a/pkg/ship/ship.go
+++ b/pkg/ship/ship.go
@@ -165,6 +165,8 @@ func (s *Ship) Execute(ctx context.Context) error {
 		return err
 	}
 
+	s.State.UpdateVersion()
+
 	debug.Log("phase", "validate-inputs", "status", "complete")
 
 	selector := &replicatedapp.Selector{

--- a/pkg/ship/unfork.go
+++ b/pkg/ship/unfork.go
@@ -37,6 +37,8 @@ func (s *Ship) Unfork(ctx context.Context) error {
 		}
 	}
 
+	s.State.UpdateVersion()
+
 	upstream := s.Viper.GetString("upstream")
 	if upstream == "" {
 		return errors.New("No upstream provided")

--- a/pkg/ship/update.go
+++ b/pkg/ship/update.go
@@ -37,10 +37,12 @@ func (s *Ship) Update(ctx context.Context) error {
 		uiPrintableStatePath = constants.StatePath
 	}
 
-	if existingState.Versioned().V1 == nil {
+	if existingState.IsEmpty() {
 		debug.Log("event", "state.missing")
 		return errors.Errorf(`No state file found at %s please run "ship init"`, uiPrintableStatePath)
 	}
+
+	s.State.UpdateVersion()
 
 	debug.Log("event", "read.upstream")
 	upstreamURL := existingState.Upstream()

--- a/pkg/test-mocks/state/manager_mock.go
+++ b/pkg/test-mocks/state/manager_mock.go
@@ -265,3 +265,13 @@ func (m *MockManager) TryLoad() (state.State, error) {
 func (mr *MockManagerMockRecorder) TryLoad() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TryLoad", reflect.TypeOf((*MockManager)(nil).TryLoad))
 }
+
+// UpdateVersion mocks base method
+func (m *MockManager) UpdateVersion() {
+	m.ctrl.Call(m, "UpdateVersion")
+}
+
+// UpdateVersion indicates an expected call of UpdateVersion
+func (mr *MockManagerMockRecorder) UpdateVersion() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateVersion", reflect.TypeOf((*MockManager)(nil).UpdateVersion))
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -3,7 +3,8 @@ package version
 import "time"
 
 var (
-	build Build
+	build    Build
+	hasBuilt = false
 )
 
 // Build holds details about this build of the Ship binary
@@ -39,24 +40,37 @@ func Init() {
 		Terraform: terraform,
 	}
 	build.Dependencies = deps
+	hasBuilt = true
 }
 
 // GetBuild gets the build
 func GetBuild() Build {
+	if !hasBuilt {
+		Init()
+	}
 	return build
 }
 
 // Version gets the version
 func Version() string {
+	if !hasBuilt {
+		Init()
+	}
 	return build.Version
 }
 
 // GitSHA gets the gitsha
 func GitSHA() string {
+	if !hasBuilt {
+		Init()
+	}
 	return build.GitSHA
 }
 
 // BuildTime gets the build time
 func BuildTime() time.Time {
+	if !hasBuilt {
+		Init()
+	}
 	return build.BuildTime
 }


### PR DESCRIPTION
What I Did
------------
Included the ship version info in the state file. This information is not used by ship at present. Resolves #866.

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------
Ship state includes ship version information.


Picture of a Ship (not required but encouraged)
------------
![USS Du Pont (DD-941)](https://upload.wikimedia.org/wikipedia/commons/9/91/USS_Du_Pont_%28DD-941%29_off_Lebanon.jpg "USS Du Pont (DD-941)")











<!-- (thanks https://github.com/docker/docker for this template) -->

