### PR TITLE
Rename files for 1.12 support

### DIFF
--- a/integration/init/cert-manager/expected/base/deploy/manifests/ClusterRole-cert-manager-webhook-webhook-requester.yaml
+++ b/integration/init/cert-manager/expected/base/deploy/manifests/ClusterRole-cert-manager-webhook-webhook-requester.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: webhook
     release: cert-manager
-  name: cert-manager-webhook:webhook-requester
+  name: cert-manager-webhook-webhook-requester
 rules:
 - apiGroups:
   - admission.certmanager.k8s.io

--- a/integration/init/cert-manager/expected/base/deploy/manifests/RoleBinding-cert-manager-webhook:webhook-authentication-reader-kube-system.yaml
+++ b/integration/init/cert-manager/expected/base/deploy/manifests/RoleBinding-cert-manager-webhook:webhook-authentication-reader-kube-system.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: webhook
     release: cert-manager
-  name: cert-manager-webhook:webhook-authentication-reader
+  name: cert-manager-webhook-webhook-authentication-reader
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/integration/init/cert-manager/expected/base/kustomization.yaml
+++ b/integration/init/cert-manager/expected/base/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 - deploy/manifests/ClusterRole-cert-manager-cainjector.yaml
 - deploy/manifests/ClusterRole-cert-manager-edit.yaml
 - deploy/manifests/ClusterRole-cert-manager-view.yaml
-- deploy/manifests/ClusterRole-cert-manager-webhook:webhook-requester.yaml
+- deploy/manifests/ClusterRole-cert-manager-webhook-webhook-requester.yaml
 - deploy/manifests/ClusterRole-cert-manager.yaml
 - deploy/manifests/ClusterRoleBinding-cert-manager-cainjector.yaml
 - deploy/manifests/ClusterRoleBinding-cert-manager-webhook:auth-delegator.yaml
@@ -19,7 +19,7 @@ resources:
 - deploy/manifests/Issuer-cert-manager-webhook-ca-cert-manager.yaml
 - deploy/manifests/Issuer-cert-manager-webhook-selfsign-cert-manager.yaml
 - deploy/manifests/Namespace-cert-manager.yaml
-- deploy/manifests/RoleBinding-cert-manager-webhook:webhook-authentication-reader-kube-system.yaml
+- deploy/manifests/RoleBinding-cert-manager-webhook-webhook-authentication-reader-kube-system.yaml
 - deploy/manifests/Service-cert-manager-webhook-cert-manager.yaml
 - deploy/manifests/ServiceAccount-cert-manager-cainjector-cert-manager.yaml
 - deploy/manifests/ServiceAccount-cert-manager-cert-manager.yaml

--- a/integration/init/cert-manager/expected/rendered.yaml
+++ b/integration/init/cert-manager/expected/rendered.yaml
@@ -1269,7 +1269,7 @@ metadata:
   labels:
     app: webhook
     release: cert-manager
-  name: cert-manager-webhook:webhook-requester
+  name: cert-manager-webhook-webhook-requester
 rules:
 - apiGroups:
   - admission.certmanager.k8s.io
@@ -1368,7 +1368,7 @@ metadata:
   labels:
     app: webhook
     release: cert-manager
-  name: cert-manager-webhook:webhook-authentication-reader
+  name: cert-manager-webhook-webhook-authentication-reader
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
rename a couple of file names because go thinks they have invalid characters