### PR TITLE
Pact tests for ship

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: make build-deps pacts
+      - run: make build-deps pacts-ci
 
   windows_build_test:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,10 @@ githooks:
 
 .PHONY: pacts
 pacts:
+	go test -v ./contracts/...
+
+.PHONY: pacts-ci
+pacts-ci:
 	docker build -t ship-contract-tests -f contracts/Dockerfile.testing .
 	docker run --rm --name ship-contract-tests \
 		ship-contract-tests \

--- a/contracts/replicatedapp/get_license_test.go
+++ b/contracts/replicatedapp/get_license_test.go
@@ -1,0 +1,74 @@
+package replicatedapp
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/pact-foundation/pact-go/dsl"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+
+	replapp "github.com/replicatedhq/ship/pkg/specs/replicatedapp"
+)
+
+func Test_GetLicense(t *testing.T) {
+	licenseID := "get-license-installation"
+
+	var test = func() (err error) {
+		req := require.New(t)
+
+		v := viper.New()
+		v.Set("customer-endpoint", fmt.Sprintf("http://localhost:%d/graphql", pact.Server.Port))
+
+		gqlClient, err := replapp.NewGraphqlClient(v, http.DefaultClient)
+		req.NoError(err)
+
+		selector := replapp.Selector{
+			LicenseID:     licenseID,
+		}
+
+		_, err = gqlClient.GetLicense(&selector)
+		req.NoError(err)
+
+		return nil
+	}
+
+	pact.AddInteraction().
+		Given("A request to get a license").
+		UponReceiving("A request to get the license from from licenseID").
+		WithRequest(dsl.Request{
+			Method: "POST",
+			Path:   dsl.String("/graphql"),
+			Headers: dsl.MapMatcher{
+				"Authorization": dsl.String(fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", licenseID, ""))))),
+				"Content-Type":  dsl.String("application/json"),
+			},
+			Body: map[string]interface{}{
+				"operationName": "",
+				"query":         replapp.GetLicenseQuery,
+				"variables": map[string]interface{}{
+					"licenseId": licenseID,
+				},
+			},
+		}).
+		WillRespondWith(dsl.Response{
+			Status: 200,
+			Body: map[string]interface{}{
+				"data": map[string]interface{}{
+					"license": map[string]interface{}{
+						"id": "get-license-installation",
+						"assignee": "Get License - Customer 0",
+						"createdAt": dsl.Like(dsl.String("Tue Jan 01 2019 01:23:46 GMT+0000 (Coordinated Universal Time)")),
+						"expiresAt": nil,
+						"type": dsl.Like(dsl.String("")),
+					},
+				},
+			},
+		})
+
+	if err := pact.Verify(test); err != nil {
+		t.Fatalf("Error on Verify: %v", err)
+	}
+}

--- a/contracts/replicatedapp/get_release_test.go
+++ b/contracts/replicatedapp/get_release_test.go
@@ -13,7 +13,7 @@ import (
 	replapp "github.com/replicatedhq/ship/pkg/specs/replicatedapp"
 )
 
-func Test_GetReleaseFromSemver(t *testing.T) {
+func Test_GetRelease(t *testing.T) {
 	customerID := "ship-fetch-release-customer-0"
 	installationID := "ship-fetch-release-installation-0"
 	semver := "1.0.2"

--- a/contracts/replicatedapp/get_slug_release_test.go
+++ b/contracts/replicatedapp/get_slug_release_test.go
@@ -1,0 +1,101 @@
+package replicatedapp
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/pact-foundation/pact-go/dsl"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+
+	replapp "github.com/replicatedhq/ship/pkg/specs/replicatedapp"
+)
+
+func Test_GetSlugRelease(t *testing.T) {
+	appSlug := "get-slug-release-app"
+	licenseID := "get-slug-release-installation"
+	releaseID := "get-slug-release-app-release"
+	semver := "get-slug-release-semver"
+
+	var test = func() (err error) {
+		req := require.New(t)
+
+		v := viper.New()
+		v.Set("customer-endpoint", fmt.Sprintf("http://localhost:%d/graphql", pact.Server.Port))
+
+		gqlClient, err := replapp.NewGraphqlClient(v, http.DefaultClient)
+		req.NoError(err)
+
+		selector := replapp.Selector{
+			AppSlug:       appSlug,
+			LicenseID:     licenseID,
+			ReleaseID:     releaseID,
+			ReleaseSemver: semver,
+		}
+
+		_, err = gqlClient.GetSlugRelease(&selector)
+		req.NoError(err)
+
+		return nil
+	}
+
+	pact.AddInteraction().
+		Given("A request to get a slug release").
+		UponReceiving("A request to get the slug release from appSlug, licenseID, releaseID and semver").
+		WithRequest(dsl.Request{
+			Method: "POST",
+			Path:   dsl.String("/graphql"),
+			Headers: dsl.MapMatcher{
+				"Authorization": dsl.String(fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", licenseID, ""))))),
+				"Content-Type":  dsl.String("application/json"),
+			},
+			Body: map[string]interface{}{
+				"operationName": "",
+				"query":         replapp.GetSlugAppSpecQuery,
+				"variables": map[string]interface{}{
+					"appSlug":   appSlug,
+					"licenseID": licenseID,
+					"releaseID": releaseID,
+					"semver":    semver,
+				},
+			},
+		}).
+		WillRespondWith(dsl.Response{
+			Status: 200,
+			Body: map[string]interface{}{
+				"data": map[string]interface{}{
+					"shipSlugRelease": map[string]interface{}{
+						"id": "get-slug-release-app-release",
+						"sequence": 1,
+						"channelId": "get-slug-release-app-stable",
+						"channelName": "Stable",
+						"channelIcon": nil,
+						"semver": "1.0.2",
+						"releaseNotes": "1.0.2",
+						"spec": dsl.Like(dsl.String("assets:\n  v1:\n    - inline:\n        contents: |\n          #!/bin/bash\n          echo \"installing nothing\"\n          echo \"config option: {{repl ConfigOption \"test_option\" }}\"\n        dest: ./scripts/install.sh\n        mode: 0777\n    - inline:\n        contents: |\n          #!/bin/bash\n          echo \"tested nothing\"\n          echo \"customer {{repl Installation \"customer_id\" }}\"\n          echo \"install {{repl Installation \"installation_id\" }}\"\n        dest: ./scripts/test.sh\n        mode: 0777\nconfig:\n  v1:\n    - name: test_options\n      title: Test Options\n      description: testing testing 123\n      items:\n      - name: test_option\n        title: Test Option\n        default: abc123_test-option-value\n        type: text\nlifecycle:\n  v1:\n    - render: {}\n")),
+						"images": []string{},
+						"githubContents": []string{},
+						"entitlements": map[string]interface{}{
+							"values": []string{},
+							"utilizations": []string{},
+							"meta": map[string]interface{}{
+								"lastUpdated": dsl.Like(dsl.String("Wed Jun 19 2019 21:12:23 GMT+0000 (Coordinated Universal Time)")),
+								"customerID": "get-slug-release-customer-0",
+								"installationID": nil,
+							},
+							"serialized": dsl.Like(dsl.String("{\"customerID\":\"get-slug-release-customer-0\",\"lastUpdated\":\"2019-06-19T21:12:23.173Z\"}[]")),
+							"signature": dsl.Like(dsl.String("L5kLCgGP2OBZ0X54kZnOi1/4hG0geh/8JnQwV56fUwov9en9vrUscdK5LlIEw7PD8sWscqHZ7iNWgfJYKdTW2+zM+JgKAfQke02+Abx7qstjqJqZf/3RqeQweIIbppNLKRga4waD53br6REAyND6CQZENBz5ZXYSO6aJS+neblmICHn//4sbHTVv0SVz0szXcElvWztiZeLEekpl8xShCmCc23rlWgzml53UDPSM6E15/Erbryx4tzabJjxgFmGub3qp7b2c3eMPMVyFQp5fVvLGqsOXiBgvnpEWcn12e+vHks1gFhDyx9NtuVMjpYgeYXP3KHMOoAVrulREa2vAxGEOxYdRRjBATd5wm//fr9N4rY/WTH2oAesmHzizDGirD4wJYkHPKz3qv6hzB6D2Qix3+y/4dhO9nW8D6skK/c1XLTq4uhswrxT71xOuRU/c22Ee78Gy+Nq6RGigjclSFCWRABYP0MIoWKWH3UgW6RuSOyojEpbX2Wif9orZ3tenu1ne40zzZPQ5mDC6uOlDbUBg9GOB/QqEA90K5M9avBM14RWBXdJdFdmpXFiPtRdKzu2gsEjaMQVutI9dXe8M4U1Z1w5TIuym/1cXiNFe+YQBrUdk7bXUl7g+fj7kjtFqONm9DhR718IsdR0+QhodqglWwOTjDYXuIdGnrknG8n0=")),
+						},
+						"created": dsl.Like(dsl.String("Tue Jan 01 2019 02:23:46 GMT+0000 (Coordinated Universal Time)")),
+						"registrySecret": dsl.Like(dsl.String("3bfd99a69b5748fab756a593c7dcc852")),
+					},
+				},
+			},
+		})
+
+	if err := pact.Verify(test); err != nil {
+		t.Fatalf("Error on Verify: %v", err)
+	}
+}

--- a/contracts/replicatedapp/prem_graphql_test.go
+++ b/contracts/replicatedapp/prem_graphql_test.go
@@ -29,8 +29,8 @@ func TestMain(m *testing.M) {
 func createPact() dsl.Pact {
 	dir, _ := os.Getwd()
 
-	pactDir := path.Join(dir, "..", "..", "..", "pacts")
-	logDir := path.Join(dir, "..", "..", "..", "logs")
+	pactDir := path.Join(dir, "..", "..", "pacts")
+	logDir := path.Join(dir, "..", "..", "logs")
 
 	return dsl.Pact{
 		Consumer: "ship",

--- a/pkg/specs/replicatedapp/graphql.go
+++ b/pkg/specs/replicatedapp/graphql.go
@@ -65,7 +65,7 @@ query($semver: String) {
   }
 }`
 
-const getSlugAppSpecQuery = `
+const GetSlugAppSpecQuery = `
 query($appSlug: String!, $licenseID: String, $releaseID: String, $semver: String) {
   shipSlugRelease (appSlug: $appSlug, licenseID: $licenseID, releaseID: $releaseID, semver: $semver) {
     id
@@ -120,7 +120,7 @@ query($appSlug: String!, $licenseID: String, $releaseID: String, $semver: String
   }
 }`
 
-const getLicenseQuery = `
+const GetLicenseQuery = `
 query($licenseId: String) {
   license (licenseId: $licenseId) {
     id
@@ -281,7 +281,7 @@ func (c *GraphQLClient) GetRelease(selector *Selector) (*state.ShipRelease, erro
 // GetSlugRelease gets a release from the graphql server by app slug
 func (c *GraphQLClient) GetSlugRelease(selector *Selector) (*state.ShipRelease, error) {
 	requestObj := GraphQLRequest{
-		Query: getSlugAppSpecQuery,
+		Query: GetSlugAppSpecQuery,
 		Variables: map[string]string{
 			"appSlug":   selector.AppSlug,
 			"licenseID": selector.LicenseID,
@@ -314,9 +314,9 @@ func (c *GraphQLClient) GetSlugRelease(selector *Selector) (*state.ShipRelease, 
 	return &shipResponse.Data.ShipSlugRelease, nil
 }
 
-func (c *GraphQLClient) getLicense(selector *Selector) (*license, error) {
+func (c *GraphQLClient) GetLicense(selector *Selector) (*license, error) {
 	requestObj := GraphQLRequest{
-		Query: getLicenseQuery,
+		Query: GetLicenseQuery,
 		Variables: map[string]string{
 			"licenseId": selector.LicenseID,
 		},

--- a/pkg/specs/replicatedapp/resolver.go
+++ b/pkg/specs/replicatedapp/resolver.go
@@ -171,7 +171,7 @@ func (r *resolver) FetchLicense(ctx context.Context, selector *Selector) (*licen
 		return &license{}, nil
 	}
 
-	license, err := r.Client.getLicense(selector)
+	license, err := r.Client.GetLicense(selector)
 	if err != nil {
 		return nil, errors.Wrapf(err, "get license")
 	}


### PR DESCRIPTION
What I Did
------------
Created pact tests for the following queries:
1- GetSlugRelease
2- GetLicense

How I Did it
------------
1- created two test files, `get_slug_release_test.go` and `get_license_test.go`.
2- created the test
3- ran it
4- verified it

How to verify it
------------
`make pacts` , and look at the output file in `pacts` directory.

Description for the Changelog
------------
Added contract tests for GraphQL API Queries

Picture of a Ship (not required but encouraged)
------------










<!-- (thanks https://github.com/docker/docker for this template) -->

