### PR TITLE
include repo, path, ref in 'no files found' github asset error

### DIFF
--- a/pkg/lifecycle/render/github/render.go
+++ b/pkg/lifecycle/render/github/render.go
@@ -104,7 +104,7 @@ func (r *LocalRenderer) Execute(
 					return errors.Wrap(err, "resolveNoProxyGithubAssets")
 				}
 			} else {
-				return errors.New("github asset returned no files")
+				return fmt.Errorf("github asset %s returned no files in %s at %s", asset.Repo, asset.Path, asset.Ref)
 			}
 		}
 


### PR DESCRIPTION
What I Did
------------
Improved the error message displayed when no files are found for a github asset

How I Did it
------------
By including the asset repo, path and ref in the error message

How to verify it
------------


Description for the Changelog
------------
Improves error messaging for github assets


Picture of a Ship (not required but encouraged)
------------
![USS Caron (DD-970)](https://upload.wikimedia.org/wikipedia/commons/5/5b/USS_Caron.jpg "USS Caron (DD-970)") 











<!-- (thanks https://github.com/docker/docker for this template) -->

