### PR TITLE
improve version command output and fix git sha

### DIFF
--- a/deploy/.goreleaser.unstable.yml
+++ b/deploy/.goreleaser.unstable.yml
@@ -25,7 +25,7 @@ builds:
   main: cmd/ship/main.go
   ldflags: -s -w 
     -X github.com/replicatedhq/ship/pkg/version.version={{.Version}}
-    -X github.com/replicatedhq/ship/pkg/version.gitSHA={{.Commit}}
+    -X github.com/replicatedhq/ship/pkg/version.gitSHA={{.FullCommit}}
     -X github.com/replicatedhq/ship/pkg/version.buildTime={{.Date}}
     -X github.com/replicatedhq/ship/pkg/version.helm=v2.14.1
     -X github.com/replicatedhq/ship/pkg/version.kustomize=v2.0.3

--- a/deploy/.goreleaser.yml
+++ b/deploy/.goreleaser.yml
@@ -25,7 +25,7 @@ builds:
   main: cmd/ship/main.go
   ldflags: -s -w
     -X github.com/replicatedhq/ship/pkg/version.version={{.Version}}
-    -X github.com/replicatedhq/ship/pkg/version.gitSHA={{.Commit}}
+    -X github.com/replicatedhq/ship/pkg/version.gitSHA={{.FullCommit}}
     -X github.com/replicatedhq/ship/pkg/version.buildTime={{.Date}}
     -X github.com/replicatedhq/ship/pkg/version.helm=v2.14.1
     -X github.com/replicatedhq/ship/pkg/version.kustomize=v2.0.3

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,6 +1,9 @@
 package version
 
-import "time"
+import (
+	"runtime"
+	"time"
+)
 
 var (
 	build Build
@@ -13,12 +16,20 @@ type Build struct {
 	BuildTime    time.Time         `json:"buildTime,omitempty"`
 	TimeFallback string            `json:"buildTimeFallback,omitempty"`
 	Dependencies BuildDependencies `json:"dependencies,omitempty"`
+	GoInfo       GoInfo            `json:"go,omitempty"`
 }
 
 type BuildDependencies struct {
 	Helm      string `json:"helm,omitempty"`
 	Kustomize string `json:"kustomize,omitempty"`
 	Terraform string `json:"terraform,omitempty"`
+}
+
+type GoInfo struct {
+	Version  string `json:"version,omitempty"`
+	Compiler string `json:"compiler,omitempty"`
+	OS       string `json:"os,omitempty"`
+	Arch     string `json:"arch,omitempty"`
 }
 
 // initBuild sets up the version info from build args
@@ -39,6 +50,8 @@ func initBuild() {
 		Terraform: terraform,
 	}
 	build.Dependencies = deps
+
+	build.GoInfo = getGoInfo()
 }
 
 // GetBuild gets the build
@@ -59,4 +72,13 @@ func GitSHA() string {
 // BuildTime gets the build time
 func BuildTime() time.Time {
 	return build.BuildTime
+}
+
+func getGoInfo() GoInfo {
+	return GoInfo{
+		Version:  runtime.Version(),
+		Compiler: runtime.Compiler,
+		OS:       runtime.GOOS,
+		Arch:     runtime.GOARCH,
+	}
 }

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,142 @@
+package version
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{
+			name: "empty",
+			want: "",
+		},
+		{
+			name: "version string",
+			want: "v0.1.2",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			version = tt.want
+			initBuild()
+
+			got := Version()
+			req.Equal(tt.want, got)
+		})
+	}
+}
+
+func TestGitSHA(t *testing.T) {
+	tests := []struct {
+		name string
+		sha  string
+		want string
+	}{
+		{
+			name: "empty",
+			sha:  "",
+			want: "",
+		},
+		{
+			name: "too short",
+			sha:  "123456",
+			want: "",
+		},
+		{
+			name: "7 chars",
+			sha:  "1234567",
+			want: "1234567",
+		},
+		{
+			name: "full sha",
+			sha:  "e21cf800acca2aa972e7f5f65f7134b5da92f05f",
+			want: "e21cf80",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			gitSHA = tt.sha
+			initBuild()
+
+			got := GitSHA()
+			req.Equal(tt.want, got)
+		})
+	}
+}
+
+func TestBuildTime(t *testing.T) {
+	req := require.New(t)
+	aTime, err := time.Parse(time.RFC3339, "2019-06-26T18:53:19Z")
+	req.NoError(err, "parse constant time")
+
+	tests := []struct {
+		name       string
+		timestring string
+		want       time.Time
+	}{
+		{
+			name:       "empty",
+			timestring: "",
+			want:       time.Time{},
+		},
+		{
+			name:       "proper format",
+			timestring: "2019-06-26T18:53:19Z",
+			want:       aTime,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			buildTime = tt.timestring
+			initBuild()
+
+			got := BuildTime()
+			req.Equal(tt.want, got)
+		})
+	}
+}
+
+func TestGetBuild(t *testing.T) {
+	tests := []struct {
+		name      string
+		gitSHA    string
+		version   string
+		buildTime string
+		want      Build
+	}{
+		{
+			name:   "goInfo",
+			gitSHA: "12345678",
+			want: Build{
+				GitSHA: "1234567",
+				GoInfo: getGoInfo(),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			version = tt.version
+			gitSHA = tt.gitSHA
+			buildTime = tt.buildTime
+
+			initBuild()
+
+			got := GetBuild()
+			req.Equal(tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
What I Did
------------
Use `.FullCommit` and not `.Commit` in goreleaser as `.Commit` is deprecated and seems to no longer work

Include go and environment info in `ship version`

Add testing for the `version` package

How I Did it
------------


How to verify it
------------

Example output:
```
{
    "version": "v0.47.0-3-gb67feab8",
    "git": "b67feab",
    "buildTime": "2019-06-27T00:19:24Z",
    "dependencies": {
        "helm": "v2.14.1",
        "kustomize": "v2.0.3",
        "terraform": "v0.11.14"
    },
    "go": {
        "version": "go1.12.6",
        "compiler": "gc",
        "os": "darwin",
        "arch": "amd64"
    }
}
```


Description for the Changelog
------------
`ship version` includes golang and runtime information


Picture of a Ship (not required but encouraged)
------------




![USS Lexington (CV-2)](https://upload.wikimedia.org/wikipedia/commons/9/94/USS_Lexington_%28CV-2%29_leaving_San_Diego_on_14_October_1941_%2880-G-416362%29.jpg "USS Lexington (CV-2)")







<!-- (thanks https://github.com/docker/docker for this template) -->

