### PR TITLE
disable building the unified integration test container as it is now unused

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -639,18 +639,6 @@ workflows:
           filters:
             branches:
               only: /master/
-      - deploy_integration:
-          requires:
-          - integration_base
-          - integration_init
-          - integration_init_edit
-          - integration_unfork
-          - integration_init_app
-          - integration_update
-          - deploy_unstable
-          filters:
-            branches:
-              only: /master/
 
 # Stable deploys the `alpha` and `latest` tags to dockerhub and github
   stable:


### PR DESCRIPTION
What I Did
------------


How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Ship (not required but encouraged)
------------


![Akizuki (DD-161)](https://upload.wikimedia.org/wikipedia/commons/b/bd/JS_Akiduki%28DD-161%29.jpg "Akizuki (DD-161)" )









<!-- (thanks https://github.com/docker/docker for this template) -->

