### PR TITLE
avoid deadlocks when starting the terraform lifecycle step

### DIFF
--- a/pkg/lifecycle/daemon/routes_navcycle_completestep.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_completestep.go
@@ -75,6 +75,7 @@ func (d *NavcycleRoutes) handleAsync(errChan chan error, debug log.Logger, step 
 	_, err := d.StateManager.StateUpdate(func(currentState state.State) (state.State, error) {
 		return currentState.WithCompletedStep(step), nil
 	})
+
 	if err != nil {
 		level.Error(d.Logger).Log("event", "state.save.fail", "err", err, "step.id", stepID)
 		return
@@ -97,11 +98,11 @@ func (d *NavcycleRoutes) awaitAsyncStep(errChan chan error, debug log.Logger, st
 				level.Error(debug).Log("event", "async.fail", "err", err, "errorWithStack", errToPrint, "progress", d.progress(step))
 				return err
 			}
-			level.Info(debug).Log("event", "task.complete", "progess", d.progress(step))
+			level.Info(debug).Log("event", "task.complete", "progress", d.progress(step))
 			return nil
 		// debug log progress every ten seconds
 		case <-time.After(10 * time.Second):
-			debug.Log("event", "task.running", "progess", d.progress(step))
+			debug.Log("event", "task.running", "progress", d.progress(step))
 		}
 	}
 }


### PR DESCRIPTION
What I Did
------------
In #937, a lock was added to prevent the "have all required steps been completed" checker from not including the previous step. This PR modifies the lock logic to first check if all required steps are completed before waiting for the currently running step to complete, and only waiting if there are incomplete steps.

This resolves an issue encountered with some terraform steps that produce large plans.

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------

Resolved an issue encountered with some terraform steps.


Picture of a Ship (not required but encouraged)
------------
![USS Elliot (DD-967)](https://upload.wikimedia.org/wikipedia/commons/6/67/USS_Elliot_%28DD-967%29_underway_in_the_Persian_Gulf%2C_in_1991.jpg "USS Elliot (DD-967)")











<!-- (thanks https://github.com/docker/docker for this template) -->

