### PR TITLE
update cypress tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
             - ship/bin
   e2e_setup:
     docker:
-      - image: cypress/browsers:chrome67
+      - image: cypress/browsers:node8.9.3-chrome73
     working_directory: ~/ship
     steps:
       - checkout
@@ -130,7 +130,7 @@ jobs:
           key: ship-e2e-setup-cy-3.1.0
   e2e_init:
     docker:
-      - image: cypress/browsers:chrome67
+      - image: cypress/browsers:node8.9.3-chrome73
     working_directory: ~/ship
     steps:
       - checkout

--- a/web/app/cypress/Dockerfile
+++ b/web/app/cypress/Dockerfile
@@ -6,7 +6,7 @@ ADD . /go/src/github.com/replicatedhq/ship
 WORKDIR /go/src/github.com/replicatedhq/ship
 RUN make build-ci-cypress
 
-FROM cypress/browsers:chrome67
+FROM cypress/browsers:node8.9.3-chrome73
 # Unzipping of Cypress binary very slow through npm install
 # Instead, pull binary directly
 # TODO: Verify checksum of binary

--- a/web/app/cypress/integration/init/testchart.spec.js
+++ b/web/app/cypress/integration/init/testchart.spec.js
@@ -75,7 +75,7 @@ describe("Ship Init test-charts/modify-chart", () => {
 
   context("outro", () => {
     it("allows the user to complete wizard", () => {
-      cy.get(".btn").first().click();
+      cy.get(".btn.primary", {timeout: 10000}).first().click({force: true});
     })
   })
 });


### PR DESCRIPTION
What I Did
------------
Cypress tests (e2e_init) should be slightly more reliable. 

How I Did it
------------
Cypress tests use Chrome 73
Added `force:true` and a longer timeout to the last button click


How to verify it
------------


Description for the Changelog
------------



Picture of a Ship (not required but encouraged)
------------


![USS Hull (DD-945)](https://upload.wikimedia.org/wikipedia/commons/6/6e/Uss_Hull_DD-945.jpg "USS Hull (DD-945)")









<!-- (thanks https://github.com/docker/docker for this template) -->

