### PR TITLE
do not use goreleaser to deploy homebrew formulae

### DIFF
--- a/deploy/.goreleaser.unstable.yml
+++ b/deploy/.goreleaser.unstable.yml
@@ -3,15 +3,6 @@ release:
   github:
     owner: replicatedhq
     name: ship
-brew:
-  github:
-    owner: replicatedhq
-    name: homebrew-ship
-  folder: Formula
-  homepage: https://ship.replicated.com/
-  description: Deploy 3rd party applications through modern pipelines
-  test: |
-    system "#{bin}/ship", "version"
 builds:
 - goos:
   - linux

--- a/deploy/.goreleaser.yml
+++ b/deploy/.goreleaser.yml
@@ -3,15 +3,6 @@ release:
   github:
     owner: replicatedhq
     name: ship
-brew:
-  github:
-    owner: replicatedhq
-    name: homebrew-ship
-  folder: Formula
-  homepage: https://ship.replicated.com/
-  description: Deploy 3rd party applications through modern pipelines
-  test: |
-    system "#{bin}/ship", "version"
 builds:
 - goos:
   - linux


### PR DESCRIPTION
What I Did
------------
Simplified the goreleaser config by no longer including an automatic homebrew release, since this is not used for the official formula anyways.

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Ship (not required but encouraged)
------------



![USS Intrepid (CV-11)](https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/USS_Intrepid_%28CV-11%29_operating_in_the_Philippine_Sea_in_November_1944_%28NH_97468%29.jpg/1280px-USS_Intrepid_%28CV-11%29_operating_in_the_Philippine_Sea_in_November_1944_%28NH_97468%29.jpg "USS Intrepid (CV-11)")








<!-- (thanks https://github.com/docker/docker for this template) -->

