### PR TITLE
Support saving/loading state data using an HTTP URL

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -58,11 +58,13 @@ func RootCmd() *cobra.Command {
 	// TODO remove me, just always set this to true
 	cmd.PersistentFlags().BoolP("navcycle", "", true, "set to false to run ship in v1/non-navigable mode (deprecated)")
 
-	cmd.PersistentFlags().String("state-from", "file", "type of resource to use when loading/saving state (currently supported values: 'file', 'secret'")
+	cmd.PersistentFlags().String("state-from", "file", "type of resource to use when loading/saving state (currently supported values: 'file', 'secret', 'url'")
 	cmd.PersistentFlags().String("state-file", "", fmt.Sprintf("path to the state file to read from, defaults to %s", constants.StatePath))
 	cmd.PersistentFlags().String("secret-namespace", "default", "namespace containing the state secret")
 	cmd.PersistentFlags().String("secret-name", "", "name of the secret to load state from")
 	cmd.PersistentFlags().String("secret-key", "", "name of the key in the secret containing state")
+	cmd.PersistentFlags().String("state-put-url", "", "the URL that will be used to store update state")
+	cmd.PersistentFlags().String("state-get-url", "", "the URL that will be used to retrieve update state")
 
 	cmd.PersistentFlags().String("upload-assets-to", "", "URL to upload assets to via HTTP PUT request. NOTE: this will cause the entire working directory to be uploaded to the specified URL, use with caution.")
 

--- a/pkg/state/state_file.go
+++ b/pkg/state/state_file.go
@@ -1,0 +1,61 @@
+package state
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/ship/pkg/constants"
+	"github.com/spf13/afero"
+)
+
+type fileSerializer struct {
+	fs     afero.Afero
+	logger log.Logger
+}
+
+func newFileSerializer(fs afero.Afero, logger log.Logger) stateSerializer {
+	return &fileSerializer{fs: fs, logger: logger}
+}
+
+func (s *fileSerializer) Load() (State, error) {
+	if _, err := s.fs.Stat(constants.StatePath); os.IsNotExist(err) {
+		level.Debug(s.logger).Log("msg", "no saved state exists", "path", constants.StatePath)
+		return State{}, nil
+	}
+
+	serialized, err := s.fs.ReadFile(constants.StatePath)
+	if err != nil {
+		return State{}, errors.Wrap(err, "read state file")
+	}
+
+	var state State
+	if err := json.Unmarshal(serialized, &state); err != nil {
+		return State{}, errors.Wrap(err, "unmarshal state")
+	}
+
+	level.Debug(s.logger).Log("event", "state.resolve", "type", "versioned")
+	return state, nil
+}
+
+func (s *fileSerializer) Save(state State) error {
+	serialized, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return errors.Wrap(err, "serialize state")
+	}
+
+	err = s.fs.MkdirAll(filepath.Dir(constants.StatePath), 0700)
+	if err != nil {
+		return errors.Wrap(err, "mkdir state")
+	}
+
+	err = s.fs.WriteFile(constants.StatePath, serialized, 0644)
+	if err != nil {
+		return errors.Wrap(err, "write state file")
+	}
+
+	return nil
+}

--- a/pkg/state/state_secret.go
+++ b/pkg/state/state_secret.go
@@ -1,0 +1,112 @@
+package state
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type secretSerializer struct {
+	secretNS   string
+	secretName string
+	secretKey  string
+	logger     log.Logger
+}
+
+func newSecretSerializer(logger log.Logger, ns string, name string, key string) stateSerializer {
+	return &secretSerializer{logger: logger, secretNS: ns, secretName: name, secretKey: key}
+}
+
+func (s *secretSerializer) Load() (State, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return State{}, errors.Wrap(err, "get in cluster config")
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return State{}, errors.Wrap(err, "get kubernetes client")
+	}
+
+	if s.secretNS == "" {
+		return State{}, errors.New("secret-namespace is not set")
+	}
+	if s.secretName == "" {
+		return State{}, errors.New("secret-name is not set")
+	}
+	if s.secretKey == "" {
+		return State{}, errors.New("secret-key is not set")
+	}
+
+	secret, err := clientset.CoreV1().Secrets(s.secretNS).Get(s.secretName, metav1.GetOptions{})
+	if err != nil {
+		return State{}, errors.Wrap(err, "get secret")
+	}
+
+	serialized, ok := secret.Data[s.secretKey]
+	if !ok {
+		err := fmt.Errorf("key not found in secret %q", s.secretName)
+		return State{}, errors.Wrap(err, "get state from secret")
+	}
+
+	// An empty secret should be treated as empty state
+	if len(strings.TrimSpace(string(serialized))) == 0 {
+		return State{}, nil
+	}
+
+	var state State
+	if err := json.Unmarshal(serialized, &state); err != nil {
+		return State{}, errors.Wrap(err, "unmarshal state")
+	}
+
+	level.Debug(s.logger).Log(
+		"event", "state.unmarshal",
+		"type", "versioned",
+		"source", "secret",
+		"value", fmt.Sprintf("%+v", state),
+	)
+
+	level.Debug(s.logger).Log("event", "state.resolve", "type", "versioned")
+	return state, nil
+}
+
+func (s *secretSerializer) Save(state State) error {
+	serialized, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return errors.Wrap(err, "serialize state")
+	}
+
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return errors.Wrap(err, "get in cluster config")
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return errors.Wrap(err, "get kubernetes client")
+	}
+
+	secret, err := clientset.CoreV1().Secrets(s.secretNS).Get(s.secretName, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(err, "get secret")
+	}
+
+	secret.Data[s.secretKey] = serialized
+	debug := level.Debug(log.With(s.logger, "method", "serializeHelmValues"))
+
+	debug.Log("event", "serializeAndWriteStateSecret", "name", secret.Name)
+
+	_, err = clientset.CoreV1().Secrets(s.secretNS).Update(secret)
+	if err != nil {
+		return errors.Wrap(err, "update secret")
+	}
+
+	return nil
+}

