### PR TITLE
fix ineffassign issues exposed in CI

### DIFF
--- a/pkg/specs/interface.go
+++ b/pkg/specs/interface.go
@@ -58,7 +58,7 @@ func (r *Resolver) ResolveUnforkRelease(ctx context.Context, upstream string, fo
 		return nil, errors.New("Unsupported fork and upstream combination")
 	}
 
-	forkedAsset := api.Asset{}
+	var forkedAsset api.Asset
 	switch forkedApp.GetType() {
 	case "helm":
 		forkedAsset = api.Asset{
@@ -89,7 +89,7 @@ func (r *Resolver) ResolveUnforkRelease(ctx context.Context, upstream string, fo
 		return nil, errors.Errorf("unknown forked application type %q", forkedApp.GetType())
 	}
 
-	upstreamAsset := api.Asset{}
+	var upstreamAsset api.Asset
 	switch upstreamApp.GetType() {
 	case "helm":
 		upstreamAsset = api.Asset{


### PR DESCRIPTION
What I Did
------------
Fixed ineffassign issues:
```
/go/src/github.com/replicatedhq/ship/pkg/specs/interface.go:61:2: ineffectual assignment to forkedAsset
/go/src/github.com/replicatedhq/ship/pkg/specs/interface.go:92:2: ineffectual assignment to upstreamAsset
```

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Ship (not required but encouraged)
------------
![USS Henry B. Wilson (DD-957/DDG-7)](https://upload.wikimedia.org/wikipedia/commons/thumb/5/55/USS_Henry_B._Wilson_%28DDG-7%29_underway_off_the_coast_of_Southern_California_on_21_April_1989_%286449805%29.jpg/1280px-USS_Henry_B._Wilson_%28DDG-7%29_underway_off_the_coast_of_Southern_California_on_21_April_1989_%286449805%29.jpg "USS Henry B. Wilson (DD-957/DDG-7)")










<!-- (thanks https://github.com/docker/docker for this template) -->

