### PR TITLE
Exclude kubernetes patches with resources

### DIFF
--- a/integration/update/excluded-basic/expected/overlays/defaults/kustomization.yaml
+++ b/integration/update/excluded-basic/expected/overlays/defaults/kustomization.yaml
@@ -1,15 +1,17 @@
+kind: ""
+apiversion: ""
+patchesJson6902:
+- target:
+    group: apps
+    version: v1beta2
+    kind: Deployment
+    name: basic
+  path: chart-patch.json
+- target:
+    group: apps
+    version: v1beta2
+    kind: Deployment
+    name: basic
+  path: heritage-patch.json
 bases:
 - ../../base
-patchesJson6902:
-- path: chart-patch.json
-  target:
-    group: apps
-    kind: Deployment
-    name: basic
-    version: v1beta2
-- path: heritage-patch.json
-  target:
-    group: apps
-    kind: Deployment
-    name: basic
-    version: v1beta2

--- a/integration/update/jenkins-deployment-labels/expected/overlays/defaults/kustomization.yaml
+++ b/integration/update/jenkins-deployment-labels/expected/overlays/defaults/kustomization.yaml
@@ -1,50 +1,52 @@
-bases:
-- ../../base
+kind: ""
+apiversion: ""
 patchesJson6902:
-- path: chart-patch.json
-  target:
+- target:
+    version: v1
     kind: PersistentVolumeClaim
     name: jenkins
+  path: chart-patch.json
+- target:
     version: v1
-- path: heritage-patch.json
-  target:
     kind: PersistentVolumeClaim
     name: jenkins
+  path: heritage-patch.json
+- target:
     version: v1
-- path: chart-patch.json
-  target:
     kind: Service
     name: jenkins-agent
-    version: v1
-- path: chart-patch.json
-  target:
+  path: chart-patch.json
+- target:
     group: apps
+    version: v1beta1
     kind: Deployment
     name: jenkins
-    version: v1beta1
-- path: heritage-patch.json
-  target:
+  path: chart-patch.json
+- target:
     group: apps
+    version: v1beta1
     kind: Deployment
     name: jenkins
-    version: v1beta1
-- path: chart-patch.json
-  target:
+  path: heritage-patch.json
+- target:
+    version: v1
     kind: Service
     name: jenkins
+  path: chart-patch.json
+- target:
     version: v1
-- path: heritage-patch.json
-  target:
     kind: Service
     name: jenkins
+  path: heritage-patch.json
+- target:
     version: v1
-- path: chart-patch.json
-  target:
     kind: Secret
     name: jenkins
+  path: chart-patch.json
+- target:
     version: v1
-- path: heritage-patch.json
-  target:
     kind: Secret
     name: jenkins
-    version: v1
+  path: heritage-patch.json
+bases:
+- ../../base

--- a/pkg/lifecycle/kustomize/kustomizer.go
+++ b/pkg/lifecycle/kustomize/kustomizer.go
@@ -214,16 +214,6 @@ func (l *Kustomizer) writeBase(base string) error {
 	}
 	shipOverlay := currentKustomize.Ship()
 
-	existingKustomize, err := l.FS.Exists(filepath.Join(base, "kustomization.yaml"))
-	if err != nil {
-		return errors.Wrapf(err, "check for kustomization in %s", base)
-	}
-	if existingKustomize {
-		// no need to write base, kustomization already exists
-		// but we do need to remove excluded bases
-		return errors.Wrapf(util.ExcludeKubernetesResources(l.FS, base, shipOverlay.ExcludedBases), "write base %s", base)
-	}
-
 	baseKustomization := ktypes.Kustomization{}
 	if err := l.FS.Walk(
 		base,

--- a/pkg/util/exclude_kubernetes.go
+++ b/pkg/util/exclude_kubernetes.go
@@ -9,81 +9,86 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 	yaml "gopkg.in/yaml.v2"
+	"sigs.k8s.io/kustomize/pkg/patch"
+	"sigs.k8s.io/kustomize/pkg/resid"
 	"sigs.k8s.io/kustomize/pkg/types"
 )
 
 // calls ExcludeKubernetesResource for each excluded resource. Returns after the first error.
 func ExcludeKubernetesResources(fs afero.Afero, basePath string, excludedResources []string) error {
 	for _, excludedResource := range excludedResources {
-		err := ExcludeKubernetesResource(fs, basePath, excludedResource)
+		excludedIDs, err := ExcludeKubernetesResource(fs, basePath, excludedResource)
 		if err != nil {
 			return errors.Wrapf(err, "excluding %s from %s", excludedResource, basePath)
+		}
+		for _, excludedID := range excludedIDs {
+			err = ExcludeKubernetesPatch(fs, basePath, excludedID)
+			if err != nil {
+				return errors.Wrapf(err, "excluding %s of %s from %s", excludedID.String(), excludedResource, basePath)
+			}
 		}
 	}
 	return nil
 }
 
 // exclude the provided kubernetes resource file from the kustomization.yaml at basePath, or from bases imported from that.
