### PR TITLE
Dont write intermediate state

### DIFF
--- a/integration/base/amazon-eks/expected/.ship/state.json
+++ b/integration/base/amazon-eks/expected/.ship/state.json
@@ -1,7 +1,7 @@
 {
   "v1": {
     "config": {},
-    "contentSHA": "7c1c9d536fd96ffe4f5de5a75014bac39c6c36d618813d9f14f539805c726352",
+    "contentSHA": "527545696c450ec581798c1601038d2d2e6bd908fee62565fc83b804dc60826a",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/basic-stateless/expected/.ship/state.json
+++ b/integration/base/basic-stateless/expected/.ship/state.json
@@ -1,7 +1,7 @@
 {
   "v1": {
     "config": {},
-    "contentSHA": "49e1c9f9fa33aaa5bfe04f7c1add52397f649b8d96842b8834a939db883438ca",
+    "contentSHA": "6b1f9bdfd91e63e1d9edb8b4c0cf755cd04e9c3d740614a8bbb63f73b2368c48",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/basic/expected/.ship/state.json
+++ b/integration/base/basic/expected/.ship/state.json
@@ -3,7 +3,7 @@
     "config": {
       "test_option": "abc123_test-option-value"
     },
-    "contentSHA": "49e1c9f9fa33aaa5bfe04f7c1add52397f649b8d96842b8834a939db883438ca",
+    "contentSHA": "6b1f9bdfd91e63e1d9edb8b4c0cf755cd04e9c3d740614a8bbb63f73b2368c48",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/config-chain-override/expected/.ship/state.json
+++ b/integration/base/config-chain-override/expected/.ship/state.json
@@ -5,7 +5,7 @@
       "t2_option": "abc123_abc123",
       "t3_option": "abc123_abc123 + abc123"
     },
-    "contentSHA": "a24b2f2247cdd061c97f64753deea506f57df4c950043630a27eedd7b8a29770",
+    "contentSHA": "7c1aefcd8b8db99572df196fb9d9fde61040a8c9bc4c2c89c479d62e9c243b6d",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/config-chain/expected/.ship/state.json
+++ b/integration/base/config-chain/expected/.ship/state.json
@@ -5,7 +5,7 @@
       "t2_option": "abc123_abc123",
       "t3_option": "abc123_abc123 + abc123"
     },
-    "contentSHA": "a24b2f2247cdd061c97f64753deea506f57df4c950043630a27eedd7b8a29770",
+    "contentSHA": "7c1aefcd8b8db99572df196fb9d9fde61040a8c9bc4c2c89c479d62e9c243b6d",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/default-values/expected/.ship/state.json
+++ b/integration/base/default-values/expected/.ship/state.json
@@ -6,7 +6,7 @@
       "namespace": "Alpha",
       "scheduler": ""
     },
-    "contentSHA": "d182801c311b0c937b7027f9b6a71704973e6bf97f9f466473aeaca804edd010",
+    "contentSHA": "fa5030e0eac3e253027361298a9194be4a5e39b41de1f4ad5dea10ea6e20edc9",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/docker-layer/expected/.ship/state.json
+++ b/integration/base/docker-layer/expected/.ship/state.json
@@ -3,7 +3,7 @@
     "config": {
       "option": "value"
     },
-    "contentSHA": "199522eb20f835e7060c9c20409daf18dc8169f118f6738bee4ae05ee1b4cde2",
+    "contentSHA": "ccb1b8618602955229ce735a838dcca657453afc4684d00f00fd7a16d67aa5a9",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/docker/expected/.ship/state.json
+++ b/integration/base/docker/expected/.ship/state.json
@@ -3,7 +3,7 @@
     "config": {
       "test_option": "abc123_test-option-value"
     },
-    "contentSHA": "2838f12b0f9649afa3f10d5047e32fd532c7d2b15ae4ec2543b756bd2eb13b3f",
+    "contentSHA": "db472b85ff0e9092e8a0e8d9f99426a16dd01914c6dc57d1aa3468b384efdfd7",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/helm-nginx/expected/.ship/state.json
+++ b/integration/base/helm-nginx/expected/.ship/state.json
@@ -1,7 +1,7 @@
 {
   "v1": {
     "config": {},
-    "contentSHA": "d0a5407090d68a8cfbd220f94e2ea5c9f64ee5133d5c6016777854821c47f4b4",
+    "contentSHA": "aba681edb8abd09e6bf579c6b7067ad497400f9df083c47bc40031ab6d8d5e22",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/web/expected/.ship/state.json
+++ b/integration/base/web/expected/.ship/state.json
@@ -4,7 +4,7 @@
       "methodType": "GET",
       "resourceURL": "https://raw.githubusercontent.com/replicatedhq/test-charts/5bf016aac1786cb74c678c3419bb8623f0388f8d/web-asset/web-asset"
     },
-    "contentSHA": "cd26c8e85fda23582ba8a3a067d1c7f76dfa421422d8a742064d6467ad6dda38",
+    "contentSHA": "758973a817c37127f2ad68fe01a25a377a294a68b73ff7f5a367f7a03ba30bfc",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/init/skipped-terraform/expected/.ship/state.json
+++ b/integration/init/skipped-terraform/expected/.ship/state.json
@@ -1,8 +1,6 @@
 {
   "v1": {
-    "config": {
-      "id_length": "8"
-    },
+    "config": {},
     "releaseName": "ship",
     "upstream": "__upstream__",
     "upstreamContents": {

--- a/integration/init_app/amazon-eks-template/expected/.ship/state.json
+++ b/integration/init_app/amazon-eks-template/expected/.ship/state.json
@@ -2,7 +2,7 @@
   "v1": {
     "config": {},
     "upstream": "__upstream__",
-    "contentSHA": "242b9d4a6c479e4c864f24d8e9bc0420e471c9e48fed0b89eec0260f3fbc7f0e",
+    "contentSHA": "a682a4883b682d147acbdd00e90e058574ee8abb611c461fde9ab9241899feeb",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "__customerID__",

--- a/integration/init_app/basic/expected/.ship/state.json
+++ b/integration/init_app/basic/expected/.ship/state.json
@@ -2,7 +2,7 @@
   "v1": {
     "config": {},
     "upstream": "__upstream__",
-    "contentSHA": "9728a969294231e722662390ed73a8573a1af59f7a50bce21a8373612b69635e",
+    "contentSHA": "37cbc1ee09877a15e0546122aef478713fbbc687d46b0fde0177928e2f4337d5",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "__customerID__",

--- a/integration/init_app/docker-asset-slug/expected/.ship/state.json
+++ b/integration/init_app/docker-asset-slug/expected/.ship/state.json
@@ -18,7 +18,7 @@
       "sequence": 0,
       "version": "0.0.1"
     },
-    "contentSHA": "7694cf3b21c6fa8eb6ed0c92d9452096ddcd7e457fb2d728e5636eff2f5d2e10",
+    "contentSHA": "301ee57127cff107fdbac348de7bd64ccc0bf44e0f866f5f4ada2800f60387ce",
     "upstreamContents": {
       "appRelease": {
         "id": "oVSYJqtZnSew_8A3fFuwz0WPwn40zjn6",

--- a/integration/init_app/docker-asset/expected/.ship/state.json
+++ b/integration/init_app/docker-asset/expected/.ship/state.json
@@ -18,7 +18,7 @@
       "sequence": 0,
       "version": "1.0.0-SNAPSHOT"
     },
-    "contentSHA": "55882cb70d6c27e8290668d1930b2a062570ac0fa8c459be94b6921c9ce7976f",
+    "contentSHA": "efe591f39f16444b5dd815d485f7ccf80d213f1678cd737a4c37eab1668d9c98",
     "upstreamContents": {
       "appRelease": {
         "id": "jDtI-DiraCbkN5euJHmbS3kIFw4N1Iw9",

--- a/integration/init_app/github-template-func/expected/.ship/state.json
+++ b/integration/init_app/github-template-func/expected/.ship/state.json
@@ -4,7 +4,7 @@
       "option": "abc123"
     },
     "upstream": "__upstream__",
-    "contentSHA": "6327e26ed6f0c8c7f693b3343d51f013048e4b5a87cf24f004e81dc7a8d8fd69",
+    "contentSHA": "3df92698e596a2920fb4d437a4155052544142e0a247813d092aa32b5e921aff",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "__customerID__",

--- a/integration/init_app/helm-github/expected/.ship/state.json
+++ b/integration/init_app/helm-github/expected/.ship/state.json
@@ -1,6 +1,7 @@
 {
   "v1": {
     "config": {},
+    "contentSHA": "8ac80c107e69986c9dd4ca9f7eec75790a2582bd14f2fc67d516837636694fdf",
     "releaseName": "integration-replicated-app-helm-github",
     "upstream": "__upstream__",
     "metadata": {
@@ -244,7 +245,6 @@
         "created": "Wed Dec 12 2018 22:03:17 GMT+0000 (UTC)",
         "entitlements": {}
       }
-    },
-    "contentSHA": "687a05a7437c94d295cab91b748304d97ebb19e398cfed034e1659d81d852876"
+    }
   }
 }

--- a/integration/init_app/installation-template-func/expected/.ship/state.json
+++ b/integration/init_app/installation-template-func/expected/.ship/state.json
@@ -2,7 +2,7 @@
   "v1": {
     "config": {},
     "upstream": "__upstream__",
-    "contentSHA": "ac7606f1553dd7bcf0a47631cd673726c550f49754d631f079a868a51204d9bd",
+    "contentSHA": "43b66ada3c5e0b44840a9a2fda7633a7253b19856d98a6fea578ea1e01960268",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "__customerID__",

--- a/integration/init_app/integration_test.go
+++ b/integration/init_app/integration_test.go
@@ -149,6 +149,8 @@ var _ = Describe("ship init replicated.app/...", func() {
 						".ship/state.json": {
 							"v1.upstreamContents.appRelease.entitlements",
 							"v1.upstreamContents.appRelease.registrySecret",
+							"v1.upstreamContents.appRelease.analyzeSpec",
+							"v1.upstreamContents.appRelease.collectSpec",
 							"v1.shipVersion",
 						},
 					}
@@ -248,6 +250,8 @@ var _ = Describe("ship init replicated.app/...", func() {
 						".ship/state.json": {
 							"v1.upstreamContents.appRelease.entitlements",
 							"v1.upstreamContents.appRelease.registrySecret",
+							"v1.upstreamContents.appRelease.analyzeSpec",
+							"v1.upstreamContents.appRelease.collectSpec",
 							"v1.shipVersion",
 						},
 					}

--- a/integration/update/app_basic/expected/.ship/state.json
+++ b/integration/update/app_basic/expected/.ship/state.json
@@ -2,7 +2,7 @@
   "v1": {
     "config": {},
     "upstream": "staging.replicated.app/some-cool-ci-tool?installation_id=3Z6uuPbVz6jTxRuXHn_l6UlYQz3hWz6-&customer_id=-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
-    "contentSHA": "9728a969294231e722662390ed73a8573a1af59f7a50bce21a8373612b69635e",
+    "contentSHA": "37cbc1ee09877a15e0546122aef478713fbbc687d46b0fde0177928e2f4337d5",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/update/integration_test.go
+++ b/integration/update/integration_test.go
@@ -117,6 +117,8 @@ var _ = Describe("ship update", func() {
 						".ship/state.json": {
 							"v1.upstreamContents.appRelease.entitlements",
 							"v1.upstreamContents.appRelease.registrySecret",
+							"v1.upstreamContents.appRelease.analyzeSpec",
+							"v1.upstreamContents.appRelease.collectSpec",
 							"v1.shipVersion",
 						},
 					}

--- a/pkg/lifecycle/daemon/headless/daemon.go
+++ b/pkg/lifecycle/daemon/headless/daemon.go
@@ -198,11 +198,6 @@ func (d *HeadlessDaemon) HeadlessResolve(ctx context.Context, release *api.Relea
 	}
 
 	d.ResolvedConfig = templateContext
-	if err := d.StateManager.SerializeConfig(nil, api.ReleaseMetadata{}, templateContext); err != nil {
-		warn.Log("msg", "serialize state failed", "err", err)
-		return err
-	}
-
 	return nil
 }
 

--- a/pkg/lifecycle/daemon/headless/daemon_test.go
+++ b/pkg/lifecycle/daemon/headless/daemon_test.go
@@ -2,7 +2,6 @@ package headless
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/mitchellh/cli"
@@ -19,11 +18,11 @@ import (
 )
 
 type TestHeadless struct {
-	Name          string
-	State         []byte
-	Release       *api.Release
-	ExpectedValue []byte
-	ExpectedError bool
+	Name           string
+	State          []byte
+	Release        *api.Release
+	ExpectedConfig map[string]interface{}
+	ExpectedError  bool
 }
 
 func TestHeadlessDaemon(t *testing.T) {
@@ -39,8 +38,8 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{}}}`),
-			ExpectedError: false,
+			ExpectedConfig: map[string]interface{}{},
+			ExpectedError:  false,
 		},
 		{
 			Name:  "one group one item, not required, no value",
@@ -63,8 +62,8 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":""}}}`),
-			ExpectedError: false,
+			ExpectedConfig: map[string]interface{}{"alpha": ""},
+			ExpectedError:  false,
 		},
 		{
 			Name:  "one group one item, required, no value",
@@ -87,8 +86,8 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{}}}`),
-			ExpectedError: true,
+			ExpectedConfig: map[string]interface{}{},
+			ExpectedError:  true,
 		},
 		{
 			Name:  "one group one item, required, value, hidden",
@@ -111,8 +110,8 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"100"}}}`),
-			ExpectedError: false,
+			ExpectedConfig: map[string]interface{}{"alpha": "100"},
+			ExpectedError:  false,
 		},
 		{
 			Name:  "one group one item, not required, no value, hidden",
@@ -135,8 +134,8 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"100"}}}`),
-			ExpectedError: false,
+			ExpectedConfig: map[string]interface{}{"alpha": "100"},
+			ExpectedError:  false,
 		},
 		{
 			Name:  "one group one item, required, no value, hidden",
@@ -159,8 +158,8 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":""}}}`),
-			ExpectedError: false,
+			ExpectedConfig: map[string]interface{}{"alpha": ""},
+			ExpectedError:  false,
 		},
 		{
 			Name:  "one group one item, required, no value, not hidden",
@@ -183,8 +182,8 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":""}}}`),
-			ExpectedError: false,
+			ExpectedConfig: map[string]interface{}{"alpha": ""},
+			ExpectedError:  false,
 		},
 		{
 			Name:  "one group one item, required, value, not hidden",
@@ -207,8 +206,8 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"100"}}}`),
-			ExpectedError: false,
+			ExpectedConfig: map[string]interface{}{"alpha": "100"},
+			ExpectedError:  false,
 		},
 		{
 			Name:  "one group one item, not required, no value, not hidden",
@@ -231,8 +230,8 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":""}}}`),
-			ExpectedError: false,
+			ExpectedConfig: map[string]interface{}{"alpha": ""},
+			ExpectedError:  false,
 		},
 		{
 			Name:  "one group one item, required, value, hidden",
@@ -255,8 +254,8 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"100"}}}`),
-			ExpectedError: false,
+			ExpectedConfig: map[string]interface{}{"alpha": "100"},
+			ExpectedError:  false,
 		},
 		{
 			Name:  "one group two items, neither required, neither present",
@@ -286,8 +285,8 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"","beta":""}}}`),
-			ExpectedError: false,
+			ExpectedConfig: map[string]interface{}{"alpha": "", "beta": ""},
+			ExpectedError:  false,
 		},
 		{
 			Name:  "one group two items, both required, neither present",
@@ -317,8 +316,8 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{}}}`),
-			ExpectedError: true,
+			ExpectedConfig: map[string]interface{}{"alpha": "", "beta": ""},
+			ExpectedError:  true,
 		},
 		{
 			Name:  "one group two items, both required, one present",
@@ -348,8 +347,8 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"","beta":""}}}`),
-			ExpectedError: true,
+			ExpectedConfig: map[string]interface{}{"alpha": "", "beta": ""},
+			ExpectedError:  true,
 		},
 		{
 			Name:  "one group two items, both required, both present",
@@ -379,8 +378,8 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"100","beta":"200"}}}`),
-			ExpectedError: false,
+			ExpectedConfig: map[string]interface{}{"alpha": "100", "beta": "200"},
+			ExpectedError:  false,
 		},
 		{
 			Name:  "beta value resolves to alpha value",
@@ -410,8 +409,8 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"101","beta":"101"}}}`),
-			ExpectedError: false,
+			ExpectedConfig: map[string]interface{}{"alpha": "101", "beta": "101"},
+			ExpectedError:  false,
 		},
 		{
 			Name:  "beta value resolves to alpha value when wrong beta value is presented",
@@ -441,8 +440,8 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"101","beta":"101"}}}`),
-			ExpectedError: false,
+			ExpectedConfig: map[string]interface{}{"alpha": "101", "beta": "101"},
+			ExpectedError:  false,
 		},
 		{
 			Name:  "charlie value resolves to beta value resolves to alpha value",
@@ -479,8 +478,8 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"100","beta":"100","charlie":"100"}}}`),
-			ExpectedError: false,
+			ExpectedConfig: map[string]interface{}{"alpha": "100", "beta": "100", "charlie": "100"},
+			ExpectedError:  false,
 		},
 		{
 			Name:  "multiple groups with multiple items",
@@ -552,8 +551,39 @@ func TestHeadlessDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedValue: []byte(`{"v1":{"config":{"alpha":"100","beta":"100","charlie":"100"}}}`),
-			ExpectedError: true,
+			ExpectedConfig: map[string]interface{}{"alpha": "100", "beta": "100", "charlie": "100"},
+			ExpectedError:  true,
+		},
+		{
+			Name:  "beta value resolves to alpha default",
+			State: []byte(`{"v1":{"config":{}}}`),
+			Release: &api.Release{
+				Spec: api.Spec{
+					Config: api.Config{
+						V1: []libyaml.ConfigGroup{{
+							Name: "testing",
+							Items: []*libyaml.ConfigItem{
+								{
+									Name:     "alpha",
+									Value:    "",
+									Default:  "100",
+									Required: false,
+									Hidden:   false,
+								},
+								{
+									Name:     "beta",
+									Value:    `{{repl ConfigOption "alpha" }}`,
+									Default:  "",
+									Required: false,
+									ReadOnly: true,
+								},
+							},
+						}},
+					},
+				},
+			},
+			ExpectedConfig: map[string]interface{}{"alpha": "100", "beta": "100"},
+			ExpectedError:  false,
 		},
 	}
 
