### PR TITLE
include all release info for replicated.app upstreams in the content sha

### DIFF
--- a/integration/base/amazon-eks/expected/.ship/state.json
+++ b/integration/base/amazon-eks/expected/.ship/state.json
@@ -1,7 +1,7 @@
 {
   "v1": {
     "config": {},
-    "contentSHA": "0f476537db7bf02980df88c12f4b43c87094314635477263a2a5468f3c74a2dc",
+    "contentSHA": "7c1c9d536fd96ffe4f5de5a75014bac39c6c36d618813d9f14f539805c726352",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/basic-stateless/expected/.ship/state.json
+++ b/integration/base/basic-stateless/expected/.ship/state.json
@@ -1,7 +1,7 @@
 {
   "v1": {
     "config": {},
-    "contentSHA": "af39a2dca324dad4488ac70eaca71806bf2def699bed604c1252b6333588309d",
+    "contentSHA": "49e1c9f9fa33aaa5bfe04f7c1add52397f649b8d96842b8834a939db883438ca",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/basic/expected/.ship/state.json
+++ b/integration/base/basic/expected/.ship/state.json
@@ -3,7 +3,7 @@
     "config": {
       "test_option": "abc123_test-option-value"
     },
-    "contentSHA": "af39a2dca324dad4488ac70eaca71806bf2def699bed604c1252b6333588309d",
+    "contentSHA": "49e1c9f9fa33aaa5bfe04f7c1add52397f649b8d96842b8834a939db883438ca",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/config-chain-override/expected/.ship/state.json
+++ b/integration/base/config-chain-override/expected/.ship/state.json
@@ -5,7 +5,7 @@
       "t2_option": "abc123_abc123",
       "t3_option": "abc123_abc123 + abc123"
     },
-    "contentSHA": "f256226c1517134c10dff4ba08dc3a6c55b28320f7ba0829b62c96ad84fe7106",
+    "contentSHA": "a24b2f2247cdd061c97f64753deea506f57df4c950043630a27eedd7b8a29770",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/config-chain/expected/.ship/state.json
+++ b/integration/base/config-chain/expected/.ship/state.json
@@ -5,7 +5,7 @@
       "t2_option": "abc123_abc123",
       "t3_option": "abc123_abc123 + abc123"
     },
-    "contentSHA": "f256226c1517134c10dff4ba08dc3a6c55b28320f7ba0829b62c96ad84fe7106",
+    "contentSHA": "a24b2f2247cdd061c97f64753deea506f57df4c950043630a27eedd7b8a29770",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/default-values/expected/.ship/state.json
+++ b/integration/base/default-values/expected/.ship/state.json
@@ -6,7 +6,7 @@
       "namespace": "Alpha",
       "scheduler": ""
     },
-    "contentSHA": "377deb7eccf40c1fede60b7db73c69ba57f28eed0cfe0fdbb8cbe11ced3f64e4",
+    "contentSHA": "d182801c311b0c937b7027f9b6a71704973e6bf97f9f466473aeaca804edd010",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/docker-layer/expected/.ship/state.json
+++ b/integration/base/docker-layer/expected/.ship/state.json
@@ -3,7 +3,7 @@
     "config": {
       "option": "value"
     },
-    "contentSHA": "181da1498e9c63c2b9a8b47446cce7dffd11c28b095814c7136a02391edbca8b",
+    "contentSHA": "199522eb20f835e7060c9c20409daf18dc8169f118f6738bee4ae05ee1b4cde2",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/docker/expected/.ship/state.json
+++ b/integration/base/docker/expected/.ship/state.json
@@ -3,7 +3,7 @@
     "config": {
       "test_option": "abc123_test-option-value"
     },
-    "contentSHA": "104541e8f52c5077198f4bd2f8a5021ee1a85c0e54d6058b3a757490add42f13",
+    "contentSHA": "2838f12b0f9649afa3f10d5047e32fd532c7d2b15ae4ec2543b756bd2eb13b3f",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/helm-nginx/expected/.ship/state.json
+++ b/integration/base/helm-nginx/expected/.ship/state.json
@@ -1,7 +1,7 @@
 {
   "v1": {
     "config": {},
-    "contentSHA": "b93b0ea7be591d5d017fe977093eab71958b9e89a062062e500961011fce7f39",
+    "contentSHA": "d0a5407090d68a8cfbd220f94e2ea5c9f64ee5133d5c6016777854821c47f4b4",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/integration_test.go
+++ b/integration/base/integration_test.go
@@ -114,7 +114,7 @@ var _ = Describe("ship app", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					ignoreUpstreamContents := map[string][]string{
-						".ship/state.json": {"v1.upstreamContents", "v1.shipVersion"},
+						".ship/state.json": {"v1.upstreamContents", "v1.shipVersion", "v1.contentSHA"},
 					}
 
 					//compare the files in the temporary directory with those in the "expected" directory

--- a/integration/base/web/expected/.ship/state.json
+++ b/integration/base/web/expected/.ship/state.json
@@ -4,7 +4,7 @@
       "methodType": "GET",
       "resourceURL": "https://raw.githubusercontent.com/replicatedhq/test-charts/5bf016aac1786cb74c678c3419bb8623f0388f8d/web-asset/web-asset"
     },
-    "contentSHA": "e2caa313a59af409fa4e096faa605ade4b5d506447ba3d4b90f25bea9d2ddffb",
+    "contentSHA": "cd26c8e85fda23582ba8a3a067d1c7f76dfa421422d8a742064d6467ad6dda38",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/init_app/amazon-eks-template/expected/.ship/state.json
+++ b/integration/init_app/amazon-eks-template/expected/.ship/state.json
@@ -2,7 +2,7 @@
   "v1": {
     "config": {},
     "upstream": "__upstream__",
-    "contentSHA": "f1eaaa149478c1f7d4a4d42f603933b3b78d8a3df50cabf8ae209cbe990590de",
+    "contentSHA": "242b9d4a6c479e4c864f24d8e9bc0420e471c9e48fed0b89eec0260f3fbc7f0e",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "__customerID__",

--- a/integration/init_app/basic/expected/.ship/state.json
+++ b/integration/init_app/basic/expected/.ship/state.json
@@ -2,7 +2,7 @@
   "v1": {
     "config": {},
     "upstream": "__upstream__",
-    "contentSHA": "6faeec976f37e880c5e70cf578412a57fbfda3b35bf8e6f73221fe5fe88f1058",
+    "contentSHA": "9728a969294231e722662390ed73a8573a1af59f7a50bce21a8373612b69635e",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "__customerID__",

--- a/integration/init_app/docker-asset-slug/expected/.ship/state.json
+++ b/integration/init_app/docker-asset-slug/expected/.ship/state.json
@@ -18,7 +18,7 @@
       "sequence": 0,
       "version": "0.0.1"
     },
-    "contentSHA": "4e212691de81e471f76ea6ef8d236bae3874d0bc2f22487d17e3e4e42138a67f",
+    "contentSHA": "7694cf3b21c6fa8eb6ed0c92d9452096ddcd7e457fb2d728e5636eff2f5d2e10",
     "upstreamContents": {
       "appRelease": {
         "id": "oVSYJqtZnSew_8A3fFuwz0WPwn40zjn6",

--- a/integration/init_app/docker-asset/expected/.ship/state.json
+++ b/integration/init_app/docker-asset/expected/.ship/state.json
@@ -18,7 +18,7 @@
       "sequence": 0,
       "version": "1.0.0-SNAPSHOT"
     },
-    "contentSHA": "a551e7640f88bd4d9e5843ea7602c046a1b89feae744c521bee558f9e44f0a69",
+    "contentSHA": "55882cb70d6c27e8290668d1930b2a062570ac0fa8c459be94b6921c9ce7976f",
     "upstreamContents": {
       "appRelease": {
         "id": "jDtI-DiraCbkN5euJHmbS3kIFw4N1Iw9",

--- a/integration/init_app/github-template-func/expected/.ship/state.json
+++ b/integration/init_app/github-template-func/expected/.ship/state.json
@@ -4,7 +4,7 @@
       "option": "abc123"
     },
     "upstream": "__upstream__",
-    "contentSHA": "9fb30c009a2bb7202d3b0dfe7683823f799e238fd6132316de1cdbc54062dc6f",
+    "contentSHA": "6327e26ed6f0c8c7f693b3343d51f013048e4b5a87cf24f004e81dc7a8d8fd69",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "__customerID__",

--- a/integration/init_app/helm-github/expected/.ship/state.json
+++ b/integration/init_app/helm-github/expected/.ship/state.json
@@ -245,6 +245,6 @@
         "entitlements": {}
       }
     },
-    "contentSHA": "275a18f485ae78a3e0c723da1625fa08d12bb27dc401c49f15231a31d939676e"
+    "contentSHA": "687a05a7437c94d295cab91b748304d97ebb19e398cfed034e1659d81d852876"
   }
 }

--- a/integration/init_app/installation-template-func/expected/.ship/state.json
+++ b/integration/init_app/installation-template-func/expected/.ship/state.json
@@ -2,7 +2,7 @@
   "v1": {
     "config": {},
     "upstream": "__upstream__",
-    "contentSHA": "c8bbe58c7ee51e7185d42b717a6465cd3d9ec1b9f8eccda20f112fe54c155d3e",
+    "contentSHA": "ac7606f1553dd7bcf0a47631cd673726c550f49754d631f079a868a51204d9bd",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "__customerID__",

--- a/integration/init_app/license-info/expected/.ship/state.json
+++ b/integration/init_app/license-info/expected/.ship/state.json
@@ -75,6 +75,6 @@
       "buildTime": "0001-01-01T00:00:00Z",
       "dependencies": {}
     },
-    "contentSHA": "a086cc2c22a907a2d6cc7b5bbc2eb8fe3530799f41e1c5add0ce8aac380e4042"
+    "contentSHA": "c1e6486e6e3c2c4e49dac714aa8c151a024765575e20a8348541cf0833c70114"
   }
 }