--- a/pkg/state/state_url.go
+++ b/pkg/state/state_url.go
@@ -1,0 +1,71 @@
+package state
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/go-kit/kit/log"
+	"github.com/pkg/errors"
+)
+
+type urlSerializer struct {
+	getURL string
+	putURL string
+	logger log.Logger
+}
+
+func newURLSerializer(logger log.Logger, getURL string, putURL string) stateSerializer {
+	return &urlSerializer{logger: logger, getURL: getURL, putURL: putURL}
+}
+
+func (s *urlSerializer) Load() (State, error) {
+	resp, err := http.Get(s.getURL)
+	if err != nil {
+		return State{}, errors.Wrap(err, "make get request")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return State{}, errors.Errorf("unexpected get status: %v", resp.StatusCode)
+	}
+
+	serialized, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return State{}, errors.Wrap(err, "read state body")
+	}
+
+	var state State
+	if err := json.Unmarshal(serialized, &state); err != nil {
+		return State{}, errors.Wrap(err, "unmarshal state")
+	}
+
+	return state, nil
+}
+
+func (s *urlSerializer) Save(state State) error {
+	serialized, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return errors.Wrap(err, "serialize state")
+	}
+
+	req, err := http.NewRequest("PUT", s.putURL, bytes.NewBuffer(serialized))
+	if err != nil {
+		return errors.Wrap(err, "create request")
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "put state object")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusCreated {
+		return errors.Errorf("unexpected put status: %v", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/pkg/state/state_url_test.go
+++ b/pkg/state/state_url_test.go
@@ -1,0 +1,102 @@
+package state
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestURLSerializer(t *testing.T) {
+	req := require.New(t)
+
+	srv, err := startStateServer(t)
+	req.NoError(err)
+
+	defer srv.Shutdown(context.TODO())
+
+	s := newURLSerializer(
+		log.NewNopLogger(),
+		fmt.Sprintf("http://%s/testurlserializer/get-state", srv.Addr),
+		fmt.Sprintf("http://%s/testurlserializer/put-state", srv.Addr),
+	)
+
+	state1 := State{
+		V1: &V1{
+			Kustomize: &Kustomize{
+				Overlays: map[string]Overlay{
+					"ship": {
+						Patches: map[string]string{
+							"deployment.yaml": "foo/bar/baz",
+						},
+						Resources: map[string]string{
+							"resource.yaml": "hi",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err = s.Save(state1)
+	req.NoError(err)
+
+	state2, err := s.Load()
+	req.NoError(err)
+	req.Equal(state1, state2)
+}
+
+func startStateServer(t *testing.T) (*http.Server, error) {
+	req := require.New(t)
+
+	rand.Seed(time.Now().UnixNano())
+	port := rand.Intn(32000) + 32000 // random port between 32000 and 64000
+	srv := &http.Server{Addr: fmt.Sprintf("127.0.0.1:%d", port)}
+
+	http.HandleFunc("/testurlserializer/ping", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(""))
+	})
+
+	var stateData []byte
+
+	http.HandleFunc("/testurlserializer/put-state", func(w http.ResponseWriter, r *http.Request) {
+		req.Equal(r.Method, "PUT")
+		req.Equal(r.Header.Get("Content-Type"), "application/json")
+		body, err := ioutil.ReadAll(r.Body)
+		req.NoError(err)
+		stateData = body
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(""))
+	})
+
+	http.HandleFunc("/testurlserializer/get-state", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(stateData)
+	})
+
+	go func() {
+		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+			fmt.Printf("ListenAndServe(): %v", err)
+		}
+	}()
+
+	var pingErr error
+	for i := 0; i < 10; i++ {
+		time.Sleep(1 * time.Second)
+		resp, err := http.Get(fmt.Sprintf("http://%s/testurlserializer/ping", srv.Addr))
+		if err == nil && resp.StatusCode == http.StatusOK {
+			return srv, nil
+		}
+		pingErr = err // safe to assume err is not nil here...
+	}
+
+	return nil, pingErr
+}


### PR DESCRIPTION
What I Did
------------
Added `url` value for `state-from` command line argument.

How I Did it
------------
Implemented the support.

How to verify it
------------
Run ship with new arguments

```
ship init --state-from=url --state-put-url http://somehost/path --state-get-url http://somehost/path
```

Description for the Changelog
------------
Command line argument `state-from` can have value `url`


Picture of a Ship (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

