### PR TITLE
metadata test no longer fetches from upstream, only uses edit

### DIFF
--- a/integration/init_app/integration_test.go
+++ b/integration/init_app/integration_test.go
@@ -34,6 +34,7 @@ type TestMetadata struct {
 	// debugging
 	SkipCleanup bool `yaml:"skip_cleanup"`
 	SkipEdit    bool `yaml:"skip_edit"`
+	SkipInit    bool `yaml:"skip_init"`
 }
 
 func TestInitReplicatedApp(t *testing.T) {
@@ -99,6 +100,10 @@ var _ = Describe("ship init replicated.app/...", func() {
 				}, 20)
 
 				It("Should output files matching those expected when communicating with the graphql api", func() {
+					if testMetadata.SkipInit {
+						Skip("this test case is set to skip init tests")
+						return
+					}
 
 					upstream := "staging.replicated.app/some-cool-ci-tool"
 

--- a/integration/init_app/license-info/metadata.yaml
+++ b/integration/init_app/license-info/metadata.yaml
@@ -6,3 +6,4 @@ replacements:
     "signature.*" : "signature: replaced signature"
 skip_cleanup: false
 skip_edit: false
+skip_init: true


### PR DESCRIPTION
the entitlements of the customer changed, and this will prevent future breakage

What I Did
------------


How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Ship (not required but encouraged)
------------




![USS Conolly (DD-979)](https://upload.wikimedia.org/wikipedia/commons/e/e6/USSConolly.jpg "USS Conolly (DD-979)")







<!-- (thanks https://github.com/docker/docker for this template) -->

