### PR TITLE
disable gogetter unit tests for bitbucket

### DIFF
--- a/pkg/specs/gogetter/go_getter_test.go
+++ b/pkg/specs/gogetter/go_getter_test.go
@@ -25,12 +25,18 @@ func TestIsGoGettable(t *testing.T) {
 			path: "github.com/replicatedhq/ship",
 			want: true,
 		},
-		{
-			name: "bitbucket",
-			// this needs to be a valid bitbucket repo to work
-			path: "bitbucket.org/ww/goautoneg",
-			want: true,
-		},
+		// {
+		// 	name: "bitbucket",
+		// 	// this needs to be a valid bitbucket repo to work
+		// 	path: "bitbucket.org/hashicorp/tf-test-git",
+		// 	want: true,
+		// },
+		// {
+		// 	name: "bitbucket",
+		// 	// this needs to be a valid bitbucket repo to work
+		// 	path: "bitbucket.org/hashicorp/tf-test-hg",
+		// 	want: true,
+		// },
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
this appears to be due to a change on Atlassian's end

see https://github.com/hashicorp/go-getter/issues/183

What I Did
------------


How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Ship (not required but encouraged)
------------

![USS Arthur W. Radford (DD-968)](https://upload.wikimedia.org/wikipedia/commons/3/30/US_Navy_021127-N-3653A-004_Spruance-class_Arthur_W._Radford_steams_through_the_Mediterranean_Sea.jpg "USS Arthur W. Radford (DD-968)")










<!-- (thanks https://github.com/docker/docker for this template) -->

