### PR TITLE
Resolve goreleaser warnings and release a versioned 'full' image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -544,7 +544,6 @@ jobs:
                docker pull replicated/ship:slim # this should be a no-op since we just built it, but just in case
                docker build -t replicated/ship:full -f deploy/Dockerfile-full deploy
                docker push replicated/ship:full
-
             fi
       # todo drop a release-api message to bump a version in the DB
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -544,6 +544,12 @@ jobs:
                docker pull replicated/ship:slim # this should be a no-op since we just built it, but just in case
                docker build -t replicated/ship:full -f deploy/Dockerfile-full deploy
                docker push replicated/ship:full
+
+               # this isn't as good as pushing major + minor + patch images independently
+               # but it's better than not including a versioned 'full' image at all
+               docker tag replicated/ship:full replicated/ship:"$(git describe)"-full
+               docker push replicated/ship:"$(git describe)"-full
+
             fi
       # todo drop a release-api message to bump a version in the DB
 

--- a/deploy/.goreleaser.unstable.yml
+++ b/deploy/.goreleaser.unstable.yml
@@ -34,7 +34,8 @@ builds:
   flags: -tags netgo -installsuffix netgo
   binary: ship
   hooks: {}
-archive:
+archives:
+- id: zip
   format: tar.gz
   name_template: '{{ .Binary }}_{{.Version}}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{.Arm }}{{ end }}-alpha'
   files:
@@ -47,10 +48,9 @@ archive:
   - changelog*
   - CHANGELOG*
 dockers:
-  - image: replicated/ship
-    dockerfile: deploy/Dockerfile
-    tag_templates:
-      - "alpha"
-      - "alpha-slim"
+  - dockerfile: deploy/Dockerfile
+    image_templates:
+    - "replicated/ship:alpha"
+    - "replicated/ship:alpha-slim"
 snapshot:
   name_template: SNAPSHOT-{{ .Commit }}

--- a/deploy/.goreleaser.yml
+++ b/deploy/.goreleaser.yml
@@ -34,7 +34,8 @@ builds:
   flags: -tags netgo -installsuffix netgo
   binary: ship
   hooks: {}
-archive:
+archives:
+- id: zip
   format: tar.gz
   name_template: '{{ .Binary }}_{{.Version}}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{.Arm }}{{ end }}'
   files:
@@ -47,16 +48,15 @@ archive:
   - changelog*
   - CHANGELOG*
 dockers:
-  - image: replicated/ship
-    dockerfile: deploy/Dockerfile
-    tag_templates:
-      - "latest"
-      - "{{ .Major }}"
-      - "{{ .Major }}.{{ .Minor }}"
-      - "{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
-      - "slim"
-      - "{{ .Major }}-slim"
-      - "{{ .Major }}.{{ .Minor }}-slim"
-      - "{{ .Major }}.{{ .Minor }}.{{ .Patch }}-slim"
+  - dockerfile: deploy/Dockerfile
+    image_templates:
+      - "replicated/ship:latest"
+      - "replicated/ship:{{ .Major }}"
+      - "replicated/ship:{{ .Major }}.{{ .Minor }}"
+      - "replicated/ship:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+      - "replicated/ship:slim"
+      - "replicated/ship:{{ .Major }}-slim"
+      - "replicated/ship:{{ .Major }}.{{ .Minor }}-slim"
+      - "replicated/ship:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-slim"
 snapshot:
   name_template: SNAPSHOT-{{ .Commit }}

--- a/web/app/cypress/integration/init/testchart.spec.js
+++ b/web/app/cypress/integration/init/testchart.spec.js
@@ -62,7 +62,7 @@ describe("Ship Init test-charts/modify-chart", () => {
       });
       context("valid Kustomize overlay written", () => {
         it("allows the overlay to be saved", () => {
-          cy.get(".primary").click();
+          cy.get(".save-btn").click();
         });
 
         it("allows navigation to the overlay finalization step", () => {


### PR DESCRIPTION
What I Did
------------
Resolved deprecation warnings in our goreleaser configs.
Added code to release a 'full' image with a semver tag.

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Ship (not required but encouraged)
------------



![USS Somers (DDG-34, ex-DD-947)](https://upload.wikimedia.org/wikipedia/commons/0/0d/USS_Somers_%28DDG-34%29_underway%2C_circa_in_the_early_1980s_%286483131%29.jpg "USS Somers (DDG-34, ex-DD-947)")








<!-- (thanks https://github.com/docker/docker for this template) -->

