### PR TITLE
update readme download link versions to 0.47.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ Configuration workflow `ship.yaml` files can be included in Kubernetes manifest 
 Ship is packaged as a single binary, and Linux and MacOS versions are distributed:
 - To download the latest Linux build, run:
 ```shell
-curl -sSL https://github.com/replicatedhq/ship/releases/download/v0.44.0/ship_0.44.0_linux_amd64.tar.gz | tar zxv && sudo mv ship /usr/local/bin
+curl -sSL https://github.com/replicatedhq/ship/releases/download/v0.47.0/ship_0.47.0_linux_amd64.tar.gz | tar zxv && sudo mv ship /usr/local/bin
 ```
 
 - To download the latest MacOS build, you can either run:
 ```shell
-curl -sSL https://github.com/replicatedhq/ship/releases/download/v0.44.0/ship_0.44.0_darwin_amd64.tar.gz | tar zxv && sudo mv ship /usr/local/bin
+curl -sSL https://github.com/replicatedhq/ship/releases/download/v0.47.0/ship_0.47.0_darwin_amd64.tar.gz | tar zxv && sudo mv ship /usr/local/bin
 ```
 
 - ... or you can install with [Homebrew](https://brew.sh/):


### PR DESCRIPTION
What I Did
------------
Updated the download links in the readme for version `0.47.0`.

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Ship (not required but encouraged)
------------

![USS Hayler (DD-997)](https://upload.wikimedia.org/wikipedia/commons/0/01/US_Navy_010618-N-6626D-002_USS_Hayler_%28DD_997%29_underway.jpg "USS Hayler (DD-997)")










<!-- (thanks https://github.com/docker/docker for this template) -->

