### PR TITLE
Bj task 20111

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,10 +168,12 @@ Maintainers of OTS (Off the Shelf) software can customize the `ship init` experi
 
 For those not interested in operating and maintaining a fleet of Ship instances, [Ship Cloud](https://www.replicated.com/ship) is available as a hosted solution for free.   With Ship Cloud, teams can collaborate and manage multiple OTS Kubernetes application settings in one place, with Ship watching and updating on any upstream or local configuration changes, and creating Pull Requests and other integrations into CI/CD systems.
 
+# Contributions and Local Development
+
+For instructions for building the project and making contributions, see [Contributing](./CONTRIBUTING.md).
+
 # Community
 
 For questions about using Ship, there's a [Replicated Community](https://help.replicated.com/community) forum, and a [#ship channel in Kubernetes Slack](https://kubernetes.slack.com/channels/ship).
 
 For bug reports, please [open an issue](https://github.com/replicatedhq/ship/issues/new) in this repo.
-
-For instructions on building the project and making contributions, see [Contributing](./CONTRIBUTING.md)

--- a/web/init/package.json
+++ b/web/init/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@babel/runtime": "^7.3.4",
     "brace": "^0.11.1",
+    "classnames": "^2.2.6",
     "history": "^4.7.2",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.11",

--- a/web/init/src/ErrorBoundary.jsx
+++ b/web/init/src/ErrorBoundary.jsx
@@ -22,7 +22,7 @@ export default class ErrorBoundary extends React.Component {
 
   render() {
     return (
-      <div className="flex-column flex1">
+      <div className="flex flex1">
         {this.state.hasError ? <div>{this.state.error.toString()}</div> : null}
         {this.props.children}
       </div>

--- a/web/init/src/components/kustomize/HelmChartInfo.jsx
+++ b/web/init/src/components/kustomize/HelmChartInfo.jsx
@@ -9,8 +9,10 @@ const HelmChartInfo = ({ shipAppMetadata, isUpdate, actions, handleAction, isLoa
         <div className="HelmIntro--wrapper flex-column">
           <p className="u-fontSize--jumbo2 u-color--tuna u-fontWeight--bold u-lineHeight--normal">Set custom values in your Helm chart</p>
           <p className="u-fontSize--normal u-fontWeight--medium u-color--dustyGray u-lineHeight--more">
-            {isUpdate ? `Let’s update the ${shipAppMetadata.name} application. Ship has downloaded the latest version of the Helm chart, and can merge your patches into the latest upstream, or allow you to edit your patches.` :
-            `Let's prepare the ${shipAppMetadata.name} chart for a Production Grade deployment. To get started, we need to confirm the values to use when generating Kubernetes YAML from the Helm chart. Click continue to review the standard values provided in the chart.` }
+            {isUpdate 
+              ? `Let’s update the ${shipAppMetadata.name} application. Ship has downloaded the latest version of the Helm chart, and can merge your patches into the latest upstream, or allow you to edit your patches.` 
+              : `Let's prepare the ${shipAppMetadata.name} chart for a Production Grade deployment. To get started, we need to confirm the values to use when generating Kubernetes YAML from the Helm chart. Click continue to review the standard values provided in the chart.` 
+            }
           </p>
           <div className="HelmIntro--diagram flex">
             <div className="detailed-steps flex flex-column">
@@ -65,9 +67,9 @@ const HelmChartInfo = ({ shipAppMetadata, isUpdate, actions, handleAction, isLoa
         </div>
       </div>
       <div className="actions-wrapper container u-width--full flex flex-auto">
-        {firstRoute ? null :
+        {!firstRoute && 
           <div className="flex-auto u-marginRight--normal">
-            <button className="btn secondary" onClick={() => goBack()}>Back</button>
+            <button className="btn secondary" onClick={goBack}>Back</button>
           </div>
         }
         <div className="flex1 flex justifyContent--flexEnd">

--- a/web/init/src/components/kustomize/HelmValuesEditor.jsx
+++ b/web/init/src/components/kustomize/HelmValuesEditor.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import * as linter from "replicated-lint";
+import classNames from "classnames";
 import Linter from "../shared/Linter";
 import AceEditor from "react-ace";
 import ErrorBoundary from "../../ErrorBoundary";
@@ -214,7 +215,7 @@ export default class HelmValuesEditor extends React.Component {
                 />
               </div> : null}
             </div>
-            <div className="AceEditor--wrapper helm-values flex1 flex u-height--full u-width--full">
+            <div className={classNames("AceEditor--wrapper helm-values flex1 flex u-height--full u-width--full", {shorten: displaySettings})}>
               <div className="flex1 flex-column u-width--half">
                 <AceEditor
                   ref={(editor) => { this.helmEditor = editor }}

--- a/web/init/src/components/kustomize/HelmValuesEditor.jsx
+++ b/web/init/src/components/kustomize/HelmValuesEditor.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import * as linter from "replicated-lint";
-import classNames from "classnames";
 import Linter from "../shared/Linter";
 import AceEditor from "react-ace";
 import ErrorBoundary from "../../ErrorBoundary";
@@ -215,7 +214,7 @@ export default class HelmValuesEditor extends React.Component {
                 />
               </div> : null}
             </div>
-            <div className={classNames("AceEditor--wrapper helm-values flex1 flex u-height--full u-width--full", {shorten: displaySettings})}>
+            <div className="AceEditor--wrapper helm-values flex1 flex u-height--full u-width--full">
               <div className="flex1 flex-column u-width--half">
                 <AceEditor
                   ref={(editor) => { this.helmEditor = editor }}

--- a/web/init/src/components/shared/DetermineComponentForRoute.jsx
+++ b/web/init/src/components/shared/DetermineComponentForRoute.jsx
@@ -290,7 +290,7 @@ export class DetermineComponentForRoute extends React.Component {
     return (
       <div className="flex-column flex1">
         <div className="flex-column flex1 u-overflow--hidden u-position--relative">
-          <div className="flex-1-auto flex-column u-overflow--auto">
+          <div className="flex-1-auto flex u-overflow--auto">
             {(isLoadingStep || dataLoading.getMetadataLoading) && !this.state.maxPollReached ?
               <div className="flex1 flex-column justifyContent--center alignItems--center">
                 <Loader size="60" />

--- a/web/init/src/scss/components/kustomize/HelmValuesEditor.scss
+++ b/web/init/src/scss/components/kustomize/HelmValuesEditor.scss
@@ -1,4 +1,11 @@
-.AceEditor--wrapper.helm-values {
+.AceEditor--wrapper {
+  max-height: 68vh;
+
+  &.shorten {
+    max-height: 50vh;
+  }
+
+  &.helm-values {
     margin-bottom: 30px;
     overflow: auto;
     border: 1px solid #C4C8CA;
@@ -8,31 +15,32 @@
       background:#FBEDEB;
       position: absolute;
     }
-  
+
     .disabled-ace-editor {
       opacity: .5;
     }
-  
+
     .ace_search {
       left: 0;
       right: auto;
     }
-
   }
 
-  .advanced-settings-wrapper {
-    .section-border {
-      border-bottom: 1px solid #DFDFDF;
-      &.closed {
-        margin-bottom: 35px;
-      }
-      & p {
-        top: -13px;
-        position: absolute;
-        border: solid 1px #DFDFDF;
-        border-radius: 50px;
-        padding: 5px;
-        background: #fff;
-      }
+}
+
+.advanced-settings-wrapper {
+  .section-border {
+    border-bottom: 1px solid #DFDFDF;
+    &.closed {
+      margin-bottom: 35px;
+    }
+    & p {
+      top: -13px;
+      position: absolute;
+      border: solid 1px #DFDFDF;
+      border-radius: 50px;
+      padding: 5px;
+      background: #fff;
     }
   }
+}

--- a/web/init/src/scss/components/kustomize/HelmValuesEditor.scss
+++ b/web/init/src/scss/components/kustomize/HelmValuesEditor.scss
@@ -1,10 +1,4 @@
 .AceEditor--wrapper {
-  max-height: 68vh;
-
-  &.shorten {
-    max-height: 50vh;
-  }
-
   &.helm-values {
     margin-bottom: 30px;
     overflow: auto;

--- a/web/init/yarn.lock
+++ b/web/init/yarn.lock
@@ -2814,7 +2814,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5:
+classnames@^2.2.5, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==


### PR DESCRIPTION
What I Did
------------
I added a `max-height` rule to make sure the page isn't super long when someone is viewing a long README.md file in the Helm Chart editor.

How I Did it
------------
* Add a `max-height` value to the HelmChartInfo component to add a scrollbar for long README files
* Put a ternary on a new line so it's easier to compare the string values
* Removed an unnecessary anonymous function
* added the lovely [classnames](https://github.com/JedWatson/classnames) package to the `init` package.


How to verify it
------------
1. Create a new watch by adding a popular Helm chart URL like DataDog or Graphana
2. Go through the flow until you get to the editor page.

Description for the Changelog
------------
Fixed an issue where long README.md files on the helm chart editor page would make the page extremely long when viewing the README.md file with the YAML editor.


Picture of a Ship (not required but encouraged)
------------
![this-is-a-ship-shipping-ship-shipping-shipping-ships-31872584](https://user-images.githubusercontent.com/7918387/58287595-44727a00-7d66-11e9-88fe-654464a55158.png)












<!-- (thanks https://github.com/docker/docker for this template) -->