--- a/integration/init_app/troubleshoot-ship-release/expected/.ship/state.json
+++ b/integration/init_app/troubleshoot-ship-release/expected/.ship/state.json
@@ -2,7 +2,7 @@
   "v1": {
     "config": {},
     "upstream": "__upstream__",
-    "contentSHA": "71dd296d8fae1f07f66b05d2e12710eb58bd7725d55093e41b6501b592418b31",
+    "contentSHA": "89cdef9a2ca2552ef5ce5be9048d6b1f75b4c59902770a4cd13d6d6b0cfd194f",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "__customerID__",

--- a/integration/update/app_basic/expected/.ship/state.json
+++ b/integration/update/app_basic/expected/.ship/state.json
@@ -2,7 +2,7 @@
   "v1": {
     "config": {},
     "upstream": "staging.replicated.app/some-cool-ci-tool?installation_id=3Z6uuPbVz6jTxRuXHn_l6UlYQz3hWz6-&customer_id=-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
-    "contentSHA": "6faeec976f37e880c5e70cf578412a57fbfda3b35bf8e6f73221fe5fe88f1058",
+    "contentSHA": "9728a969294231e722662390ed73a8573a1af59f7a50bce21a8373612b69635e",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/pkg/specs/content.go
+++ b/pkg/specs/content.go
@@ -3,6 +3,7 @@ package specs
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -177,7 +178,13 @@ func (c *ContentProcessor) ReadContentSHAForWatch(ctx context.Context, upstream 
 			return "", errors.Wrap(err, "fetch release")
 		}
 
-		return fmt.Sprintf("%x", sha256.Sum256([]byte(release.Spec))), nil
+		release.Entitlements.Signature = "" // entitlements signature is not stable
+		releaseJSON, err := json.Marshal(release)
+		if err != nil {
+			return "", errors.Wrap(err, "marshal release for sha256")
+		}
+
+		return fmt.Sprintf("%x", sha256.Sum256(releaseJSON)), nil
 	}
 
 	return "", errors.Errorf("Could not continue with application type %q of upstream %s", app.GetType(), upstream)

--- a/pkg/specs/interface_test.go
+++ b/pkg/specs/interface_test.go
@@ -356,7 +356,7 @@ func TestResolver_ReadContentSHAForWatch(t *testing.T) {
 					AppSlug:        "",
 				}).Return(&state2.ShipRelease{Spec: "its fake"}, nil)
 			},
