### PR TITLE
Upgrade to @babel/polyfill. 

### DIFF
--- a/web/init/.babelrc
+++ b/web/init/.babelrc
@@ -1,7 +1,8 @@
 {
   "presets": [
     ["@babel/preset-env", {
-      "modules": false
+      "modules": false,
+      "useBuiltIns": "entry"
     }],
     "@babel/preset-react"
   ],

--- a/web/init/package.json
+++ b/web/init/package.json
@@ -8,8 +8,8 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "webpack --config webpack.config.js --mode production",
-    "build-dev": "npm run build -- --mode development",
-    "start": "npm run build-dev -- --colors --watch",
+    "build-dev": "webpack --config webpack.config.js --mode development",
+    "start": "yarn build-dev --colors --watch",
     "dashboard": "cross-env DASHBOARD=true webpack-dashboard -m -- npm run start",
     "gen-prop-docs": "rmd Ship src/Ship.jsx props.md",
     "test": "node scripts/test.js --env=jsdom"
@@ -46,6 +46,7 @@
     "@babel/cli": "^7.1.2",
     "@babel/core": "^7.1.2",
     "@babel/plugin-proposal-class-properties": "^7.1.0",
+    "@babel/polyfill": "^7.4.4",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-stage-0": "^7.0.0",
@@ -59,7 +60,6 @@
     "babel-jest": "^23.6.0",
     "babel-loader": "^8.0.4",
     "babel-plugin-rewire": "^1.2.0",
-    "babel-polyfill": "^6.26.0",
     "babel-preset-react-app": "^3.1.2",
     "chai": "^4.1.2",
     "cross-env": "^5.2.0",

--- a/web/init/package.json
+++ b/web/init/package.json
@@ -8,8 +8,8 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "webpack --config webpack.config.js --mode production",
-    "build-dev": "webpack --config webpack.config.js --mode development",
-    "start": "yarn build-dev --colors --watch",
+    "build-dev": "npm run build -- --mode development",
+    "start": "npm run build-dev -- --colors --watch",
     "dashboard": "cross-env DASHBOARD=true webpack-dashboard -m -- npm run start",
     "gen-prop-docs": "rmd Ship src/Ship.jsx props.md",
     "test": "node scripts/test.js --env=jsdom"

--- a/web/init/src/index.js
+++ b/web/init/src/index.js
@@ -1,2 +1,4 @@
+import "@babel/polyfill";
+
 export { Ship } from "./Ship.jsx"
 export { ShipConfigRenderer } from "./ShipConfigRenderer.jsx"

--- a/web/init/webpack.config.js
+++ b/web/init/webpack.config.js
@@ -51,8 +51,7 @@ module.exports = (env, { mode }) => {
 
   return {
     entry: [
-        "babel-polyfill",
-        path.resolve(__dirname, 'src/index.js'),
+      path.resolve(__dirname, 'src/index.js')
     ],
     mode: "production",
     output: {

--- a/web/init/yarn.lock
+++ b/web/init/yarn.lock
@@ -611,6 +611,14 @@
     "@babel/helper-regex" "^7.0.0"
     regexpu-core "^4.1.3"
 
+"@babel/polyfill@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.4.4.tgz#78801cf3dbe657844eeabf31c1cae3828051e893"
+  integrity sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==
+  dependencies:
+    core-js "^2.6.5"
+    regenerator-runtime "^0.13.2"
+
 "@babel/preset-env@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.1.0.tgz#e67ea5b0441cfeab1d6f41e9b5c79798800e8d11"
@@ -2039,15 +2047,6 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-polyfill@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
-  integrity sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=
-  dependencies:
-    babel-runtime "^6.26.0"
-    core-js "^2.5.0"
-    regenerator-runtime "^0.10.5"
-
 babel-preset-env@1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.6.1.tgz#a18b564cc9b9afdf4aae57ae3c1b0d99188e6f48"
@@ -3198,6 +3197,11 @@ core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
   integrity sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==
+
+core-js@^2.6.5:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
+  integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
 
 core-js@~2.3.0:
   version "2.3.0"
@@ -9991,15 +9995,15 @@ regenerate@^1.2.1, regenerate@^1.4.0:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
 
-regenerator-runtime@^0.10.5:
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
-  integrity sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=
-
 regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
+
+regenerator-runtime@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
 
 regenerator-transform@^0.10.0:
   version "0.10.1"


### PR DESCRIPTION
What I Did
------------
I removed `babel-polyfill` and replaced it with `@babel/polyfill`

How I Did it
------------
Edited the `webpack` configuration and imported `@babel/polyfill` in the 


How to verify it
------------
Look at `package.json` and see the absence of `babel-polyfill`. The project should also be building correctly.

Description for the Changelog
------------
Updated internal libraries and tools to further reduce bundle size.


Picture of a Ship (not required but encouraged)
------------
![714PH4X5FRL _SX311_BO1,204,203,200_](https://user-images.githubusercontent.com/7918387/58666334-e60a4600-82e7-11e9-8ac1-063a361d85e1.jpg)

Note: [This is a real book](https://www.amazon.com/Avoid-Huge-Ships-John-Trimmer/dp/0870334336)











<!-- (thanks https://github.com/docker/docker for this template) -->

