### PR TITLE
add some basic retry logic to the e2e_init CI step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,31 @@ jobs:
           at: ~/
       - run:
           name: Run Tests
-          command: make cypress_base
+          # https://unix.stackexchange.com/a/137639
+          command: |
+            function fail {
+              echo $1 >&2
+              exit 1
+            }
+
+            function retry {
+              local n=1
+              local max=5
+              local delay=5
+              while true; do
+                "$@" && break || {
+                  if [[ $n -lt $max ]]; then
+                    ((n++))
+                    echo "Command failed. Attempt $n/$max:"
+                    sleep $delay;
+                  else
+                    fail "The command has failed after $n attempts."
+                  fi
+                }
+              done
+            }
+
+            retry make cypress_base
 
   test:
     docker:


### PR DESCRIPTION
What I Did
------------
Added retry logic to the `e2e_init` CI step. It will now run up to 5 times before giving up as failed. Everyone loves flaky tests.

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Ship (not required but encouraged)
------------
![USS Hornet (CV-12)]( https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/USS_Hornet_%28CVS-12%29_underway_at_sea_on_9_August_1968_%28USN_1116887%29.jpg/819px-USS_Hornet_%28CVS-12%29_underway_at_sea_on_9_August_1968_%28USN_1116887%29.jpg "USS Hornet (CV-12)")











<!-- (thanks https://github.com/docker/docker for this template) -->

