### PR TITLE
update readme download link versions to 0.47.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ Configuration workflow `ship.yaml` files can be included in Kubernetes manifest 
 Ship is packaged as a single binary, and Linux and MacOS versions are distributed:
 - To download the latest Linux build, run:
 ```shell
-curl -sSL https://github.com/replicatedhq/ship/releases/download/v0.47.0/ship_0.47.0_linux_amd64.tar.gz | tar zxv && sudo mv ship /usr/local/bin
+curl -sSL https://github.com/replicatedhq/ship/releases/download/v0.47.1/ship_0.47.1_linux_amd64.tar.gz | tar zxv && sudo mv ship /usr/local/bin
 ```
 
 - To download the latest MacOS build, you can either run:
 ```shell
-curl -sSL https://github.com/replicatedhq/ship/releases/download/v0.47.0/ship_0.47.0_darwin_amd64.tar.gz | tar zxv && sudo mv ship /usr/local/bin
+curl -sSL https://github.com/replicatedhq/ship/releases/download/v0.47.1/ship_0.47.1_darwin_amd64.tar.gz | tar zxv && sudo mv ship /usr/local/bin
 ```
 
 - ... or you can install with [Homebrew](https://brew.sh/):


### PR DESCRIPTION
<!--

  Hello Friend! Thank you for contributing to Ship!

  If you worked on the front end (i.e React component side)...
  Did you bump the version number in package.json?

  Thanks again! You are awesome!
-->
What I Did
------------
Updated the download links in the readme for version `0.47.1`.

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Ship (not required but encouraged)
------------




![USS Saratoga (CV-3)](https://upload.wikimedia.org/wikipedia/commons/7/7f/USS_Saratoga_%28CV-3%29_underway%2C_circa_in_1942_%2880-G-K-459%29.jpg "USS Saratoga (CV-3)")







<!-- (thanks https://github.com/docker/docker for this template) -->

