### PR TITLE
fix reincluding removed kubernetes resources

### DIFF
--- a/pkg/util/exclude_kubernetes_test.go
+++ b/pkg/util/exclude_kubernetes_test.go
@@ -27,7 +27,7 @@ func TestExcludeKubernetesResource(t *testing.T) {
 		{
 			name:             "existsInBase",
 			basePath:         "base",
-			excludedResource: "myresource.yaml",
+			excludedResource: "/myresource.yaml",
 			wantErr:          false,
 			inputFiles: []fileStruct{
 				{
@@ -114,7 +114,7 @@ resources:
 		{
 			name:             "exists in child base",
 			basePath:         "base",
-			excludedResource: "another-base/anotherresource.yaml",
+			excludedResource: "/another-base/anotherresource.yaml",
 			wantErr:          false,
 			inputFiles: []fileStruct{
 				{
@@ -252,7 +252,254 @@ resources:
 
 				req.Equal(outFile.data, string(fileBytes), "compare file %s", outFile.name)
 			}
+		})
+	}
+}
 
+func TestUnExcludeKubernetesResource(t *testing.T) {
+	type fileStruct struct {
+		name string
+		data string
+	}
+
+	tests := []struct {
+		name             string
+		basePath         string
+		excludedResource string
+		wantErr          bool
+		outputFiles      []fileStruct
+		inputFiles       []fileStruct
+	}{
+		{
+			name:             "existsInBase",
+			basePath:         "base",
+			excludedResource: "/myresource.yaml",
+			wantErr:          false,
+			inputFiles: []fileStruct{
+				{
+					name: "base/kustomization.yaml",
+					data: `kind: ""
+apiversion: ""
+resources:
+- notmyresource.yaml
+`,
+				},
+				{
+					name: "base/myresource.yaml",
+					data: `#unused`,
+				},
+				{
+					name: "base/notmyresource.yaml",
+					data: `#unused`,
+				},
+			},
+			outputFiles: []fileStruct{
+				{
+					name: "base/kustomization.yaml",
+					data: `kind: ""
+apiversion: ""
+resources:
+- notmyresource.yaml
+- myresource.yaml
+`,
+				},
+				{
+					name: "base/myresource.yaml",
+					data: `#unused`,
+				},
+				{
+					name: "base/notmyresource.yaml",
+					data: `#unused`,
+				},
+			},
+		},
+		{
+			name:             "does not exist",
+			basePath:         "base",
+			excludedResource: "notexist-resource.yaml",
+			wantErr:          true,
+			inputFiles: []fileStruct{
+				{
+					name: "base/kustomization.yaml",
+					data: `kind: ""
+apiversion: ""
+resources:
+- myresource.yaml
+- notmyresource.yaml
+`,
+				},
+				{
+					name: "base/myresource.yaml",
+					data: `#unused`,
+				},
+				{
+					name: "base/notmyresource.yaml",
+					data: `#unused`,
+				},
+			},
+			outputFiles: []fileStruct{
+				{
+					name: "base/kustomization.yaml",
+					data: `kind: ""
+apiversion: ""
+resources:
+- myresource.yaml
+- notmyresource.yaml
+`,
+				},
+				{
+					name: "base/myresource.yaml",
+					data: `#unused`,
+				},
+				{
+					name: "base/notmyresource.yaml",
+					data: `#unused`,
+				},
+			},
+		},
+		{
+			name:             "exists in child base",
+			basePath:         "base",
+			excludedResource: "/another-base/anotherresource.yaml",
+			wantErr:          false,
+			inputFiles: []fileStruct{
+				{
+					name: "base/kustomization.yaml",
+					data: `kind: ""
+apiversion: ""
+bases:
+- ../another/base
+resources:
+- myresource.yaml
+`,
+				},
+				{
+					name: "base/myresource.yaml",
+					data: `#unused`,
+				},
+				{
+					name: "another/base/kustomization.yaml",
+					data: `kind: ""
+apiversion: ""
+`,
+				},
+				{
+					name: "another/base/anotherresource.yaml",
+					data: `#unused`,
+				},
+			},
+			outputFiles: []fileStruct{
+				{
+					name: "base/kustomization.yaml",
+					data: `kind: ""
+apiversion: ""
+bases:
+- ../another/base
+resources:
+- myresource.yaml
+`,
+				},
+				{
+					name: "base/myresource.yaml",
+					data: `#unused`,
+				},
+				{
+					name: "another/base/kustomization.yaml",
+					data: `kind: ""
+apiversion: ""
+resources:
+- anotherresource.yaml
+`,
+				},
+				{
+					name: "another/base/anotherresource.yaml",
+					data: `#unused`,
+				},
+			},
+		},
+		{
+			name:             "already included",
+			basePath:         "base",
+			excludedResource: "myresource.yaml",
+			wantErr:          false,
+			inputFiles: []fileStruct{
+				{
+					name: "base/kustomization.yaml",
+					data: `kind: ""
+apiversion: ""
+resources:
+- myresource.yaml
+- notmyresource.yaml
+`,
+				},
+				{
+					name: "base/myresource.yaml",
+					data: `#unused`,
+				},
+				{
+					name: "base/notmyresource.yaml",
+					data: `#unused`,
+				},
+			},
+			outputFiles: []fileStruct{
+				{
+					name: "base/kustomization.yaml",
+					data: `kind: ""
+apiversion: ""
+resources:
+- myresource.yaml
+- notmyresource.yaml
+`,
+				},
+				{
+					name: "base/myresource.yaml",
+					data: `#unused`,
+				},
+				{
+					name: "base/notmyresource.yaml",
+					data: `#unused`,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			// setup input FS
+			mockFs := afero.Afero{Fs: afero.NewMemMapFs()}
+			for _, inFile := range tt.inputFiles {
+				req.NoError(mockFs.MkdirAll(filepath.Dir(inFile.name), os.FileMode(0644)))
+				req.NoError(mockFs.WriteFile(inFile.name, []byte(inFile.data), os.FileMode(0644)))
+			}
+
+			// run unexclude function
+			if err := UnExcludeKubernetesResource(mockFs, tt.basePath, tt.excludedResource); (err != nil) != tt.wantErr {
+				t.Errorf("UnExcludeKubernetesResource() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// compare output FS - contents should match originals
+			var expectedFileNames, actualFileNames []string
+			for _, expectedFile := range tt.outputFiles {
+				expectedFileNames = append(expectedFileNames, expectedFile.name)
+			}
+			err := mockFs.Walk("", func(path string, info os.FileInfo, err error) error {
+				if !info.IsDir() {
+					actualFileNames = append(actualFileNames, path)
+					fmt.Println(path)
+				}
+				return nil
+			})
+			req.NoError(err, "read output /")
+
+			req.ElementsMatch(expectedFileNames, actualFileNames, "comparing expected and actual output files, expected %+v got %+v", expectedFileNames, actualFileNames)
+
+			for _, outFile := range tt.outputFiles {
+				fileBytes, err := mockFs.ReadFile(outFile.name)
+				req.NoError(err, "reading output file %s", outFile.name)
+
+				req.Equal(outFile.data, string(fileBytes), "compare file %s", outFile.name)
+			}
 		})
 	}
 }


### PR DESCRIPTION
What I Did
------------
When reincluding previously removed kubernetes resources, those resources will be added as kustomize resources to the appropriate bases.

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------
Fix reincluding previously removed kubernetes resources.


Picture of a Ship (not required but encouraged)
------------

![USS Yorktown (CV-10)](https://upload.wikimedia.org/wikipedia/commons/e/e4/USS_Yorktown_%28CVS-10%29_at_sea_off_Hawaii%2C_circa_in_1962_%28NH_97458-KN%29.jpg "USS Yorktown (CV-10)")










<!-- (thanks https://github.com/docker/docker for this template) -->

