### PR TITLE
Fix missed passed prop in FileTree recursive rendering

### DIFF
--- a/web/init/src/components/kustomize/kustomize_overlay/FileTree.jsx
+++ b/web/init/src/components/kustomize/kustomize_overlay/FileTree.jsx
@@ -9,9 +9,9 @@ export default class FileTree extends React.Component {
   }
 
   handleDeleteOverlay = (e, path) => {
-    const { isResourceTree, isBaseTree, isOverlayTree } = this.props;
     e.stopPropagation();
 
+    const { isResourceTree, isBaseTree, isOverlayTree } = this.props;
     if (isResourceTree) {
       return this.props.handleDeleteOverlay(path, RESOURCE_OVERLAY);
     }
@@ -41,19 +41,34 @@ export default class FileTree extends React.Component {
             <FileTree
               files={file.children}
               handleFileSelect={(path) => handleFileSelect(path)}
-              handleDeleteOverlay={(path) => handleDeleteOverlay(path)}
+              handleDeleteOverlay={(path, type) => handleDeleteOverlay(path, type)}
+              handleClickExcludedBase={(e) => this.props.handleClickExcludedBase(e, file.path)}
               selectedFile={selectedFile}
               isOverlayTree={isOverlayTree}
               isBaseTree={isBaseTree}
             />
           </li>
           :
-          file.isExcluded ? <li key={file.path} className={`u-position--relative is-file ${file.isExcluded ? "is-excluded" : ""}`} onClick={(e) => this.handleClickExcludedBase(e, file.path)}>{file.name}</li> :
-          <li key={file.path} className={`u-position--relative is-file ${selectedFile === file.path ? "is-selected" : ""} ${file.hasOverlay ? "edited" : ""} ${isBaseTree ? "is-base" : ""}`} onClick={() => this.handleFileSelect(file.path)}>
-            {file.name}
-            {isOverlayTree || isResourceTree ? <span className="icon clickable u-deleteOverlayIcon" onClick={(e) => this.handleDeleteOverlay(e, file.path)}></span> : null}
-            {isBaseTree ? <span className="icon clickable u-deleteOverlayIcon" onClick={(e) => this.handleDeleteOverlay(e, file.path)}></span> : null}
-          </li>
+          file.isExcluded
+            ? (
+              <li
+                key={file.path}
+                className={`u-position--relative is-file ${file.isExcluded ? "is-excluded" : ""}`}
+                onClick={(e) => this.handleClickExcludedBase(e, file.path)}
+                >
+                {file.name}
+              </li>
+            )
+            :(
+              <li
+                key={file.path}
+                className={`u-position--relative is-file ${selectedFile === file.path ? "is-selected" : ""} ${file.hasOverlay ? "edited" : ""} ${isBaseTree ? "is-base" : ""}`}
+                onClick={() => this.handleFileSelect(file.path)}>
+                {file.name}
+                {isOverlayTree || isResourceTree ? <span className="icon clickable u-deleteOverlayIcon" onClick={(e) => this.handleDeleteOverlay(e, file.path)}></span> : null}
+                {isBaseTree ? <span className="icon clickable u-deleteOverlayIcon" onClick={(e) => this.handleDeleteOverlay(e, file.path)}></span> : null}
+              </li>
+            )
         ))
         }
       </ul>

--- a/web/init/src/components/kustomize/kustomize_overlay/KustomizeOverlay.jsx
+++ b/web/init/src/components/kustomize/kustomize_overlay/KustomizeOverlay.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import classNames from "classnames";
 import AceEditor from "react-ace";
 import ReactTooltip from "react-tooltip"
 import * as yaml from "js-yaml";
@@ -231,7 +232,6 @@ export default class KustomizeOverlay extends React.Component {
     const { fileTree, selectedFile } = this.state;
     const isResource = overlayType === RESOURCE_OVERLAY;
     const isBase = overlayType === BASE_OVERLAY;
-
     const overlays = find(fileTree, { name: "overlays" });
     const overlayExists = overlays && findIndex(overlays.children, { path }) > -1;
 
@@ -425,23 +425,38 @@ export default class KustomizeOverlay extends React.Component {
               <div className="flex-column flex1">
                 <div className="flex1 u-overflow--auto u-background--biscay">
                   <div className="flex1 dirtree-wrapper u-overflow--hidden flex-column">
-                    {fileTree.map((tree, i) => (
-                      <div className={`u-overflow--auto FileTree-wrapper u-position--relative dirtree ${i > 0 ? "flex-auto has-border" : "flex-0-auto"}`} key={i}>
-                        <input type="checkbox" name={`sub-dir-${tree.name}-${tree.children.length}-${tree.path}-${i}`} id={`sub-dir-${tree.name}-${tree.children.length}-${tree.path}-${i}`} defaultChecked={true} />
-                        <label htmlFor={`sub-dir-${tree.name}-${tree.children.length}-${tree.path}-${i}`}>{tree.name === "/" ? "base" : tree.name}</label>
-                        <FileTree
-                          files={tree.children}
-                          basePath={tree.name}
-                          handleFileSelect={(path) => this.setSelectedFile(path)}
-                          handleDeleteOverlay={this.toggleModal}
-                          handleClickExcludedBase={this.toggleModalForExcludedBase}
-                          selectedFile={this.state.selectedFile}
-                          isOverlayTree={tree.name === "overlays"}
-                          isResourceTree={tree.name === "resources"}
-                          isBaseTree={tree.name === "/"}
-                        />
-                      </div>
-                    ))}
+                    {fileTree.map((tree, i) => {
+                        const id = `sub-dir-${tree.name}-${tree.children.length}-${tree.path}-${i}`;
+                        return (
+                          <div
+                            key={id}
+                            className={classNames("u-overflow--auto FileTree-wrapper u-position--relative dirtree", {
+                              "flex-auto has-border": i > 0,
+                              "flex-0-auto": i <= 0
+                            })}>
+                              <input
+                                type="checkbox"
+                                name={id}
+                                id={id}
+                                defaultChecked={true}
+                              />
+                              <label htmlFor={id}>
+                                {tree.name === "/" ? "base" : tree.name}
+                              </label>
+                              <FileTree
+                                files={tree.children}
+                                basePath={tree.name}
+                                handleFileSelect={(path) => this.setSelectedFile(path)}
+                                handleDeleteOverlay={this.toggleModal}
+                                handleClickExcludedBase={this.toggleModalForExcludedBase}
+                                selectedFile={this.state.selectedFile}
+                                isOverlayTree={tree.name === "overlays"}
+                                isResourceTree={tree.name === "resources"}
+                                isBaseTree={tree.name === "/"}
+                              />
+                          </div>
+                        );
+                      })}
                     <div className="add-new-resource u-position--relative" ref={this.addResourceWrapper}>
                       <input
                         type="text"


### PR DESCRIPTION
What I Did
------------
Fixed an error with recursive file trees not passing previous props and missing file types

How I Did it
------------
Detective work

How to verify it
------------
`ship init` a helm chart with a lot of files within a nested folder structure like [Istio](https://github.com/istio/istio/tree/1.2.0/install/kubernetes/helm/istio). Get to the Kustomize step, and delete a base YAML file.

Description for the Changelog
------------
Fixed an error where deleting YAML base files in a nested folder structure wouldn't work.


Picture of a Ship (not required but encouraged)
------------
🚢 











<!-- (thanks https://github.com/docker/docker for this template) -->