-			expectSHA: "a9274e43955abe372d508864d19aa8be39872a39f44c8c5e2e04a4ef98c4aa04", // sha256.Sum256([]byte("its fake"))
+			expectSHA: "ef1a4329e78b65e847e7428c3427f99b02a2d6c04ab3adb3910b9473b8bc7edb", // sha256.Sum256(json.Marshal(state2.ShipRelease{Spec: "its fake"}))
 		},
 	}
 	for _, test := range tests {

--- a/pkg/specs/replicatedapp/local.go
+++ b/pkg/specs/replicatedapp/local.go
@@ -56,12 +56,13 @@ func (r *resolver) resolveRunbookRelease(selector *Selector) (*state.ShipRelease
 		Semver:         semver,
 		GithubContents: fakeGithubContents,
 		Entitlements:   *fakeEntitlements,
+		Images:         []state.Image{},
 	}, nil
 }
 
 func (r *resolver) loadLocalGitHubContents() ([]state.GithubContent, error) {
 	debug := level.Debug(log.With(r.Logger, "method", "loadLocalGitHubContents"))
-	var fakeGithubContents []state.GithubContent
+	fakeGithubContents := []state.GithubContent{}
 	for _, content := range r.SetGitHubContents {
 		debug.Log("event", "githubcontents.set", "received", content)
 		split := strings.Split(content, ":")

--- a/pkg/specs/replicatedapp/local_test.go
+++ b/pkg/specs/replicatedapp/local_test.go
@@ -19,7 +19,7 @@ func TestLoadLocalGitHubContents(t *testing.T) {
 		{
 			name:           "none to set",
 			githubContent:  nil,
-			expectContents: nil,
+			expectContents: []state.GithubContent{},
 		},
 		{
 			name: "set one file",

--- a/pkg/specs/replicatedapp/resolver.go
+++ b/pkg/specs/replicatedapp/resolver.go
@@ -24,7 +24,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-type shaSummer func([]byte) string
+type shaSummer func(release state.ShipRelease) string
 type dater func() string
 type resolver struct {
 	Logger               log.Logger
@@ -65,8 +65,14 @@ func NewAppResolver(
 		RunbookReleaseSemver: v.GetString("release-semver"),
 		IsEdit:               v.GetBool("isEdit"),
 		StateManager:         stateManager,
-		ShaSummer: func(bytes []byte) string {
-			return fmt.Sprintf("%x", sha256.Sum256(bytes))
+		ShaSummer: func(release state.ShipRelease) string {
+			release.Entitlements.Signature = "" // entitlements signature is not stable
+			releaseJSON, err := json.Marshal(release)
+			if err != nil {
+				panic(errors.Wrap(err, "marshal release to json for content sha"))
+			}
+
+			return fmt.Sprintf("%x", sha256.Sum256(releaseJSON))
 		},
 		Dater: func() string {
 			// format consistent with what we get from GQL
@@ -218,7 +224,7 @@ func (r *resolver) persistRelease(release *state.ShipRelease, license *license, 
 		return nil, errors.Wrap(err, "serialize app metadata")
 	}
 
-	contentSHA := r.ShaSummer([]byte(release.Spec))
+	contentSHA := r.ShaSummer(*release)
 	if err := r.StateManager.SerializeContentSHA(contentSHA); err != nil {
 		return nil, errors.Wrap(err, "serialize content sha")
 	}

--- a/pkg/specs/replicatedapp/resolver_test.go
+++ b/pkg/specs/replicatedapp/resolver_test.go
@@ -60,7 +60,7 @@ assets:
 				CustomerID:     "kfbr",
 				InstallationID: "392",
 			},
-			shaSummer: func(bytes []byte) string {
+			shaSummer: func(resolver state2.ShipRelease) string {
 				return "abcdef"
 			},
 			license: &license{},


### PR DESCRIPTION
update init_app, update, and base integration tests to use the new shas

What I Did
------------
Sequence number, github contents and entitlement values (among other things) are now used to calculate whether a `replicated.app` upstream has been updated, not just the yaml spec.

How I Did it
------------
Content sha is calculated from a jsonified version of the ship app struct. Before converting to json, the entitlements signature is cleared, as it is not constant and should not trigger an app update.


How to verify it
------------
New content shas in the integration tests. No-op release promotions (same yaml + different semver, etc) will cause `ship watch` to return.

Description for the Changelog
------------
`ship watch` now takes into account proxied Github contents and the release sequence when using a `replicated.app` upstream


Picture of a Ship (not required but encouraged)
------------

![USS Scott (DDG-995)](https://upload.wikimedia.org/wikipedia/commons/3/3f/USS_Scott_DDG-995.jpg "USS Scott (DDG-995)")










<!-- (thanks https://github.com/docker/docker for this template) -->

