### PR TITLE
Cache state to improve performance with URL-based storage.

### DIFF
--- a/integration/init/grafana-preserve-state/input/state.json
+++ b/integration/init/grafana-preserve-state/input/state.json
@@ -31,16 +31,6 @@
       "sequence": 0,
       "version": "1.19.0"
     },
-    "contentSHA": "091919437262ee08b6d7afa80dc43e55c59acf7c2995118bfaaa9dfbc7facf7f",
-    "lifecycle": {
-      "stepsCompleted": {
-        "intro": true,
-        "kustomize": true,
-        "kustomize-intro": true,
-        "outro": true,
-        "render": true,
-        "values": true
-      }
-    }
+    "contentSHA": "091919437262ee08b6d7afa80dc43e55c59acf7c2995118bfaaa9dfbc7facf7f"
   }
 }

--- a/integration/init_app/integration_test.go
+++ b/integration/init_app/integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/onsi/gomega/format"
 	"github.com/replicatedhq/ship/integration"
 	"github.com/replicatedhq/ship/pkg/cli"
+	"github.com/replicatedhq/ship/pkg/state"
 	"gopkg.in/yaml.v2"
 )
 
@@ -92,10 +93,17 @@ var _ = Describe("ship init replicated.app/...", func() {
 				AfterEach(func() {
 					os.Unsetenv("REPLICATED_REGISTRY")
 					if !testMetadata.SkipCleanup && os.Getenv("SHIP_INTEGRATION_SKIP_CLEANUP_ALL") == "" {
+						err := state.GetSingleton().RemoveStateFile()
+						Expect(err).NotTo(HaveOccurred())
+
 						// remove the temporary directory
-						err := os.RemoveAll(testOutputPath)
+						err = os.RemoveAll(testOutputPath)
 						Expect(err).NotTo(HaveOccurred())
 					}
+
+					err := state.GetSingleton().RemoveStateFile()
+					Expect(err).NotTo(HaveOccurred())
+
 					os.Chdir(integrationDir)
 				}, 20)
 
@@ -204,6 +212,10 @@ var _ = Describe("ship init replicated.app/...", func() {
 						err := os.RemoveAll(testOutputPath)
 						Expect(err).NotTo(HaveOccurred())
 					}
+
+					err := state.GetSingleton().RemoveStateFile()
+					Expect(err).NotTo(HaveOccurred())
+
 					os.Chdir(integrationDir)
 				}, 20)
 
@@ -234,6 +246,11 @@ var _ = Describe("ship init replicated.app/...", func() {
 					Expect(err).NotTo(HaveOccurred())
 					err = ioutil.WriteFile(writePath, stateFile, os.ModePerm)
 					Expect(err).NotTo(HaveOccurred())
+
+					if state.GetSingleton() != nil {
+						err = state.GetSingleton().ReloadFile()
+						Expect(err).NotTo(HaveOccurred())
+					}
 
 					cmd := cli.RootCmd()
 					buf := new(bytes.Buffer)

--- a/integration/unfork/integration_test.go
+++ b/integration/unfork/integration_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/onsi/gomega/format"
 	"github.com/replicatedhq/ship/integration"
 	"github.com/replicatedhq/ship/pkg/cli"
+	"github.com/replicatedhq/ship/pkg/state"
 	"gopkg.in/yaml.v2"
 )
 
@@ -71,6 +72,8 @@ var _ = Describe("ship unfork", func() {
 				}, 20)
 
 				AfterEach(func() {
+					err := state.GetSingleton().RemoveStateFile()
+					Expect(err).NotTo(HaveOccurred())
 					os.Chdir(integrationDir)
 				}, 20)
 

--- a/integration/update/integration_test.go
+++ b/integration/update/integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/onsi/gomega/format"
 	"github.com/replicatedhq/ship/integration"
 	"github.com/replicatedhq/ship/pkg/cli"
+	"github.com/replicatedhq/ship/pkg/state"
 	"gopkg.in/yaml.v2"
 )
 
@@ -88,8 +89,11 @@ var _ = Describe("ship update", func() {
 
 				AfterEach(func() {
 					if !testMetadata.SkipCleanup && os.Getenv("SHIP_INTEGRATION_SKIP_CLEANUP_ALL") == "" {
+						err := state.GetSingleton().RemoveStateFile()
+						Expect(err).NotTo(HaveOccurred())
+
 						// remove the temporary directory
-						err := os.RemoveAll(testOutputPath)
+						err = os.RemoveAll(testOutputPath)
 						Expect(err).NotTo(HaveOccurred())
 					}
 					os.Chdir(integrationDir)
@@ -103,6 +107,7 @@ var _ = Describe("ship update", func() {
 					cmd := cli.RootCmd()
 					buf := new(bytes.Buffer)
 					cmd.SetOutput(buf)
+					os.Setenv("PRELOAD_TEST_STATE", "1")
 					args := []string{
 						"update",
 						"--headless",

--- a/pkg/filetree/loader.go
+++ b/pkg/filetree/loader.go
@@ -51,7 +51,7 @@ type aferoLoader struct {
 }
 
 func (a *aferoLoader) loadShipOverlay() error {
-	currentState, err := a.StateManager.TryLoad()
+	currentState, err := a.StateManager.CachedState()
 	if err != nil {
 		return errors.Wrap(err, "failed to load state")
 	}

--- a/pkg/filetree/loader_test.go
+++ b/pkg/filetree/loader_test.go
@@ -76,7 +76,7 @@ func TestAferoLoader(t *testing.T) {
 				testResources[resource.Key.(string)] = resource.Value.(string)
 			}
 
-			mockState.EXPECT().TryLoad().Return(state.State{
+			mockState.EXPECT().CachedState().Return(state.State{
 				V1: &state.V1{
 					Kustomize: &state.Kustomize{
 						Overlays: map[string]state.Overlay{

--- a/pkg/lifecycle/daemon/daemontypes/types.go
+++ b/pkg/lifecycle/daemon/daemontypes/types.go
@@ -36,7 +36,7 @@ type Daemon interface {
 	TerraformConfirmedChan() chan bool
 	KustomizeSavedChan() chan interface{}
 	UnforkSavedChan() chan interface{}
-	GetCurrentConfig() map[string]interface{}
+	GetCurrentConfig() (map[string]interface{}, error)
 	AwaitShutdown() error
 }
 

--- a/pkg/lifecycle/daemon/routes_navcycle.go
+++ b/pkg/lifecycle/daemon/routes_navcycle.go
@@ -163,7 +163,7 @@ func (d *NavcycleRoutes) getRequiredButIncompleteStepFor(requires []string, with
 	}
 
 	stepsCompleted := map[string]interface{}{}
-	currentState, err := d.StateManager.TryLoad()
+	currentState, err := d.StateManager.CachedState()
 	if err != nil {
 		return "", errors.Wrap(err, "load state")
 	}

--- a/pkg/lifecycle/daemon/routes_navcycle_completestep_test.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_completestep_test.go
@@ -336,7 +336,9 @@ func TestV2CompleteStep(t *testing.T) {
 
 			testLogger := &logger.TestLogger{T: t}
 			fs := afero.Afero{Fs: afero.NewMemMapFs()}
-			realState := state2.NewManager(testLogger, fs, viper.New())
+			realState, err := state2.NewDisposableManager(testLogger, fs, viper.New())
+			req.NoError(err)
+
 			mc := gomock.NewController(t)
 			messenger := lifecycle.NewMockMessenger(mc)
 			renderer := lifecycle.NewMockRenderer(mc)
@@ -393,7 +395,7 @@ func TestV2CompleteStep(t *testing.T) {
 						// there is almost certainly a better solution than this
 						time.Sleep(time.Duration(time.Millisecond * 500))
 
-						loadState, err := realState.TryLoad()
+						loadState, err := realState.CachedState()
 						req.NoError(err)
 						req.True(testCase.ExpectState.Test(loadState), testCase.ExpectState.Describe)
 					}

--- a/pkg/lifecycle/daemon/routes_navcycle_config.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_config.go
@@ -33,7 +33,7 @@ func (d *NavcycleRoutes) postAppConfigLive(release *api.Release) gin.HandlerFunc
 		}
 
 		debug.Log("event", "state.tryLoad")
-		savedSate, err := d.StateManager.TryLoad()
+		savedSate, err := d.StateManager.CachedState()
 		if err != nil {
 			level.Error(d.Logger).Log("msg", "failed to load stateManager", "err", err)
 			c.AbortWithStatus(500)
@@ -46,7 +46,14 @@ func (d *NavcycleRoutes) postAppConfigLive(release *api.Release) gin.HandlerFunc
 		}
 
 		debug.Log("event", "resolveConfig")
-		resolvedConfig, err := d.ConfigRenderer.ResolveConfig(c, release, savedSate.CurrentConfig(), liveValues, true)
+		currentConfig, err := savedSate.CurrentConfig()
+		if err != nil {
+			level.Error(d.Logger).Log("msg", "failed to get current config", "err", err)
+			c.AbortWithStatus(500)
+			return
+		}
+
+		resolvedConfig, err := d.ConfigRenderer.ResolveConfig(c, release, currentConfig, liveValues, true)
 		if err != nil {
 			level.Error(d.Logger).Log("event", "resolveconfig failed", "err", err)
 			c.AbortWithStatus(500)
@@ -92,7 +99,7 @@ func (d *NavcycleRoutes) putAppConfig(release *api.Release) gin.HandlerFunc {
 		}
 
 		debug.Log("event", "state.tryLoad")
-		savedState, err := d.StateManager.TryLoad()
+		savedState, err := d.StateManager.CachedState()
 		if err != nil {
 			level.Error(d.Logger).Log("msg", "failed to load stateManager", "err", err)
 			c.AbortWithStatus(500)
@@ -105,7 +112,14 @@ func (d *NavcycleRoutes) putAppConfig(release *api.Release) gin.HandlerFunc {
 		}
 
 		debug.Log("event", "resolveConfig")
-		resolvedConfig, err := d.ConfigRenderer.ResolveConfig(c, release, savedState.CurrentConfig(), liveValues, false)
+		currentConfig, err := savedState.CurrentConfig()
+		if err != nil {
+			level.Error(d.Logger).Log("msg", "failed to get current config", "err", err)
+			c.AbortWithStatus(500)
+			return
+		}
+
+		resolvedConfig, err := d.ConfigRenderer.ResolveConfig(c, release, currentConfig, liveValues, false)
 		if err != nil {
 			level.Error(d.Logger).Log("event", "resolveconfig failed", "err", err)
 			c.AbortWithStatus(500)

--- a/pkg/lifecycle/daemon/routes_navcycle_getstep_test.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_getstep_test.go
@@ -227,7 +227,7 @@ func TestV2GetStep(t *testing.T) {
 				StepProgress:   progressmap,
 			}
 
-			fakeState.EXPECT().TryLoad().Return(state2.State{
+			fakeState.EXPECT().CachedState().Return(state2.State{
 				V1: &state2.V1{
 					Lifecycle: test.State,
 				},
@@ -564,8 +564,8 @@ func TestHydrateStep(t *testing.T) {
 			mockState := state.NewMockManager(mc)
 
 			if !test.state.IsEmpty() {
-				mockState.EXPECT().TryLoad().Return(test.state, nil)
-				mockState.EXPECT().TryLoad().Return(test.state, nil)
+				mockState.EXPECT().CachedState().Return(test.state, nil)
+				mockState.EXPECT().CachedState().Return(test.state, nil)
 			}
 
 			for fn, file := range test.fs {
@@ -700,9 +700,9 @@ func TestHydrateTemplatedKustomizeStep(t *testing.T) {
 			mockFs := afero.Afero{Fs: afero.NewMemMapFs()}
 			mockState := state.NewMockManager(mc)
 			if !test.state.IsEmpty() {
-				mockState.EXPECT().TryLoad().Return(test.state, nil)
-				mockState.EXPECT().TryLoad().Return(test.state, nil)
-				mockState.EXPECT().TryLoad().Return(test.state, nil)
+				mockState.EXPECT().CachedState().Return(test.state, nil)
+				mockState.EXPECT().CachedState().Return(test.state, nil)
+				mockState.EXPECT().CachedState().Return(test.state, nil)
 			}
 
 			for _, dir := range test.fs {

--- a/pkg/lifecycle/daemon/routes_navcycle_kustomize.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_kustomize.go
@@ -60,7 +60,7 @@ func (d *NavcycleRoutes) kustomizeDoSaveOverlay(request SaveOverlayRequest) erro
 	debug := level.Debug(log.With(d.Logger, "handler", "kustomizeSaveOverlay"))
 
 	debug.Log("event", "state.load")
-	currentState, err := d.StateManager.TryLoad()
+	currentState, err := d.StateManager.CachedState()
 	if err != nil {
 		return errors.Wrap(err, "load state")
 	}
@@ -126,7 +126,7 @@ func (d *NavcycleRoutes) kustomizeGetFile(c *gin.Context) {
 		return
 	}
 
-	savedState, err := d.StateManager.TryLoad()
+	savedState, err := d.StateManager.CachedState()
 	if err != nil {
 		level.Error(d.Logger).Log("event", "load state failed", "err", err)
 		c.AbortWithError(500, err)
@@ -286,7 +286,7 @@ func (d *NavcycleRoutes) deleteBase(c *gin.Context) {
 		return
 	}
 
-	currentState, err := d.StateManager.TryLoad()
+	currentState, err := d.StateManager.CachedState()
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, errors.Wrap(err, "delete base"))
 		return
@@ -349,7 +349,7 @@ func (d *NavcycleRoutes) includeBase(c *gin.Context) {
 	}
 
 	debug.Log("event", "load state")
-	currentState, err := d.StateManager.TryLoad()
+	currentState, err := d.StateManager.CachedState()
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, errors.Wrap(err, "include base"))
 		return
@@ -427,7 +427,7 @@ func (d *NavcycleRoutes) deletePatch(c *gin.Context) {
 func (d *NavcycleRoutes) deleteFile(pathQueryParam string, getFiles func(overlay state.Overlay) map[string]string) error {
 	debug := level.Debug(log.With(d.Logger, "struct", "daemon", "handler", "deleteFile"))
 	debug.Log("event", "state.load")
-	currentState, err := d.StateManager.TryLoad()
+	currentState, err := d.StateManager.CachedState()
 	if err != nil {
 		return errors.Wrap(err, "load state")
 	}

--- a/pkg/lifecycle/daemon/routes_navcycle_kustomize_test.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_kustomize_test.go
@@ -147,7 +147,7 @@ func TestV2KustomizeSaveFile(t *testing.T) {
 				StepProgress: progressmap,
 			}
 
-			fakeState.EXPECT().TryLoad().Return(state.State{
+			fakeState.EXPECT().CachedState().Return(state.State{
 				V1: &test.InState,
 			}, nil).AnyTimes()
 
@@ -269,7 +269,7 @@ func TestV2KustomizeDeleteFile(t *testing.T) {
 				StepProgress: progressmap,
 			}
 
-			fakeState.EXPECT().TryLoad().Return(state.State{
+			fakeState.EXPECT().CachedState().Return(state.State{
 				V1: &test.InState,
 			}, nil).AnyTimes()
 

--- a/pkg/lifecycle/daemon/routes_v1.go
+++ b/pkg/lifecycle/daemon/routes_v1.go
@@ -236,7 +236,7 @@ func (d *V1Routes) getCurrentStep(c *gin.Context) {
 		return
 	}
 
-	currentState, err := d.StateManager.TryLoad()
+	currentState, err := d.StateManager.CachedState()
 	if err != nil {
 		level.Error(d.Logger).Log("event", "tryLoad,fail", "err", err)
 		c.AbortWithError(500, errors.New("internal_server_error"))

--- a/pkg/lifecycle/daemon/routes_v1_config.go
+++ b/pkg/lifecycle/daemon/routes_v1_config.go
@@ -8,9 +8,9 @@ func (d *V1Routes) ConfigSavedChan() chan interface{} {
 	return d.ConfigSaved
 }
 
-func (d *V1Routes) GetCurrentConfig() map[string]interface{} {
+func (d *V1Routes) GetCurrentConfig() (map[string]interface{}, error) {
 	if d.CurrentConfig == nil {
-		return make(map[string]interface{})
+		return make(map[string]interface{}), nil
 	}
-	return d.CurrentConfig
+	return d.CurrentConfig, nil
 }

--- a/pkg/lifecycle/helmValues/helmValues.go
+++ b/pkg/lifecycle/helmValues/helmValues.go
@@ -56,7 +56,7 @@ func (h *helmValues) Execute(ctx context.Context, release *api.Release, step *ap
 
 	debug.Log("event", "readfile.attempt", "dest", path.Join(constants.HelmChartPath, "values.yaml"))
 
-	currentState, err := h.StateManager.TryLoad()
+	currentState, err := h.StateManager.CachedState()
 	if err != nil {
 		return errors.Wrap(err, "load state")
 	}
@@ -113,7 +113,7 @@ func (h *helmValues) resolveStateHelmValues() error {
 func resolveStateHelmValues(logger log.Logger, manager state.Manager, fs afero.Afero) error {
 	debug := level.Debug(log.With(logger, "step.type", "helmValues", "resolveHelmValues"))
 	debug.Log("event", "tryLoadState")
-	editState, err := manager.TryLoad()
+	editState, err := manager.CachedState()
 	if err != nil {
 		return errors.Wrap(err, "try load state")
 	}

--- a/pkg/lifecycle/kubectl/daemonless.go
+++ b/pkg/lifecycle/kubectl/daemonless.go
@@ -125,12 +125,17 @@ func (d *DaemonlessKubectl) Execute(ctx context.Context, release api.Release, st
 }
 
 func (d *DaemonlessKubectl) prepareCmd(release api.Release, step api.KubectlApply) (*exec.Cmd, error) {
-	currState, err := d.StateManager.TryLoad()
+	currState, err := d.StateManager.CachedState()
 	if err != nil {
 		return nil, errors.Wrap(err, "load state")
 	}
 
-	builder, err := d.BuilderBuilder.FullBuilder(release.Metadata, release.Spec.Config.V1, currState.CurrentConfig())
+	currentConfig, err := currState.CurrentConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "get current config")
+	}
+
+	builder, err := d.BuilderBuilder.FullBuilder(release.Metadata, release.Spec.Config.V1, currentConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "get builder")
 	}

--- a/pkg/lifecycle/kustomize/daemonless.go
+++ b/pkg/lifecycle/kustomize/daemonless.go
@@ -46,7 +46,7 @@ func (l *Kustomizer) Execute(ctx context.Context, release *api.Release, step api
 		return errors.Wrap(err, "write base kustomization")
 	}
 
-	current, err := l.State.TryLoad()
+	current, err := l.State.CachedState()
 	if err != nil {
 		return errors.Wrap(err, "load state")
 	}

--- a/pkg/lifecycle/kustomize/kustomizer.go
+++ b/pkg/lifecycle/kustomize/kustomizer.go
@@ -203,7 +203,7 @@ func (l *Kustomizer) writeOverlay(
 func (l *Kustomizer) writeBase(base string) error {
 	debug := level.Debug(log.With(l.Logger, "method", "writeBase"))
 
-	currentState, err := l.State.TryLoad()
+	currentState, err := l.State.CachedState()
 	if err != nil {
 		return errors.Wrap(err, "load state")
 	}

--- a/pkg/lifecycle/kustomize/kustomizer_test.go
+++ b/pkg/lifecycle/kustomize/kustomizer_test.go
@@ -330,7 +330,7 @@ resources:
 			mockDaemon := daemon2.NewMockDaemon(mc)
 			mockState := state2.NewMockManager(mc)
 
-			mockState.EXPECT().TryLoad().Return(state.State{
+			mockState.EXPECT().CachedState().Return(state.State{
 				V1: &state.V1{
 					Kustomize: &state.Kustomize{
 						Overlays: map[string]state.Overlay{
@@ -509,7 +509,7 @@ resources:
 				BasePath: constants.KustomizeBasePath,
 			})
 			mockDaemon.EXPECT().KustomizeSavedChan().Return(saveChan)
-			mockState.EXPECT().TryLoad().Return(state.State{V1: &state.V1{
+			mockState.EXPECT().CachedState().Return(state.State{V1: &state.V1{
 				Kustomize: test.kustomize,
 			}}, nil).Times(2)
 

--- a/pkg/lifecycle/kustomize/patch.go
+++ b/pkg/lifecycle/kustomize/patch.go
@@ -76,7 +76,7 @@ func (l *Kustomizer) generateTillerPatches(step api.Kustomize) error {
 	}
 
 	var excludedBases []string
-	state, err := l.State.TryLoad()
+	state, err := l.State.CachedState()
 	if err != nil {
 		return errors.Wrap(err, "load state")
 	}

--- a/pkg/lifecycle/kustomize/patch_test.go
+++ b/pkg/lifecycle/kustomize/patch_test.go
@@ -251,9 +251,10 @@ metadata:
 				req.NoError(err)
 			}
 
-			stateManager := state.NewManager(log.NewNopLogger(), mockFs, viper.New())
+			stateManager, err := state.NewDisposableManager(log.NewNopLogger(), mockFs, viper.New())
+			req.NoError(err)
 
-			err := stateManager.Save(state.State{V1: &state.V1{Kustomize: &state.Kustomize{}}})
+			err = stateManager.Save(state.State{V1: &state.V1{Kustomize: &state.Kustomize{}}})
 			req.NoError(err)
 
 			l := &Kustomizer{

--- a/pkg/lifecycle/message/templates.go
+++ b/pkg/lifecycle/message/templates.go
@@ -32,7 +32,12 @@ func (ctx builderContext) FuncMap() template.FuncMap {
 			debug.Log("event", "daemon.missing", "func", "ConfigOption", "requested", name)
 			return ""
 		}
-		configItemValue, ok := ctx.daemon.GetCurrentConfig()[name]
+		currentConfig, err := ctx.daemon.GetCurrentConfig()
+		if err != nil {
+			debug.Log("event", "daemon.missing", "func", "ConfigOption", "requested", name, "error", err)
+			return ""
+		}
+		configItemValue, ok := currentConfig[name]
 		if !ok {
 			debug.Log("event", "daemon.missing", "func", "ConfigOption", "requested", name)
 		}

--- a/pkg/lifecycle/render/config/daemonresolver.go
+++ b/pkg/lifecycle/render/config/daemonresolver.go
@@ -63,7 +63,7 @@ func (d *DaemonResolver) awaitConfigSaved(ctx context.Context, daemonExitedChan 
 		select {
 		case <-d.Daemon.ConfigSavedChan():
 			debug.Log("event", "config.saved")
-			return d.Daemon.GetCurrentConfig(), nil
+			return d.Daemon.GetCurrentConfig()
 		case <-time.After(10 * time.Second):
 			debug.Log("waitingFor", "config.saved")
 		case <-ctx.Done():

--- a/pkg/lifecycle/render/config/daemonresolver_test.go
+++ b/pkg/lifecycle/render/config/daemonresolver_test.go
@@ -466,13 +466,15 @@ func TestHeadlessResolver(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			req := require.New(t)
 			v := viper.New()
 
 			viper.Set("api-port", 0)
 			fs := afero.Afero{Fs: afero.NewMemMapFs()}
 			log := &logger.TestLogger{T: t}
 
-			manager := state.NewManager(log, fs, v)
+			manager, err := state.NewDisposableManager(log, fs, v)
+			req.NoError(err)
 
 			builderBuilder := templates.NewBuilderBuilder(log, v, manager)
 

--- a/pkg/lifecycle/render/helm/template.go
+++ b/pkg/lifecycle/render/helm/template.go
@@ -111,7 +111,7 @@ func (f *LocalTemplater) Template(
 		return errors.Wrapf(err, "create tmp directory in %s", constants.ShipPathInternalTmp)
 	}
 
-	state, err := f.StateManager.TryLoad()
+	state, err := f.StateManager.CachedState()
 	if err != nil {
 		debug.Log("event", "tryloadState.fail", "err", err)
 		return errors.Wrapf(err, "try load state")
@@ -425,7 +425,7 @@ func (f *LocalTemplater) writeMergedAndDefaultHelmValues(valuesPath, defaultValu
 func (f *LocalTemplater) writeStateHelmValuesTo(dest string, defaultValuesPath string) error {
 	debug := level.Debug(log.With(f.Logger, "step.type", "helmValues", "resolveHelmValues"))
 	debug.Log("event", "tryLoadState")
-	editState, err := f.StateManager.TryLoad()
+	editState, err := f.StateManager.CachedState()
 	if err != nil {
 		return errors.Wrap(err, "try load state")
 	}

--- a/pkg/lifecycle/render/helm/template_test.go
+++ b/pkg/lifecycle/render/helm/template_test.go
@@ -172,7 +172,7 @@ func TestLocalTemplater(t *testing.T) {
 			}
 
 			if test.state == nil {
-				mockState.EXPECT().TryLoad().Return(state2.State{
+				mockState.EXPECT().CachedState().Return(state2.State{
 					V1: &state2.V1{
 						HelmValues:  "we fake",
 						ReleaseName: channelName,
@@ -181,7 +181,7 @@ func TestLocalTemplater(t *testing.T) {
 			} else {
 				testState := *test.state
 				testState.V1.ReleaseName = channelName
-				mockState.EXPECT().TryLoad().Return(testState, nil)
+				mockState.EXPECT().CachedState().Return(testState, nil)
 			}
 
 			chartRoot := "/tmp/chartroot"
@@ -787,7 +787,7 @@ something: maybe
 			err := mockFs.WriteFile(tt.defaultValuesPath, []byte(tt.defaultValuesContent), 0755)
 			req.NoError(err)
 
-			mockState.EXPECT().TryLoad().Return(state2.State{V1: &state2.V1{}}, nil)
+			mockState.EXPECT().CachedState().Return(state2.State{V1: &state2.V1{}}, nil)
 			f := &LocalTemplater{
 				Logger:       &logger.TestLogger{T: t},
 				FS:           mockFs,

--- a/pkg/lifecycle/render/noconfig.go
+++ b/pkg/lifecycle/render/noconfig.go
@@ -46,12 +46,16 @@ func (r *noconfigrenderer) Execute(ctx context.Context, release *api.Release, st
 
 	r.StatusReceiver.SetProgress(ProgressRead)
 	debug.Log("event", "try.load")
-	previousState, err := r.StateManager.TryLoad()
+	previousState, err := r.StateManager.CachedState()
 	if err != nil {
 		return err
 	}
 
-	templateContext := previousState.CurrentConfig()
+	templateContext, err := previousState.CurrentConfig()
+	if err != nil {
+		return err
+	}
+
 	r.StatusReceiver.SetProgress(ProgressRender)
 
 	// this should probably happen even higher up, like to the validation stage where we assign IDs to lifecycle steps, but moving it up here for now

--- a/pkg/lifecycle/render/noconfig_test.go
+++ b/pkg/lifecycle/render/noconfig_test.go
@@ -57,7 +57,7 @@ func TestRenderNoConfig(t *testing.T) {
 			func() {
 				defer mc.Finish()
 
-				mockState.EXPECT().TryLoad().Return(state.State{V1: &state.V1{Config: test.ViperConfig}}, nil)
+				mockState.EXPECT().CachedState().Return(state.State{V1: &state.V1{Config: test.ViperConfig}}, nil)
 
 				expectedConfig := test.ViperConfig
 				if expectedConfig == nil {

--- a/pkg/lifecycle/render/render_test.go
+++ b/pkg/lifecycle/render/render_test.go
@@ -61,11 +61,13 @@ func TestRender(t *testing.T) {
 			renderer.UI = mockUI
 			renderer.ConfigResolver = configResolver
 			renderer.Planner = p
-			renderer.StateManager = &state.MManager{
-				Logger: renderer.Logger,
-				FS:     mockFS,
-				V:      viper.New(),
-			}
+
+			// this has to be the singleton state manager because ship will not always
+			// re-use renderer.StateManager
+			state, err := state.GetManager(renderer.Logger, mockFS, viper.New())
+			assert.NoError(t, err)
+
+			renderer.StateManager = state
 
 			prog := mockDaemon.EXPECT().SetProgress(ProgressRead)
 			prog = mockDaemon.EXPECT().SetProgress(ProgressRender).After(prog)

--- a/pkg/lifecycle/terraform/state.go
+++ b/pkg/lifecycle/terraform/state.go
@@ -32,7 +32,7 @@ func persistState(debug log.Logger, fs afero.Afero, statemanager state.Manager, 
 	}
 
 	debug.Log("event", "state.load", "path", statePath)
-	shipstate, err := statemanager.TryLoad()
+	shipstate, err := statemanager.CachedState()
 	if err != nil {
 		return errors.Wrapf(err, "load ship state")
 	}
@@ -54,7 +54,7 @@ func persistState(debug log.Logger, fs afero.Afero, statemanager state.Manager, 
 func restoreState(debug log.Logger, fs afero.Afero, statemanager state.Manager, dir string) error {
 
 	debug.Log("event", "state.load")
-	shipstate, err := statemanager.TryLoad()
+	shipstate, err := statemanager.CachedState()
 	if err != nil {
 		return errors.Wrapf(err, "load ship state")
 	}

--- a/pkg/lifecycle/terraform/state_test.go
+++ b/pkg/lifecycle/terraform/state_test.go
@@ -98,7 +98,7 @@ func TestPersistState(t *testing.T) {
 			err := mockFs.WriteFile("installer/terraform.tfstate", []byte(test.state), 0644)
 			req.NoError(err)
 
-			statemanager.EXPECT().TryLoad().Return(test.instate, nil)
+			statemanager.EXPECT().CachedState().Return(test.instate, nil)
 			statemanager.EXPECT().Save(&matchers.Is{
 				Test: func(v interface{}) bool {
 					vstate := v.(state.State)
@@ -192,7 +192,7 @@ func TestRestoreState(t *testing.T) {
 			mockFs := afero.Afero{Fs: afero.NewMemMapFs()}
 			statemanager := state2.NewMockManager(mc)
 
-			statemanager.EXPECT().TryLoad().Return(test.instate, nil)
+			statemanager.EXPECT().CachedState().Return(test.instate, nil)
 
 			err := restoreState(debug, mockFs, statemanager, "installer")
 			req.NoError(err)

--- a/pkg/lifecycle/terraform/when.go
+++ b/pkg/lifecycle/terraform/when.go
@@ -28,12 +28,17 @@ func evaluateWhen(when string, release api.Release, logger log.Logger, viper *vi
 
 	builderBuilder := templates.BuilderBuilder{Logger: logger, Viper: viper, Manager: manager}
 
-	configState, err := manager.TryLoad()
+	configState, err := manager.CachedState()
 	if err != nil {
 		_ = logger.Log("terraform.when.loadState", err.Error())
 	}
 
-	fullBuilder, err := builderBuilder.FullBuilder(release.Metadata, release.Spec.Config.V1, configState.CurrentConfig())
+	currentConfig, err := configState.CurrentConfig()
+	if err != nil {
+		_ = logger.Log("terraform.when.getConfig", err.Error())
+	}
+
+	fullBuilder, err := builderBuilder.FullBuilder(release.Metadata, release.Spec.Config.V1, currentConfig)
 	if err != nil {
 		_ = logger.Log("terraform.when.buildBuilder", err.Error())
 	}

--- a/pkg/lifecycle/terraform/when_test.go
+++ b/pkg/lifecycle/terraform/when_test.go
@@ -75,7 +75,8 @@ func TestEvaluateWhen(t *testing.T) {
 			fs := afero.Afero{Fs: afero.NewMemMapFs()}
 			tlogger := &logger.TestLogger{T: t}
 			tviper := viper.New()
-			stateManager := state.NewManager(tlogger, fs, tviper)
+			stateManager, err := state.NewDisposableManager(tlogger, fs, tviper)
+			req.NoError(err)
 
 			req.NoError(stateManager.Save(tt.State))
 			req.NoError(stateManager.SerializeAppMetadata(tt.release.Metadata))

--- a/pkg/lifecycle/unfork/unforker.go
+++ b/pkg/lifecycle/unfork/unforker.go
@@ -99,7 +99,7 @@ func (l *daemonunforker) awaitUnforkerSaved(ctx context.Context, daemonExitedCha
 func (l *Unforker) writeBase(step api.Unfork) error {
 	debug := level.Debug(log.With(l.Logger, "method", "writeBase"))
 
-	currentState, err := l.State.TryLoad()
+	currentState, err := l.State.CachedState()
 	if err != nil {
 		return errors.Wrap(err, "load state")
 	}

--- a/pkg/ship/dig.go
+++ b/pkg/ship/dig.go
@@ -76,7 +76,7 @@ func buildInjector(v *viper.Viper) (*dig.Container, error) {
 		daemon.NewV1Router,
 		resolve.NewRenderer,
 
-		state.NewManager,
+		state.GetManager,
 		planner.NewFactory,
 		specs.NewResolver,
 		replicatedapp.NewGraphqlClient,

--- a/pkg/ship/ship.go
+++ b/pkg/ship/ship.go
@@ -266,5 +266,8 @@ func (s *Ship) maybeWriteStateFromFile() error {
 	if err := s.FS.WriteFile(constants.StatePath, stateFile, 0644); err != nil {
 		return errors.Wrap(err, "write passed state file to constants.StatePath")
 	}
+
+	s.State.ReloadFile()
+
 	return nil
 }

--- a/pkg/ship/watch.go
+++ b/pkg/ship/watch.go
@@ -25,7 +25,7 @@ func (s *Ship) Watch(ctx context.Context) error {
 	defer s.Shutdown(cancelFunc)
 
 	for {
-		existingState, err := s.State.TryLoad()
+		existingState, err := s.State.CachedState()
 		if err != nil {
 			return errors.Wrap(err, "load state")
 		}
@@ -84,6 +84,10 @@ func (s *Ship) Watch(ctx context.Context) error {
 
 		noUpdateMsg := fmt.Sprintf("No update was found for %s", upstream)
 		s.UI.Info(noUpdateMsg)
+
+		if err := s.State.CommitState(); err != nil {
+			return errors.Wrap(err, "commit state")
+		}
 
 		if s.Viper.GetBool("exit") {
 			return nil

--- a/pkg/specs/apptype/determine_type.go
+++ b/pkg/specs/apptype/determine_type.go
@@ -113,7 +113,7 @@ func (i *inspector) DetermineApplicationType(ctx context.Context, upstream strin
 }
 
 func (i *inspector) fetchEditFiles(ctx context.Context) (app LocalAppCopy, err error) {
-	state, err := i.state.TryLoad()
+	state, err := i.state.CachedState()
 	if err != nil {
 		return nil, errors.Wrap(err, "load app state")
 	}

--- a/pkg/specs/apptype/determine_type_test.go
+++ b/pkg/specs/apptype/determine_type_test.go
@@ -69,8 +69,9 @@ func Test_inspector_fetchEditFiles(t *testing.T) {
 			vip := viper.New()
 			vip.Set("isEdit", true)
 
-			manager := state.NewManager(&tlog, fs, vip)
-			err := manager.SerializeUpstreamContents(&tt.state)
+			manager, err := state.NewDisposableManager(&tlog, fs, vip)
+			req.NoError(err)
+			err = manager.SerializeUpstreamContents(&tt.state)
 			req.NoError(err)
 
 			i := NewInspector(&tlog, fs, vip, manager, nil).(*inspector)

--- a/pkg/specs/chart.go
+++ b/pkg/specs/chart.go
@@ -273,7 +273,7 @@ func (r *Resolver) resolveMetadata(ctx context.Context, upstream, localPath stri
 
 	if r.isEdit {
 		debug.Log("event", "releaseNotes.resolve.cancel")
-		state, err := r.StateManager.TryLoad()
+		state, err := r.StateManager.CachedState()
 		if err != nil {
 			return nil, errors.Wrap(err, "load state to fetch metadata")
 		}

--- a/pkg/specs/content.go
+++ b/pkg/specs/content.go
@@ -61,9 +61,12 @@ func NewContentProcessor(v *viper.Viper) (*ContentProcessor, error) {
 	}
 	gqlClient, err := replicatedapp.NewGraphqlClient(v, http.DefaultClient)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "create gql client")
 	}
-	stateManager := state.NewManager(logger, fs, v)
+	stateManager, err := state.NewDisposableManager(logger, fs, v)
+	if err != nil {
+		return nil, errors.Wrap(err, "create state manager")
+	}
 	appTypeInspector := apptype.NewInspector(logger, fs, v, stateManager, ui)
 	return &ContentProcessor{
 		Logger:           logger,

--- a/pkg/specs/interface.go
+++ b/pkg/specs/interface.go
@@ -426,7 +426,7 @@ func (r *Resolver) resolveRelease(
 		Spec: *spec,
 	}
 
-	currentState, err := r.StateManager.TryLoad()
+	currentState, err := r.StateManager.CachedState()
 	if err != nil {
 		return nil, errors.Wrap(err, "try load")
 	}

--- a/pkg/specs/interface_test.go
+++ b/pkg/specs/interface_test.go
@@ -102,7 +102,7 @@ icon: https://kfbr.392/x5.png
 				}, "helm").After(inOrder)
 				inOrder = mockUi.EXPECT().Info("Looking for ship.yaml ...").After(inOrder)
 				inOrder = mockUi.EXPECT().Info("ship.yaml not found in upstream, generating default lifecycle for application ...").After(inOrder)
-				inOrder = mockState.EXPECT().TryLoad().Return(state2.State{}, nil).After(inOrder)
+				inOrder = mockState.EXPECT().CachedState().Return(state2.State{}, nil).After(inOrder)
 				mockState.EXPECT().SerializeReleaseName("i-know-what-the-x5-is").After(inOrder)
 
 			},
@@ -205,7 +205,7 @@ icon: https://kfbr.392/x5.png
 				inOrder = mockState.EXPECT().SerializeContentSHA("abcdef1234567890").After(inOrder)
 				inOrder = mockUi.EXPECT().Info("Looking for ship.yaml ...").After(inOrder)
 				inOrder = mockUi.EXPECT().Info("ship.yaml not found in upstream, generating default lifecycle for application ...").After(inOrder)
-				inOrder = mockState.EXPECT().TryLoad().Return(state2.State{}, nil).After(inOrder)
+				inOrder = mockState.EXPECT().CachedState().Return(state2.State{}, nil).After(inOrder)
 				mockState.EXPECT().SerializeReleaseName("ship").After(inOrder)
 			},
 			expectRelease: &api.Release{

--- a/pkg/specs/replicatedapp/resolver.go
+++ b/pkg/specs/replicatedapp/resolver.go
@@ -138,7 +138,7 @@ func (r *resolver) ResolveAppRelease(ctx context.Context, selector *Selector, ap
 }
 
 func (r *resolver) ResolveEditRelease(ctx context.Context) (*api.Release, error) {
-	stateData, err := r.StateManager.TryLoad()
+	stateData, err := r.StateManager.CachedState()
 	if err != nil {
 		return nil, errors.Wrap(err, "load state to resolve release")
 	}
@@ -352,7 +352,7 @@ func (r *resolver) loadFakeEntitlements() (*api.Entitlements, error) {
 
 // read the upstream, get the host/path, and replace the query params with the ones from the provided selector
 func (r *resolver) updateUpstream(selector Selector) error {
-	currentState, err := r.StateManager.TryLoad()
+	currentState, err := r.StateManager.CachedState()
 	if err != nil {
 		return errors.Wrap(err, "retrieve state")
 	}

--- a/pkg/specs/replicatedapp/resolver_test.go
+++ b/pkg/specs/replicatedapp/resolver_test.go
@@ -159,19 +159,20 @@ func Test_resolver_updateUpstream(t *testing.T) {
 
 			fs := afero.Afero{Fs: afero.NewMemMapFs()}
 
-			realState := state2.MManager{FS: fs, Logger: &logger.TestLogger{T: t}, V: viper.New()}
+			realState, err := state2.NewDisposableManager(&logger.TestLogger{T: t}, fs, viper.New())
+			req.NoError(err)
 
 			resolver := &resolver{
 				Logger:       &logger.TestLogger{T: t},
-				StateManager: &realState,
+				StateManager: realState,
 			}
 
 			req.NoError(realState.SerializeUpstream(tt.initUpstream))
 
-			err := resolver.updateUpstream(tt.selector)
+			err = resolver.updateUpstream(tt.selector)
 			req.NoError(err)
 
-			afterState, err := realState.TryLoad()
+			afterState, err := realState.CachedState()
 			req.NoError(err)
 
 			req.Equal(tt.expectUpstream, afterState.Upstream())

--- a/pkg/state/state_secret.go
+++ b/pkg/state/state_secret.go
@@ -110,3 +110,7 @@ func (s *secretSerializer) Save(state State) error {
 
 	return nil
 }
+
+func (s *secretSerializer) Remove() error {
+	return errors.New("secret based state storage does not support state removal")
+}

--- a/pkg/state/state_url.go
+++ b/pkg/state/state_url.go
@@ -75,3 +75,7 @@ func (s *urlSerializer) Save(state State) error {
 
 	return nil
 }
+
+func (s *urlSerializer) Remove() error {
+	return errors.New("URL based state storage does not support state removal")
+}

--- a/pkg/templates/ship_context.go
+++ b/pkg/templates/ship_context.go
@@ -87,7 +87,7 @@ func AddAzureAKSPath(name string, path string) {
 func (ctx ShipContext) makeCaKey(caName string, caType string) string {
 	// check if the CA exists - if it does, use the existing one
 	// if it does not, make a new one
-	currentState, err := ctx.Manager.TryLoad()
+	currentState, err := ctx.Manager.CachedState()
 	if err != nil {
 		ctx.Logger.Log("method", "makeCaKey", "action", "tryLoad", "error", err)
 		return ""
@@ -115,7 +115,7 @@ func (ctx ShipContext) makeCaKey(caName string, caType string) string {
 }
 
 func (ctx ShipContext) getCaCert(caName string) string {
-	currentState, err := ctx.Manager.TryLoad()
+	currentState, err := ctx.Manager.CachedState()
 	if err != nil {
 		ctx.Logger.Log("method", "getCaCert", "action", "tryLoad", "error", err)
 		return ""
@@ -135,7 +135,7 @@ func (ctx ShipContext) getCaCert(caName string) string {
 // P256, P384, or P521.
 func (ctx ShipContext) makeCertKey(certName string, caName string, hosts string, certType string) string {
 	// try to find existing cert to use
-	currentState, err := ctx.Manager.TryLoad()
+	currentState, err := ctx.Manager.CachedState()
 	if err != nil {
 		ctx.Logger.Log("method", "makeCertKey", "action", "tryLoad", "error", err)
 		return ""
@@ -177,7 +177,7 @@ func (ctx ShipContext) makeCertKey(certName string, caName string, hosts string,
 }
 
 func (ctx ShipContext) getCert(certName string) string {
-	currentState, err := ctx.Manager.TryLoad()
+	currentState, err := ctx.Manager.CachedState()
 	if err != nil {
 		ctx.Logger.Log("method", "getCert", "action", "tryLoad", "error", err)
 		return ""

--- a/pkg/templates/ship_context_test.go
+++ b/pkg/templates/ship_context_test.go
@@ -15,23 +15,21 @@ import (
 )
 
 func makeTestShipCtx(t *testing.T) ShipContext {
+	req := require.New(t)
+
 	testLogger := logger.TestLogger{T: t}
 	testViper := viper.New()
 
 	mmFs := afero.NewMemMapFs()
 	mmAfero := afero.Afero{Fs: mmFs}
 
-	testManager := state.NewManager(
-		&testLogger,
-		mmAfero,
-		testViper,
-	)
+	testManager, err := state.NewDisposableManager(&testLogger, mmAfero, testViper)
+	req.NoError(err)
 
 	return ShipContext{
 		Logger:  &testLogger,
 		Manager: testManager,
 	}
-
 }
 
 // tests that generated CAs can be referenced again + that more than one CA can be generated

--- a/pkg/test-mocks/daemon/daemon.go
+++ b/pkg/test-mocks/daemon/daemon.go
@@ -103,10 +103,11 @@ func (mr *MockDaemonMockRecorder) EnsureStarted(arg0, arg1 interface{}) *gomock.
 }
 
 // GetCurrentConfig mocks base method
-func (m *MockDaemon) GetCurrentConfig() map[string]interface{} {
+func (m *MockDaemon) GetCurrentConfig() (map[string]interface{}, error) {
 	ret := m.ctrl.Call(m, "GetCurrentConfig")
 	ret0, _ := ret[0].(map[string]interface{})
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetCurrentConfig indicates an expected call of GetCurrentConfig

--- a/pkg/test-mocks/state/manager_mock.go
+++ b/pkg/test-mocks/state/manager_mock.go
@@ -36,6 +36,11 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 	return m.recorder
 }
 
+// WithEmptyState a mock with an empty state
+func (m *MockManager) WithEmptyState(ctrl *gomock.Controller) *MockManager {
+	return m
+}
+
 // AddCA mocks base method
 func (m *MockManager) AddCA(arg0 string, arg1 util.CAType) error {
 	ret := m.ctrl.Call(m, "AddCA", arg0, arg1)
@@ -229,17 +234,41 @@ func (mr *MockManagerMockRecorder) StateUpdate(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateUpdate", reflect.TypeOf((*MockManager)(nil).StateUpdate), arg0)
 }
 
-// TryLoad mocks base method
-func (m *MockManager) TryLoad() (state.State, error) {
-	ret := m.ctrl.Call(m, "TryLoad")
+// CachedState mocks base method
+func (m *MockManager) CachedState() (state.State, error) {
+	ret := m.ctrl.Call(m, "CachedState")
 	ret0, _ := ret[0].(state.State)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// TryLoad indicates an expected call of TryLoad
-func (mr *MockManagerMockRecorder) TryLoad() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TryLoad", reflect.TypeOf((*MockManager)(nil).TryLoad))
+// CachedState indicates an expected call of CachedState
+func (mr *MockManagerMockRecorder) CachedState() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CachedState", reflect.TypeOf((*MockManager)(nil).CachedState))
+}
+
+// CommitState mocks base method
+func (m *MockManager) CommitState() error {
+	ret := m.ctrl.Call(m, "CommitState")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CommitState indicates an expected call of CommitState
+func (mr *MockManagerMockRecorder) CommitState() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitState", reflect.TypeOf((*MockManager)(nil).CommitState))
+}
+
+// ReloadFile mocks base method
+func (m *MockManager) ReloadFile() error {
+	ret := m.ctrl.Call(m, "ReloadFile")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReloadFile indicates an expected call of CommitState
+func (mr *MockManagerMockRecorder) ReloadFile() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReloadFile", reflect.TypeOf((*MockManager)(nil).ReloadFile))
 }
 
 // UpdateVersion mocks base method


### PR DESCRIPTION
<!--

  Hello Friend! Thank you for contributing to Ship!

  If you worked on the front end (i.e React component side)...
  Did you bump the version number in package.json?

  Thanks again! You are awesome!
-->
What I Did
------------
Improved performance when using HTTP-based backend for state storage.

How I Did it
------------
State is now loaded and persisted once when using secret and URL-based backends.  File based storage is still updated continuously.  State is now served from an in-memory cache, and state manager is now implemented as a singleton.


How to verify it
------------
Run ship init and ship update.


Description for the Changelog
------------
Improved performance for HTTP-based state storage.


Picture of a Ship (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