@@ -599,16 +629,15 @@ func TestHeadlessDaemon(t *testing.T) {
 			if test.ExpectedError {
 				req.Error(err)
 			} else {
-				updatedState, err := fakeFS.ReadFile(constants.StatePath)
-				req.NoError(err)
+				resolvedConfig := daemon.ResolvedConfig
 
-				var obj interface{}
-				err = json.Unmarshal(test.ExpectedValue, &obj)
-				req.NoError(err)
-				pretty, err := json.MarshalIndent(obj, "", "  ")
-				req.NoError(err)
-				req.Equal(pretty, updatedState)
+				req.Equal(test.ExpectedConfig, resolvedConfig)
 			}
+
+			updatedState, err := fakeFS.ReadFile(constants.StatePath)
+			req.NoError(err)
+
+			req.Equal(test.State, updatedState)
 		})
 	}
 }


### PR DESCRIPTION
What I Did
------------
The config render process no longer writes intermediate values to the state file. This prevents default values from being included in the state.

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Ship (not required but encouraged)
------------


![USS Essex (CV-9)](https://upload.wikimedia.org/wikipedia/commons/a/a8/USS_Essex_%28CV-9%29_in_Hampton_Roads_on_1_February_1943_%28NNAM.1996.488.242.078%29.jpg "USS Essex (CV-9)")









<!-- (thanks https://github.com/docker/docker for this template) -->

