### PR TITLE
Ignore 504 errors while polling for progress

### DIFF
--- a/web/init/package.json
+++ b/web/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replicatedhq/ship-init",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Shared component that contains the Ship Init app",
   "author": "Replicated, Inc.",
   "license": "Apache-2.0",

--- a/web/init/src/redux/data/appRoutes/actions.js
+++ b/web/init/src/redux/data/appRoutes/actions.js
@@ -94,6 +94,11 @@ export function pollContentForStep(stepId, cb) {
         clearInterval(intervalId);
         return;
       });
+      // Ignore Gateway Timeout errors
+      if (body.status === 504) {
+        return;
+      }
+      
       dispatch(setProgress(body.progress));
 
       const { progress } = body;


### PR DESCRIPTION
What I Did
------------
I stopped the console from yelling when there's a 504 error in `ship`

How I Did it
------------
I added a conditional in the polling method to suppress the error.

How to verify it
------------
Edit a helm chart with a custom config where the GET endpoint to `apiEndpoint` is set up to return a 504 error.

Description for the Changelog
------------
* Suppressed 504 issues and progress bar errors while awaiting an API response


Picture of a Ship (not required but encouraged)
------------
![e4c97939c1db2c28e975578e9e2e8e1b](https://user-images.githubusercontent.com/7918387/58599136-c1549680-8233-11e9-8117-07cc29f401a9.jpg)












<!-- (thanks https://github.com/docker/docker for this template) -->

