### PR TITLE
Bj feature 20124

### DIFF
--- a/web/init/props.md
+++ b/web/init/props.md
@@ -10,3 +10,4 @@ apiEndpoint|string||Yes|API endpoint for the Ship binary
 basePath|string|""|No|Base path name for the internal Ship Init component router<br>Note: If basePath is omitted, it will default the base route to "/"
 headerEnabled|bool|false|No|Determines whether default header is displayed
 history|object|null|No|Parent history needed to sync Ship routing with parent<br>Note: Defaults to instantiate own internal BrowserRouter if omitted.
+onError|function|undefined|No|If there's an error inside of the component, `onError` will be called with the `error` and `info` arguments in `componentDidCatch` [lifecycle method](https://reactjs.org/docs/react-component.html#componentdidcatch).

--- a/web/init/src/ErrorBoundary.jsx
+++ b/web/init/src/ErrorBoundary.jsx
@@ -1,5 +1,8 @@
 import React from "react";
 
+/**
+ * Creates an error boundary for any child component rendered inside
+ */
 export default class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props);
@@ -10,21 +13,25 @@ export default class ErrorBoundary extends React.Component {
     }
   }
 
-  componentDidCatch(error, info) {
-    this.setState({
-      error: error,
-      errorInfo: info,
+  static getDerivedStateFromError(error) {
+    return {
+      error,
       hasError: true
-    });
+    };
+  }
+
+  componentDidCatch() {
     // We can thow an error modal, or some sort of error UI that can be used globally.
     // We should also send this error to bugsnag or some sort of reporting service here.
   }
 
   render() {
+    const { children } = this.props;
+    const { hasError, error } = this.state;
     return (
       <div className="flex flex1">
-        {this.state.hasError ? <div>{this.state.error.toString()}</div> : null}
-        {this.props.children}
+        {hasError && <div>{error.toString()}</div>}
+        {children}
       </div>
     );
   }

--- a/web/init/src/Ship.jsx
+++ b/web/init/src/Ship.jsx
@@ -22,7 +22,7 @@ export class Ship extends React.Component {
     history: PropTypes.object,
     /** Callback function to be invoked at the finalization of the Ship Init flow */
     onCompletion: PropTypes.func,
-    /** Callback function to be invoked when there's an unresolved error thrown */
+    /** Callback function to be invoked when there's an unresolved error thrown followed componentDidCatch() method signature */
     onError: PropTypes.func
   }
 

--- a/web/init/src/Ship.jsx
+++ b/web/init/src/Ship.jsx
@@ -22,6 +22,8 @@ export class Ship extends React.Component {
     history: PropTypes.object,
     /** Callback function to be invoked at the finalization of the Ship Init flow */
     onCompletion: PropTypes.func,
+    /** Callback function to be invoked when there's an unresolved error thrown */
+    onError: PropTypes.func
   }
 
   static defaultProps = {
@@ -47,6 +49,13 @@ export class Ship extends React.Component {
       this.setState({
         store: configureStore(apiEndpoint)
       });
+    }
+  }
+
+  componentDidCatch(error, errorInfo) {
+    const { onError } = this.props;
+    if (onError) {
+      onError(error, errorInfo);
     }
   }
 


### PR DESCRIPTION
What I Did
------------
Added an Error Boundary to the top level component and a callback prop

How I Did it
------------
I used the `componentDidCatch` lifecycle method and added an `onError` prop to the `<Ship>` component so users can catch their own errors and do stuff about it when `Ship` has some sort of error that happens due to config or whatnot.


How to verify it
------------
Intentionally throw an error or pass a bad prop into `<Ship>`


Description for the Changelog
------------
* Added an `onError` prop so you can pass in a function to be called when something goes wrong in the `<Ship>` react component.


Picture of a Ship (not required but encouraged)
------------

![lcs-1-060923-O-0000X-001](https://user-images.githubusercontent.com/7918387/58500003-26c25d80-8136-11e9-9cdf-b3b3aeb8b7d3.jpg)










<!-- (thanks https://github.com/docker/docker for this template) -->

