### PR TITLE
Preserve license info in ship edit

### DIFF
--- a/integration/init_app/license-info/expected/.ship/release.yml
+++ b/integration/init_app/license-info/expected/.ship/release.yml
@@ -1,0 +1,15 @@
+---
+assets:
+  v1:
+    - inline:
+        contents: |
+          {{repl ShipCustomerRelease }}
+        dest: ./license-info.yaml
+        mode: 0777
+
+config:
+    v1: []
+
+lifecycle:
+  v1:
+    - render: {}

--- a/integration/init_app/license-info/expected/.ship/state.json
+++ b/integration/init_app/license-info/expected/.ship/state.json
@@ -1,0 +1,80 @@
+{
+  "v1": {
+    "config": {},
+    "releaseName": "nightly",
+    "upstream": "staging.replicated.app/ship-integration-testing/?license_id=hLHawMDiyQIeFS7kqVFtD2f44LNh8u5Z\u0026semver=0.0.1",
+    "metadata": {
+      "applicationType": "replicated.app",
+      "sequence": 0,
+      "releaseNotes": "",
+      "version": "0.0.1",
+      "licenseID": "hLHawMDiyQIeFS7kqVFtD2f44LNh8u5Z",
+      "appSlug": "ship-integration-testing",
+      "license": {
+        "id": "hLHawMDiyQIeFS7kqVFtD2f44LNh8u5Z",
+        "assignee": "customer info test",
+        "createdAt": "2019-06-11T21:24:30Z",
+        "expiresAt": "0001-01-01T00:00:00Z",
+        "type": "dev"
+      }
+    },
+    "upstreamContents": {
+      "appRelease": {
+        "id": "TncM-Wu2g4OxW2exEFKTaYoXNZGGDE4H",
+        "sequence": 1,
+        "channelId": "1TzgBWDvp4PW3xUfdJ7FqyCsoztmDxiv",
+        "channelName": "Nightly",
+        "channelIcon": "",
+        "semver": "0.0.1",
+        "releaseNotes": "",
+        "spec": "---\nassets:\n  v1:\n    - inline:\n        contents: |\n          {{repl ShipCustomerRelease }}\n        dest: ./license-info.yaml\n        mode: 0777\n\nconfig:\n    v1: []\n\nlifecycle:\n  v1:\n    - render: {}",
+        "images": [],
+        "githubContents": [],
+        "created": "Tue Jun 11 2019 21:24:11 GMT+0000 (UTC)",
+        "registrySecret": "3bfd99a69b5748fab756a593c7dcc852",
+        "entitlements": {
+          "meta": {
+            "last_updated": "0001-01-01T00:00:00Z",
+            "customer_id": ""
+          },
+          "signature": "eVlVacoh3aPSx+EvhmD+B8vG3QicsaWkJ+9vcFReB2xRgPtNgedfQkS7bmJxNwCHZlcOXX/m1io5IkFFXPdW4mXvIRO/5p6xJWFj/icU1iHOBPYf6Q2pEC9+ylXAj8upyPPGGJc+MN5X83Sxk/JumRJPMCNoykwgixkai7NtiZgEjvyfMLPZhYwZ5MBNEv6CJ5NCCw7JO1Ga8G6CDa6E3NLsFJLLLcYUQO+7+hDb9IMxkynHJCoazJ1587fVUgeZ1QLt+mWdJoILn+ioDH4TJ0XZMWvLdRDoV6JTugs1O3O9qh3sMu5C2fow0i3Cnr+K8DsWDpazXTBQzd2ZIuUFf02CgCEF+0M/o9DMbpocePjmHufxZXcEl3jv8rMv5wa6civwRA9W8dbv+eepMf4ngcUP/hxz4WkCSTWT5Zf6+JngXYylDZta+/HnzRMczhG9Laaa+TRhm+fsxApQ4wORvdms3xwcxg35FTzUy4gMoSCLFiNjN7e/GZWsb9NYlFoI/sfhqVsNljFJlN4+XgqEGyU1tn4ggdBeQ9J4/E6NUkvu8+lWqfvNrapGNm2+3J7hAIvfpNo/sOXLGfbHjXu+hM3RWkxgvVKecqMeEAO0MSNZouIRMKmT/qHz15Ds7vww0lkRKQG2xcXFitLVCglcAe2ApriNTAY19MWBVVMUKfY=",
+          "values": [
+            {
+              "key": "my_field",
+              "value": "The default",
+              "labels": [
+                {
+                  "key": "replicated.default",
+                  "value": "true"
+                },
+                {
+                  "key": "entitlements.replicated.com/type",
+                  "value": "string"
+                }
+              ]
+            },
+            {
+              "key": "my_other_field",
+              "value": "1",
+              "labels": [
+                {
+                  "key": "replicated.default",
+                  "value": "true"
+                },
+                {
+                  "key": "entitlements.replicated.com/type",
+                  "value": "number"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "shipVersion": {
+      "buildTime": "0001-01-01T00:00:00Z",
+      "dependencies": {}
+    },
+    "contentSHA": "a086cc2c22a907a2d6cc7b5bbc2eb8fe3530799f41e1c5add0ce8aac380e4042"
+  }
+}

--- a/integration/init_app/license-info/expected/installer/license-info.yaml
+++ b/integration/init_app/license-info/expected/installer/license-info.yaml
@@ -1,0 +1,54 @@
+releaseId: TncM-Wu2g4OxW2exEFKTaYoXNZGGDE4H
+sequence: 1
+customerId: ""
+installation: ""
+channelId: 1TzgBWDvp4PW3xUfdJ7FqyCsoztmDxiv
+appSlug: ship-integration-testing
+licenseId: hLHawMDiyQIeFS7kqVFtD2f44LNh8u5Z
+channelName: Nightly
+channelIcon: ""
+semver: 0.0.1
+releaseNotes: ""
+created: Tue Jun 11 2019 21:24:11 GMT+0000 (UTC)
+installed: replaced datetime
+registrySecret: 3bfd99a69b5748fab756a593c7dcc852
+images: []
+githubContents: []
+shipAppMetadata:
+  description: ""
+  version: ""
+  icon: ""
+  name: ""
+  readme: ""
+  url: ""
+  contentSHA: ""
+  releaseNotes: ""
+entitlements:
+  meta:
+    lastupdated: 0001-01-01T00:00:00Z
+    customerid: ""
+  signature: replaced signature
+  values:
+  - key: my_field
+    value: The default
+    labels:
+    - key: replicated.default
+      value: "true"
+    - key: entitlements.replicated.com/type
+      value: string
+  - key: my_other_field
+    value: "1"
+    labels:
+    - key: replicated.default
+      value: "true"
+    - key: entitlements.replicated.com/type
+      value: number
+  utilizations: []
+type: replicated.app
+license:
+  id: hLHawMDiyQIeFS7kqVFtD2f44LNh8u5Z
+  assignee: customer info test
+  createdAt: 2019-06-11T21:24:30Z
+  expiresAt: 0001-01-01T00:00:00Z
+  type: dev
+

--- a/integration/init_app/license-info/input/.ship/release.yml
+++ b/integration/init_app/license-info/input/.ship/release.yml
@@ -1,0 +1,15 @@
+---
+assets:
+  v1:
+  - inline:
+      contents: |
+        {{repl ShipCustomerRelease }}
+      dest: ./license-info.yaml
+      mode: 0777
+
+config:
+  v1: []
+
+lifecycle:
+  v1:
+  - render: {}

--- a/integration/init_app/license-info/metadata.yaml
+++ b/integration/init_app/license-info/metadata.yaml
@@ -1,0 +1,8 @@
+license_id: "hLHawMDiyQIeFS7kqVFtD2f44LNh8u5Z"
+app_slug: "ship-integration-testing"
+release_version: "0.0.1"
+replacements:
+    "installed.*" : "installed: replaced datetime"
+    "signature.*" : "signature: replaced signature"
+skip_cleanup: false
+skip_edit: false

--- a/integration/lib.go
+++ b/integration/lib.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	. "github.com/onsi/gomega"
@@ -113,7 +114,14 @@ func CompareDir(expected, actual string, replacements map[string]string, ignored
 
 			// find and replace strings from the expected contents (customerID, installationID, etc)
 			for k, v := range replacements {
-				expectedContents = strings.Replace(expectedContents, k, v, -1)
+				re := regexp.MustCompile(k)
+				expectedContents = re.ReplaceAllString(expectedContents, v)
+			}
+
+			// find and replace strings from the actual contents (datetime, signature, etc)
+			for k, v := range replacements {
+				re := regexp.MustCompile(k)
+				actualContents = re.ReplaceAllString(actualContents, v)
 			}
 
 			diff := difflib.UnifiedDiff{

--- a/pkg/state/models.go
+++ b/pkg/state/models.go
@@ -357,6 +357,12 @@ func (v State) ReleaseMetadata() *api.ReleaseMetadata {
 				baseMeta.CustomerID = v.V1.Metadata.CustomerID
 				baseMeta.InstallationID = v.V1.Metadata.InstallationID
 				baseMeta.LicenseID = v.V1.Metadata.LicenseID
+				baseMeta.AppSlug = v.V1.Metadata.AppSlug
+				baseMeta.License.ID = v.V1.Metadata.License.ID
+				baseMeta.License.Assignee = v.V1.Metadata.License.Assignee
+				baseMeta.License.CreatedAt = v.V1.Metadata.License.CreatedAt
+				baseMeta.License.ExpiresAt = v.V1.Metadata.License.ExpiresAt
+				baseMeta.License.Type = v.V1.Metadata.License.Type
 			}
 			return &baseMeta
 		}

--- a/pkg/state/models_test.go
+++ b/pkg/state/models_test.go
@@ -1,0 +1,121 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/replicatedhq/ship/pkg/api"
+)
+
+func TestState_ReleaseMetadata(t *testing.T) {
+	tests := []struct {
+		name string
+		V1   *V1
+		want *api.ReleaseMetadata
+	}{
+		{
+			name: "all nil",
+			V1:   nil,
+			want: nil,
+		},
+		{
+			name: "no upstream contents",
+			V1:   &V1{ReleaseName: "no upstream contents"},
+			want: nil,
+		},
+		{
+			name: "basic upstream contents",
+			V1: &V1{
+				UpstreamContents: &UpstreamContents{
+					AppRelease: &ShipRelease{ID: "abc"},
+				},
+			},
+			want: &api.ReleaseMetadata{
+				ReleaseID:      "abc",
+				Images:         []api.Image{},
+				GithubContents: []api.GithubContent{},
+			},
+		},
+		{
+			name: "upstream contents with metadata",
+			V1: &V1{
+				UpstreamContents: &UpstreamContents{
+					AppRelease: &ShipRelease{ID: "abc"},
+				},
+				Metadata: &Metadata{
+					CustomerID: "xyz",
+					License: License{
+						ID: "licenseID",
+					},
+				},
+			},
+			want: &api.ReleaseMetadata{
+				ReleaseID:      "abc",
+				Images:         []api.Image{},
+				GithubContents: []api.GithubContent{},
+				CustomerID:     "xyz",
+				License: api.License{
+					ID: "licenseID",
+				},
+			},
+		},
+		{
+			name: "upstream contents with actual contents",
+			V1: &V1{
+				UpstreamContents: &UpstreamContents{
+					AppRelease: &ShipRelease{
+						ID: "abc",
+						GithubContents: []GithubContent{
+							{
+								Repo: "testRepo",
+								Path: "testPath",
+								Ref:  "testRef",
+								Files: []GithubFile{
+									{
+										Name: "testFileName",
+										Path: "testFilePath",
+										Sha:  "testFileSha",
+										Size: 1234,
+										Data: "testFileData",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &api.ReleaseMetadata{
+				ReleaseID: "abc",
+				Images:    []api.Image{},
+				GithubContents: []api.GithubContent{
+					{
+						Repo: "testRepo",
+						Path: "testPath",
+						Ref:  "testRef",
+						Files: []api.GithubFile{
+							{
+								Name: "testFileName",
+								Path: "testFilePath",
+								Sha:  "testFileSha",
+								Size: 1234,
+								Data: "testFileData",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+			v := State{
+				V1: tt.V1,
+			}
+			got := v.ReleaseMetadata()
+
+			req.Equal(tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
What I Did
------------
Improved the function that converts a saved ship state into an app release for `ship edit`
Added an integration test covering this functionality

This resolves #960.

How I Did it
------------


How to verify it
------------
Observe that the newly added integration test [fails](https://circleci.com/workflow-run/0d468cbd-89c5-44e5-8a03-9d0456e790a9) the `ship edit` component prior to the code changes in the second commit.

Description for the Changelog
------------
`ship edit` of replicated.app upstreams properly includes app license info


Picture of a Ship (not required but encouraged)
------------
![USS Peterson (DD-969)](https://upload.wikimedia.org/wikipedia/en/2/23/USS_Peterson_DD-969.jpg "USS Peterson (DD-969)")











<!-- (thanks https://github.com/docker/docker for this template) -->

