### PR TITLE
Honor the log-format parameter for debug logs

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"fmt"
+	"io"
 	golog "log"
 	"os"
 	"path"
@@ -32,7 +33,7 @@ func New(v *viper.Viper, fs afero.Afero) log.Logger {
 
 	fullPathCaller := pathCaller(6)
 	var stdoutLogger log.Logger
-	stdoutLogger = withFormat(viper.GetString("log-format"))
+	stdoutLogger = withFormat(viper.GetString("log-format"), os.Stdout)
 	stdoutLogger = log.With(stdoutLogger, "ts", log.DefaultTimestampUTC)
 	stdoutLogger = log.With(stdoutLogger, "caller", fullPathCaller)
 	stdoutLogger = withLevel(stdoutLogger, v.GetString("log-level"))
@@ -52,7 +53,7 @@ func New(v *viper.Viper, fs afero.Afero) log.Logger {
 		return stdoutLogger
 	}
 
-	debugLogger = log.NewJSONLogger(debugLogWriter)
+	debugLogger = withFormat(viper.GetString("log-format"), debugLogWriter)
 	debugLogger = log.With(debugLogger, "ts", log.DefaultTimestampUTC)
 	debugLogger = log.With(debugLogger, "caller", fullPathCaller)
 	debugLogger = withLevel(debugLogger, "debug")
@@ -68,14 +69,14 @@ func New(v *viper.Viper, fs afero.Afero) log.Logger {
 	return realLogger
 }
 
-func withFormat(format string) log.Logger {
+func withFormat(format string, w io.Writer) log.Logger {
 	switch format {
 	case "json":
-		return log.NewJSONLogger(os.Stdout)
+		return log.NewJSONLogger(w)
 	case "logfmt":
-		return log.NewLogfmtLogger(os.Stdout)
+		return log.NewLogfmtLogger(w)
 	default:
-		return log.NewLogfmtLogger(os.Stdout)
+		return log.NewLogfmtLogger(w)
 	}
 
 }


### PR DESCRIPTION
What I Did
------------
Made debug logger honor the `log-format` command line parameter.  This closes #886.

How I Did it
------------
Removed the hardcoded call to `NewJSONLogger`.

How to verify it
------------
Run ship, look at debug logs.   Instead of this:
```
$ tail -f .ship/debug.log 
{"caller":"github.com/replicatedhq/ship/pkg/state/manager.go","level":"debug","msg":"no saved state exists","path":".ship/state.json","ts":"2019-06-21T22:24:32.557732Z"}
{"caller":"github.com/replicatedhq/ship/pkg/state/manager.go","level":"debug","method":"serializeAndWriteState","stateFrom":"file","ts":"2019-06-21T22:24:32.557762Z"}
{"caller":"github.com/replicatedhq/ship/pkg/specs/interface.go","event":"applicationType.resolve","level":"debug","method":"ResolveRelease","ts":"2019-06-21T22:24:32.558395Z","type":"replicated.app"}
```

there should be this:

```
$ tail -f .ship/debug.log 
ts=2019-06-21T22:27:08.532125Z caller=github.com/replicatedhq/ship/pkg/state/manager.go level=debug msg="no saved state exists" path=.ship/state.json
ts=2019-06-21T22:27:08.532148Z caller=github.com/replicatedhq/ship/pkg/state/manager.go level=debug method=serializeAndWriteState stateFrom=file
ts=2019-06-21T22:27:08.532698Z caller=github.com/replicatedhq/ship/pkg/specs/interface.go level=debug method=ResolveRelease event=applicationType.resolve type=replicated.app
```

Description for the Changelog
------------
Debug logger honors the `log-format` command line parameter


Picture of a Ship (not required but encouraged)
------------

 \___________|











<!-- (thanks https://github.com/docker/docker for this template) -->

