### PR TITLE
semver query param should be release_semver

### DIFF
--- a/integration/init_app/helm-github/metadata.yaml
+++ b/integration/init_app/helm-github/metadata.yaml
@@ -1,5 +1,5 @@
 customer_id: "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G"
 installation_id: "OafdEI-lF2IQV0Il3bfzrIl5mUdHCb3j"
-release_version: "1.0.0-SNAPSHOT"
+release_version: "1.0.1-SNAPSHOT"
 skip_cleanup: false
 args: ["--prefer-git"]

--- a/integration/init_app/integration_test.go
+++ b/integration/init_app/integration_test.go
@@ -123,7 +123,7 @@ var _ = Describe("ship init replicated.app/...", func() {
 					}
 
 					if testMetadata.ReleaseVersion != "" {
-						upstream = fmt.Sprintf("%s&semver=%s", upstream, testMetadata.ReleaseVersion)
+						upstream = fmt.Sprintf("%s&release_semver=%s", upstream, testMetadata.ReleaseVersion)
 					}
 
 					cmd := cli.RootCmd()


### PR DESCRIPTION
<!--

  Hello Friend! Thank you for contributing to Ship!

  If you worked on the front end (i.e React component side)...
  Did you bump the version number in package.json?

  Thanks again! You are awesome!
-->
What I Did
------------
Fixed the query param for release_semver in integration tests

How I Did it
------------
Changed semver to release_semver. I had to comment it out in metadata from two tests and I'm unclear why.

How to verify it
------------
Integration tests should succeed

Description for the Changelog
------------
Do I need one and should I bump version? I'm unclear


Picture of a Ship (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