-func ExcludeKubernetesResource(fs afero.Afero, basePath string, excludedResource string) error {
-	kustomizeYaml, err := fs.ReadFile(filepath.Join(basePath, "kustomization.yaml"))
+func ExcludeKubernetesResource(fs afero.Afero, basePath string, excludedResource string) ([]resid.ResId, error) {
+	kustomization, err := getKustomization(fs, basePath)
 	if err != nil {
-		return errors.Wrapf(err, "read kustomization yaml in %s", basePath)
-	}
-
-	kustomization := types.Kustomization{}
-	err = yaml.Unmarshal(kustomizeYaml, &kustomization)
-	if err != nil {
-		return errors.Wrapf(err, "unmarshal kustomization yaml from %s", basePath)
+		return nil, errors.Wrapf(err, "exclude resource %s", excludedResource)
 	}
 
 	excludedResource = strings.TrimPrefix(excludedResource, string(filepath.Separator))
 
 	newResources := []string{}
+	var excludedResourceBytes []byte
 	for _, existingResource := range kustomization.Resources {
 		if existingResource != excludedResource {
 			newResources = append(newResources, existingResource)
+		} else {
+			excludedResourceBytes, err = fs.ReadFile(filepath.Join(basePath, excludedResource))
+			if err != nil {
+				return nil, errors.Wrapf(err, "read to-be-excluded resource file")
+			}
 		}
 	}
 
 	if len(newResources) != len(kustomization.Resources) {
+		// parse to-be-excluded resource file
+
+		excludedResources, err := NewKubernetesResources(excludedResourceBytes)
+		if err != nil {
+			return nil, errors.Wrapf(err, "parse to-be-excluded resource file")
+		}
+
 		kustomization.Resources = newResources
-
 		// write updated kustomization to disk - resource has been removed
-		kustomizeYaml, err = yaml.Marshal(kustomization)
-		if err != nil {
-			return errors.Wrapf(err, "marshal kustomization yaml from %s", basePath)
-		}
 
-		err = fs.WriteFile(filepath.Join(basePath, "kustomization.yaml"), kustomizeYaml, 0644)
+		err = writeKustomization(fs, basePath, kustomization)
 		if err != nil {
-			return errors.Wrapf(err, "write kustomization yaml to %s", basePath)
+			return nil, errors.Wrapf(err, "persist kustomization for %s", basePath)
 		}
-		return nil
+		return ResIDs(excludedResources), nil
 	}
 
 	// check if the resource is already removed from this dir
-	alreadyRemoved := false
-	err = fs.Walk(basePath, func(path string, info os.FileInfo, err error) error {
-		if !info.IsDir() {
-			if err != nil {
-				return err
-			}
-			relPath, err := filepath.Rel(basePath, path)
-			if err != nil {
-				return errors.Wrapf(err, "get relative path to %s from %s", path, basePath)
-			}
-			if relPath == excludedResource {
-				alreadyRemoved = true
-			}
-		}
-		return nil
-	})
+	alreadyRemoved, err := fs.Exists(filepath.Join(basePath, excludedResource))
 	if err != nil {
-		return errors.Wrapf(err, "walk files in %s", basePath)
+		return nil, errors.Wrapf(err, "check if %s exists in %s", excludedResource, basePath)
 	}
 	if alreadyRemoved {
 		// the file to be removed exists within this base dir, and not within the kustomization yaml
-		return nil
+		excludedResourceBytes, err = fs.ReadFile(filepath.Join(basePath, excludedResource))
+		if err != nil {
+			return nil, errors.Wrapf(err, "read already-excluded resource file")
+		}
+
+		excludedResources, err := NewKubernetesResources(excludedResourceBytes)
+		if err != nil {
+			return nil, errors.Wrapf(err, "parse to-be-excluded resource file")
+		}
+
+		return ResIDs(excludedResources), nil
 	}
 
 	for _, newBase := range kustomization.Bases {
@@ -98,21 +103,76 @@ func ExcludeKubernetesResource(fs afero.Afero, basePath string, excludedResource
 		}
 	}
 
-	return fmt.Errorf("unable to find resource %s in %s or its bases", excludedResource, basePath)
+	return nil, fmt.Errorf("unable to find resource %s in %s or its bases", excludedResource, basePath)
+}
+
+// for the provided base and all subbases, check each strategic merge patch and json patch
+// if they match the resid provided, remove them
+func ExcludeKubernetesPatch(fs afero.Afero, basePath string, excludedResource resid.ResId) error {
+	kustomization, err := getKustomization(fs, basePath)
+	if err != nil {
+		return errors.Wrapf(err, "exclude patch %s", excludedResource.String())
+	}
+
+	newJsonPatches := []patch.Json6902{}
+	for _, jsonPatch := range kustomization.PatchesJson6902 {
+		if excludedResource.Gvk().Equals(jsonPatch.Target.Gvk) {
+			if jsonPatch.Target.Name == excludedResource.Name() {
+				// don't add to new patch list
+				continue
+			}
+		}
+		newJsonPatches = append(newJsonPatches, jsonPatch)
+	}
+	kustomization.PatchesJson6902 = newJsonPatches
+
+	newMergePatches := []patch.StrategicMerge{}
+MERGEPATCHES:
+	for _, mergePatch := range kustomization.PatchesStrategicMerge {
+		// read contents of resource and convert it to ResID form
+		patchBytes, err := fs.ReadFile(filepath.Join(basePath, string(mergePatch)))
+		if err != nil {
+			return errors.Wrapf(err, "read %s in %s to exclude patches for %s", string(mergePatch), basePath, excludedResource.String())
+		}
+
+		patchResources, err := NewKubernetesResources(patchBytes)
+		if err != nil {
+			return errors.Wrapf(err, "parse %s in %s to exclude patches for %s", string(mergePatch), basePath, excludedResource.String())
+		}
+
+		patchIDs := ResIDs(patchResources)
+
+		for _, patchID := range patchIDs {
+			if patchID.GvknEquals(excludedResource) {
+				// this file of patches touches the excluded resource, and should be discarded
+				continue MERGEPATCHES
+			}
+		}
+
+		newMergePatches = append(newMergePatches, mergePatch)
+	}
+	kustomization.PatchesStrategicMerge = newMergePatches
+
+	for _, base := range kustomization.Bases {
+		err = ExcludeKubernetesPatch(fs, filepath.Join(basePath, base), excludedResource)
+		if err != nil {
+			return errors.Wrapf(err, "base %s of %s", base, basePath)
+		}
+	}
+
+	err = writeKustomization(fs, basePath, kustomization)
+	if err != nil {
+		return errors.Wrapf(err, "persist kustomization for %s", basePath)
+	}
+
+	return nil
 }
 
 // UnExcludeKubernetesResource finds a deleted resource in a child of the basePath and includes it again
 func UnExcludeKubernetesResource(fs afero.Afero, basePath string, unExcludedResource string) error {
-
-	kustomizeYaml, err := fs.ReadFile(filepath.Join(basePath, "kustomization.yaml"))
+	kustomization, err := getKustomization(fs, basePath)
 	if err != nil {
-		return errors.Wrapf(err, "read kustomization yaml in %s", basePath)
-	}
-
-	kustomization := types.Kustomization{}
-	err = yaml.Unmarshal(kustomizeYaml, &kustomization)
-	if err != nil {
-		return errors.Wrapf(err, "unmarshal kustomization yaml from %s", basePath)
+		return errors.Wrapf(err, "unexclude resource %s", unExcludedResource)
 	}
 
 	unExcludedResource = strings.TrimPrefix(unExcludedResource, string(filepath.Separator))
@@ -147,14 +207,9 @@ func UnExcludeKubernetesResource(fs afero.Afero, basePath string, unExcludedReso
 
 	if resourceLength != len(kustomization.Resources) {
 		// write updated kustomization to disk - resource has been reincluded
-		kustomizeYaml, err = yaml.Marshal(kustomization)
+		err = writeKustomization(fs, basePath, kustomization)
 		if err != nil {
-			return errors.Wrapf(err, "marshal kustomization yaml from %s", basePath)
-		}
-
-		err = fs.WriteFile(filepath.Join(basePath, "kustomization.yaml"), kustomizeYaml, 0644)
-		if err != nil {
-			return errors.Wrapf(err, "write kustomization yaml to %s", basePath)
+			return errors.Wrapf(err, "persist kustomization for %s", basePath)
 		}
 		return nil
 	}
@@ -172,4 +227,39 @@ func UnExcludeKubernetesResource(fs afero.Afero, basePath string, unExcludedReso
 	}
 
 	return fmt.Errorf("unable to find resource %s in %s or its bases", unExcludedResource, basePath)
+}
+
+func getKustomization(fs afero.Afero, basePath string) (*types.Kustomization, error) {
+	exists, err := fs.Exists(filepath.Join(basePath, "kustomization.yaml"))
+	if err != nil {
+		return nil, errors.Wrapf(err, "check kustomization yaml in %s", basePath)
+	}
+	if !exists {
+		return nil, fmt.Errorf("kustomization in %s does not exist", basePath)
+	}
+
+	kustomizeYaml, err := fs.ReadFile(filepath.Join(basePath, "kustomization.yaml"))
+	if err != nil {
+		return nil, errors.Wrapf(err, "read kustomization yaml in %s", basePath)
+	}
+
+	kustomization := types.Kustomization{}
+	err = yaml.Unmarshal(kustomizeYaml, &kustomization)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unmarshal kustomization yaml from %s", basePath)
+	}
+	return &kustomization, nil
+}
+
+func writeKustomization(fs afero.Afero, basePath string, kustomization *types.Kustomization) error {
+	kustomizeYaml, err := yaml.Marshal(kustomization)
+	if err != nil {
+		return errors.Wrapf(err, "marshal kustomization yaml from %s", basePath)
+	}
+
+	err = fs.WriteFile(filepath.Join(basePath, "kustomization.yaml"), kustomizeYaml, 0644)
+	if err != nil {
+		return errors.Wrapf(err, "write kustomization yaml to %s", basePath)
+	}
+	return nil
 }

--- a/pkg/util/exclude_kubernetes.go
+++ b/pkg/util/exclude_kubernetes.go
@@ -35,7 +35,7 @@ func ExcludeKubernetesResources(fs afero.Afero, basePath string, overlaysPath st
 func ExcludeKubernetesResource(fs afero.Afero, basePath string, excludedResource string) ([]resid.ResId, error) {
 	kustomization, err := getKustomization(fs, basePath)
 	if err != nil {
-		return nil, errors.Wrapf(err, "exclude resource %s", excludedResource)
+		return nil, errors.Wrapf(err, "get kustomization for %s", basePath)
 	}
 
 	excludedResource = strings.TrimPrefix(excludedResource, string(filepath.Separator))
@@ -85,7 +85,7 @@ func ExcludeKubernetesResource(fs afero.Afero, basePath string, excludedResource
 
 		excludedResources, err := NewKubernetesResources(excludedResourceBytes)
 		if err != nil {
-			return nil, errors.Wrapf(err, "parse to-be-excluded resource file")
+			return nil, errors.Wrapf(err, "parse already-excluded resource file")
 		}
 
 		return ResIDs(excludedResources), nil
@@ -111,7 +111,7 @@ func ExcludeKubernetesResource(fs afero.Afero, basePath string, excludedResource
 func ExcludeKubernetesPatch(fs afero.Afero, basePath string, excludedResource resid.ResId) error {
 	kustomization, err := getKustomization(fs, basePath)
 	if err != nil {
-		return errors.Wrapf(err, "exclude patch %s", excludedResource.String())
+		return errors.Wrapf(err, "get kustomization for %s", basePath)
 	}
 
 	newJSONPatches := []patch.Json6902{}
@@ -142,7 +142,7 @@ func ExcludeKubernetesPatch(fs afero.Afero, basePath string, excludedResource re
 	for _, base := range kustomization.Bases {
 		err = ExcludeKubernetesPatch(fs, filepath.Join(basePath, base), excludedResource)
 		if err != nil {
-			return errors.Wrapf(err, "base %s of %s", base, basePath)
+			return errors.Wrapf(err, "exclude kubernetes patch %s from base %s of %s", excludedResource.String(), base, basePath)
 		}
 	}
 
@@ -158,7 +158,7 @@ func ExcludeKubernetesPatch(fs afero.Afero, basePath string, excludedResource re
 func UnExcludeKubernetesResource(fs afero.Afero, basePath string, unExcludedResource string) error {
 	kustomization, err := getKustomization(fs, basePath)
 	if err != nil {
-		return errors.Wrapf(err, "unexclude resource %s", unExcludedResource)
+		return errors.Wrapf(err, "get kustomization for %s", basePath)
 	}
 
 	unExcludedResource = strings.TrimPrefix(unExcludedResource, string(filepath.Separator))

--- a/pkg/util/exclude_kubernetes.go
+++ b/pkg/util/exclude_kubernetes.go
@@ -15,14 +15,14 @@ import (
 )
 
 // calls ExcludeKubernetesResource for each excluded resource. Returns after the first error.
-func ExcludeKubernetesResources(fs afero.Afero, basePath string, excludedResources []string) error {
+func ExcludeKubernetesResources(fs afero.Afero, basePath string, overlaysPath string, excludedResources []string) error {
 	for _, excludedResource := range excludedResources {
 		excludedIDs, err := ExcludeKubernetesResource(fs, basePath, excludedResource)
 		if err != nil {
 			return errors.Wrapf(err, "excluding %s from %s", excludedResource, basePath)
 		}
 		for _, excludedID := range excludedIDs {
-			err = ExcludeKubernetesPatch(fs, basePath, excludedID)
+			err = ExcludeKubernetesPatch(fs, overlaysPath, excludedID)
 			if err != nil {
 				return errors.Wrapf(err, "excluding %s of %s from %s", excludedID.String(), excludedResource, basePath)
 			}

--- a/pkg/util/exclude_kubernetes_test.go
+++ b/pkg/util/exclude_kubernetes_test.go
@@ -1,13 +1,14 @@
 package util
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/kustomize/pkg/gvk"
+	"sigs.k8s.io/kustomize/pkg/resid"
 )
 
 func TestExcludeKubernetesResource(t *testing.T) {
@@ -23,6 +24,7 @@ func TestExcludeKubernetesResource(t *testing.T) {
 		wantErr          bool
 		inputFiles       []fileStruct
 		outputFiles      []fileStruct
+		wantResIDs       []resid.ResId
 	}{
 		{
 			name:             "existsInBase",
@@ -141,7 +143,18 @@ resources:
 				},
 				{
 					name: "another/base/anotherresource.yaml",
-					data: `#unused`,
+					data: `
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: jaeger-collector
+  labels:
+    app: jaeger
+    jaeger-infra: collector-deployment
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate`,
 				},
 			},
 			outputFiles: []fileStruct{
@@ -167,9 +180,21 @@ apiversion: ""
 				},
 				{
 					name: "another/base/anotherresource.yaml",
-					data: `#unused`,
+					data: `
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: jaeger-collector
+  labels:
+    app: jaeger
+    jaeger-infra: collector-deployment
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate`,
 				},
 			},
+			wantResIDs: []resid.ResId{resid.NewResId(gvk.Gvk{Group: "extensions", Version: "v1beta1", Kind: "Deployment"}, "jaeger-collector")},
 		},
 		{
 			name:             "already removed",
@@ -226,7 +251,8 @@ resources:
 			}
 
 			// run exclude function
-			if err := ExcludeKubernetesResource(mockFs, tt.basePath, tt.excludedResource); (err != nil) != tt.wantErr {
+			actualResIDs, err := ExcludeKubernetesResource(mockFs, tt.basePath, tt.excludedResource)
+			if (err != nil) != tt.wantErr {
 				t.Errorf("ExcludeKubernetesResource() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
@@ -235,10 +261,474 @@ resources:
 			for _, expectedFile := range tt.outputFiles {
 				expectedFileNames = append(expectedFileNames, expectedFile.name)
 			}
-			err := mockFs.Walk("", func(path string, info os.FileInfo, err error) error {
+			err = mockFs.Walk("", func(path string, info os.FileInfo, err error) error {
 				if !info.IsDir() {
 					actualFileNames = append(actualFileNames, path)
-					fmt.Println(path)
+				}
+				return nil
+			})
+			req.NoError(err, "read output /")
+
+			req.ElementsMatch(expectedFileNames, actualFileNames, "comparing expected and actual output files, expected %+v got %+v", expectedFileNames, actualFileNames)
+
+			for _, outFile := range tt.outputFiles {
+				fileBytes, err := mockFs.ReadFile(outFile.name)
+				req.NoError(err, "reading output file %s", outFile.name)
+
+				req.Equal(outFile.data, string(fileBytes), "compare file %s", outFile.name)
+			}
+			req.ElementsMatch(tt.wantResIDs, actualResIDs)
+		})
+	}
+}
+
+func TestExcludeKubernetesPatch(t *testing.T) {
+	type fileStruct struct {
+		name string
+		data string
+	}
+
+	tests := []struct {
+		name          string
+		basePath      string
+		excludedPatch resid.ResId
+		wantErr       bool
+		inputFiles    []fileStruct
+		outputFiles   []fileStruct
+	}{
+		{
+			name:          "existsInBase",
+			basePath:      "base",
+			excludedPatch: resid.NewResId(gvk.Gvk{Group: "extensions", Version: "v1beta1", Kind: "Deployment"}, "jaeger-collector"),
+			wantErr:       false,
+			inputFiles: []fileStruct{
+				{
+					name: "base/kustomization.yaml",
+					data: `kind: ""
+apiversion: ""
+patchesStrategicMerge:
+- myresource.yaml
+- notmyresource.yaml
+`,
+				},
+				{
+					name: "base/myresource.yaml",
+					data: `
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: jaeger-collector
+  labels:
+    app: jaeger
+    jaeger-infra: collector-deployment
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate`,
+				},
+				{
+					name: "base/notmyresource.yaml",
+					data: `
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: jaeger-collector-two
+  labels:
+    app: jaeger
+    jaeger-infra: collector-deployment
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate`,
+				},
+			},
+			outputFiles: []fileStruct{
+				{
+					name: "base/kustomization.yaml",
+					data: `kind: ""
+apiversion: ""
+patchesStrategicMerge:
+- notmyresource.yaml
+`,
+				},
+				{
+					name: "base/myresource.yaml",
+					data: `
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: jaeger-collector
+  labels:
+    app: jaeger
+    jaeger-infra: collector-deployment
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate`,
+				},
+				{
+					name: "base/notmyresource.yaml",
+					data: `
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: jaeger-collector-two
+  labels:
+    app: jaeger
+    jaeger-infra: collector-deployment
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate`,
+				},
+			},
+		},
+		{
+			name:          "does not exist",
+			basePath:      "base",
+			excludedPatch: resid.NewResId(gvk.Gvk{Group: "extensions", Version: "v1beta1", Kind: "Deployment"}, "jaeger-collector"),
+			wantErr:       false,
+			inputFiles: []fileStruct{
+				{
+					name: "base/kustomization.yaml",
+					data: `kind: ""
+apiversion: ""
+patchesStrategicMerge:
+- myresource.yaml
+- notmyresource.yaml
+`,
+				},
+				{
+					name: "base/myresource.yaml",
+					data: `
+apiVersion: extensions/v1beta2
+kind: Deployment
+metadata:
+  name: jaeger-collector
+  labels:
+    app: jaeger
+    jaeger-infra: collector-deployment
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate`,
+				},
+				{
+					name: "base/notmyresource.yaml",
+					data: `
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: jaeger-collector-two
+  labels:
+    app: jaeger
+    jaeger-infra: collector-deployment
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate`,
+				},
+			},
+			outputFiles: []fileStruct{
+				{
+					name: "base/kustomization.yaml",
+					data: `kind: ""
+apiversion: ""
+patchesStrategicMerge:
+- myresource.yaml
+- notmyresource.yaml
+`,
+				},
+				{
+					name: "base/myresource.yaml",
+					data: `
+apiVersion: extensions/v1beta2
+kind: Deployment
+metadata:
+  name: jaeger-collector
+  labels:
+    app: jaeger
+    jaeger-infra: collector-deployment
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate`,
+				},
+				{
+					name: "base/notmyresource.yaml",
+					data: `
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: jaeger-collector-two
+  labels:
+    app: jaeger
+    jaeger-infra: collector-deployment
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate`,
+				},
+			},
+		},
+		{
+			name:          "exists in child base",
+			basePath:      "base",
+			excludedPatch: resid.NewResId(gvk.Gvk{Group: "extensions", Version: "v1beta1", Kind: "Deployment"}, "jaeger-collector"),
+			wantErr:       false,
+			inputFiles: []fileStruct{
+				{
+					name: "base/kustomization.yaml",
+					data: `kind: ""
+apiversion: ""
+bases:
+- ../another/base
+patchesStrategicMerge:
+- myresource.yaml
+`,
+				},
+				{
+					name: "base/myresource.yaml",
+					data: `
+apiVersion: extension/v1beta1
+kind: Deployment
+metadata:
+  name: jaeger-collector
+  labels:
+    app: jaeger
+    jaeger-infra: collector-deployment
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate`,
+				},
+				{
+					name: "another/base/kustomization.yaml",
+					data: `kind: ""
+apiversion: ""
+patchesStrategicMerge:
+- anotherresource.yaml
+`,
+				},
+				{
+					name: "another/base/anotherresource.yaml",
+					data: `
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: jaeger-collector
+  labels:
+    app: jaeger
+    jaeger-infra: collector-deployment
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate`,
+				},
+			},
+			outputFiles: []fileStruct{
+				{
+					name: "base/kustomization.yaml",
+					data: `kind: ""
+apiversion: ""
+patchesStrategicMerge:
+- myresource.yaml
+bases:
+- ../another/base
+`,
+				},
+				{
+					name: "base/myresource.yaml",
+					data: `
+apiVersion: extension/v1beta1
+kind: Deployment
+metadata:
+  name: jaeger-collector
+  labels:
+    app: jaeger
+    jaeger-infra: collector-deployment
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate`,
+				},
+				{
+					name: "another/base/kustomization.yaml",
+					data: `kind: ""
+apiversion: ""
+`,
+				},
+				{
+					name: "another/base/anotherresource.yaml",
+					data: `
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: jaeger-collector
+  labels:
+    app: jaeger
+    jaeger-infra: collector-deployment
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate`,
+				},
+			},
+		},
+		{
+			name:          "already removed",
+			basePath:      "base",
+			excludedPatch: resid.NewResId(gvk.Gvk{Group: "extensions", Version: "v1beta1", Kind: "Deployment"}, "jaeger-collector"),
+			wantErr:       false,
+			inputFiles: []fileStruct{
+				{
+					name: "base/kustomization.yaml",
+					data: `kind: ""
+apiversion: ""
+patchesStrategicMerge:
+- notmyresource.yaml
+`,
+				},
+				{
+					name: "base/myresource.yaml",
+					data: `
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: jaeger-collector
+  labels:
+    app: jaeger
+    jaeger-infra: collector-deployment
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate`,
+				},
+				{
+					name: "base/notmyresource.yaml",
+					data: `
+apiVersion: extensions/v1beta1
+kind: Deployment-test
+metadata:
+  name: jaeger-collector
+  labels:
+    app: jaeger
+    jaeger-infra: collector-deployment
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate`,
+				},
+			},
+			outputFiles: []fileStruct{
+				{
+					name: "base/kustomization.yaml",
+					data: `kind: ""
+apiversion: ""
+patchesStrategicMerge:
+- notmyresource.yaml
+`,
+				},
+				{
+					name: "base/myresource.yaml",
+					data: `
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: jaeger-collector
+  labels:
+    app: jaeger
+    jaeger-infra: collector-deployment
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate`,
+				},
+				{
+					name: "base/notmyresource.yaml",
+					data: `
+apiVersion: extensions/v1beta1
+kind: Deployment-test
+metadata:
+  name: jaeger-collector
+  labels:
+    app: jaeger
+    jaeger-infra: collector-deployment
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate`,
+				},
+			},
+		},
+		{
+			name:          "jsonPatch",
+			basePath:      "base",
+			excludedPatch: resid.NewResId(gvk.Gvk{Group: "extensions", Version: "v1beta1", Kind: "Deployment"}, "jaeger-collector"),
+			wantErr:       false,
+			inputFiles: []fileStruct{
+				{
+					name: "base/kustomization.yaml",
+					data: `kind: ""
+apiversion: ""
+patchesJson6902:
+- path: chart-patch.json
+  target:
+    group: extensions
+    kind: Deployment
+    name: jaeger-collector
+    version: v1beta1
+- path: chart-patch-2.json
+  target:
+    group: extensions
+    kind: Deployment
+    name: istio-galley-default
+    version: v1beta1
+`,
+				},
+			},
+			outputFiles: []fileStruct{
+				{
+					name: "base/kustomization.yaml",
+					data: `kind: ""
+apiversion: ""
+patchesJson6902:
+- target:
+    group: extensions
+    version: v1beta1
+    kind: Deployment
+    name: istio-galley-default
+  path: chart-patch-2.json
+`,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			// setup input FS
+			mockFs := afero.Afero{Fs: afero.NewMemMapFs()}
+			for _, inFile := range tt.inputFiles {
+				req.NoError(mockFs.MkdirAll(filepath.Dir(inFile.name), os.FileMode(0644)))
+				req.NoError(mockFs.WriteFile(inFile.name, []byte(inFile.data), os.FileMode(0644)))
+			}
+
+			// run exclude function
+			err := ExcludeKubernetesPatch(mockFs, tt.basePath, tt.excludedPatch)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ExcludeKubernetesPatch() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// compare output FS
+			var expectedFileNames, actualFileNames []string
+			for _, expectedFile := range tt.outputFiles {
+				expectedFileNames = append(expectedFileNames, expectedFile.name)
+			}
+			err = mockFs.Walk("", func(path string, info os.FileInfo, err error) error {
+				if !info.IsDir() {
+					actualFileNames = append(actualFileNames, path)
 				}
 				return nil
 			})
@@ -486,7 +976,6 @@ resources:
 			err := mockFs.Walk("", func(path string, info os.FileInfo, err error) error {
 				if !info.IsDir() {
 					actualFileNames = append(actualFileNames, path)
-					fmt.Println(path)
 				}
 				return nil
 			})

--- a/pkg/util/kubernetes_resource.go
+++ b/pkg/util/kubernetes_resource.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/kustomize/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/pkg/gvk"
+	"sigs.k8s.io/kustomize/pkg/resid"
 	"sigs.k8s.io/kustomize/pkg/resource"
 )
 
@@ -15,12 +16,30 @@ func NewKubernetesResource(in []byte) (*resource.Resource, error) {
 
 	resources, err := resourceFactory.SliceFromBytes(in)
 	if err != nil {
-		return nil, errors.Wrap(err, "decode json")
+		return nil, errors.Wrap(err, "decode resource")
 	}
 	if len(resources) != 1 {
 		return nil, fmt.Errorf("expected 1 resource, got %d", len(resources))
 	}
 	return resources[0], nil
+}
+
+func NewKubernetesResources(in []byte) ([]*resource.Resource, error) {
+	resourceFactory := resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl())
+
+	resources, err := resourceFactory.SliceFromBytes(in)
+	if err != nil {
+		return nil, errors.Wrap(err, "decode resources")
+	}
+
+	return resources, nil
+}
+
+func ResIDs(in []*resource.Resource) (generated []resid.ResId) {
+	for _, thisResource := range in {
+		generated = append(generated, thisResource.Id())
+	}
+	return
 }
 
 func ToGroupVersionKind(in gvk.Gvk) schema.GroupVersionKind {


### PR DESCRIPTION
What I Did
------------
When excluding kubernetes resources in the kustomize step, patches referring to that resource should be removed too.

How I Did it
------------
When removing a resource, the GVK+name+ns are stored. Then, the kustomize tree is walked for all patchesStrategicMerge or patchesJson6902 that refer to the same GVK+name+ns, and matches are removed.

How to verify it
------------
Deleting k8s resources created by a helm chart works properly.

Description for the Changelog
------------
Fix removing k8s resources created by a helm chart with kustomize


Picture of a Ship (not required but encouraged)
------------

![USS Wasp (CV-18)](https://upload.wikimedia.org/wikipedia/commons/thumb/d/dc/USS_Wasp_%28CVS-18%29_underway_at_sea%2C_circa_in_early_1967_%28NH_97509%29.jpg/1238px-USS_Wasp_%28CVS-18%29_underway_at_sea%2C_circa_in_early_1967_%28NH_97509%29.jpg "USS Wasp (CV-18)")










<!-- (thanks https://github.com/docker/docker for this template) -->

