### PR TITLE
the checkIsChild function should recognize unexecuted template functions

### DIFF
--- a/pkg/lifecycle/render/helm/template.go
+++ b/pkg/lifecycle/render/helm/template.go
@@ -65,6 +65,8 @@ var valueLineRegex = regexp.MustCompile(`^\s*value:\s*$`)
 
 var nullValueLineRegex = regexp.MustCompile(`^(\s*value:)\s*null\s*$`)
 
+var templateFunctionRegex = regexp.MustCompile(`^\s*{{`)
+
 // LocalTemplater implements Templater by using the Commands interface
 // from pkg/helm and creating the chart in place
 type LocalTemplater struct {
@@ -566,6 +568,11 @@ func checkIsChild(firstLine, secondLine string) bool {
 
 	if firstIndentation < secondIndentation {
 		// if the next line is more indented, it's a child
+		return true
+	}
+
+	if templateFunctionRegex.MatchString(secondLine) {
+		// next line is a template function
 		return true
 	}
 

--- a/pkg/lifecycle/render/helm/template_test.go
+++ b/pkg/lifecycle/render/helm/template_test.go
@@ -703,6 +703,42 @@ func Test_validateGeneratedFiles(t *testing.T) {
 			},
 		},
 		{
+			name: "templated values",
+			dir:  "test",
+			inputFiles: []file{
+				{
+					path: "test/null_values.yaml",
+					contents: `
+  value:
+
+{{ template }}
+
+  value:
+  {{ template }}
+
+  value:
+    value: {{ template }}
+`,
+				},
+			},
+			outputFiles: []file{
+				{
+					path: "test/null_values.yaml",
+					contents: `
+  value:
+
+{{ template }}
+
+  value:
+  {{ template }}
+
+  value:
+    value: {{ template }}
+`,
+				},
+			},
+		},
+		{
 			name: "everything",
 			dir:  "test",
 			inputFiles: []file{


### PR DESCRIPTION
What I Did
------------
Fixed #1008 by checking for template functions on successive lines

How I Did it
------------


How to verify it
------------
Look at the new unit test

Description for the Changelog
------------
Fixed an issue that could lead to ship manipulating some values within yaml configmaps


Picture of a Ship (not required but encouraged)
------------




![USS Cabot (CVL-28)](https://upload.wikimedia.org/wikipedia/commons/1/10/USS_Cabot_%28CVL-28%29.jpg "USS Cabot (CVL-28)")







<!-- (thanks https://github.com/docker/docker for this template) -->

