### PR TITLE
Entitlements meta uses wrong json param names

### DIFF
--- a/contracts/replicatedapp/get_slug_release_test.go
+++ b/contracts/replicatedapp/get_slug_release_test.go
@@ -67,58 +67,58 @@ func Test_GetSlugRelease(t *testing.T) {
 			Body: map[string]interface{}{
 				"data": map[string]interface{}{
 					"shipSlugRelease": map[string]interface{}{
-						"id": "release-with-specs-app-release",
-						"sequence": 1,
-						"channelId": "release-with-specs-app-stable",
-						"channelName": "Stable",
-						"channelIcon": nil,
-						"semver": "1.0.2",
-						"releaseNotes": "1.0.2",
-						"spec": dsl.Like(dsl.String("assets:\n  v1:\n    - inline:\n        contents: |\n          #!/bin/bash\n          echo \"installing nothing\"\n          echo \"config option: {{repl ConfigOption \"test_option\" }}\"\n        dest: ./scripts/install.sh\n        mode: 0777\n    - inline:\n        contents: |\n          #!/bin/bash\n          echo \"tested nothing\"\n          echo \"customer {{repl Installation \"customer_id\" }}\"\n          echo \"install {{repl Installation \"installation_id\" }}\"\n        dest: ./scripts/test.sh\n        mode: 0777\nconfig:\n  v1:\n    - name: test_options\n      title: Test Options\n      description: testing testing 123\n      items:\n      - name: test_option\n        title: Test Option\n        default: abc123_test-option-value\n        type: text\nlifecycle:\n  v1:\n    - render: {}\n")),
-						"images": []string{},
-						"githubContents": []string{},
-						"configSpec": dsl.Like(dsl.String("v1:\n  - name: test_options\n    title: Test Options\n    description: testing testing 123\n    items:\n      - name: test_option\n        title: Test Option\n        default: abc123_test-option-value\n        type: text\n")),
+						"id":              "release-with-specs-app-release",
+						"sequence":        1,
+						"channelId":       "release-with-specs-app-stable",
+						"channelName":     "Stable",
+						"channelIcon":     nil,
+						"semver":          "1.0.2",
+						"releaseNotes":    "1.0.2",
+						"spec":            dsl.Like(dsl.String("assets:\n  v1:\n    - inline:\n        contents: |\n          #!/bin/bash\n          echo \"installing nothing\"\n          echo \"config option: {{repl ConfigOption \"test_option\" }}\"\n        dest: ./scripts/install.sh\n        mode: 0777\n    - inline:\n        contents: |\n          #!/bin/bash\n          echo \"tested nothing\"\n          echo \"customer {{repl Installation \"customer_id\" }}\"\n          echo \"install {{repl Installation \"installation_id\" }}\"\n        dest: ./scripts/test.sh\n        mode: 0777\nconfig:\n  v1:\n    - name: test_options\n      title: Test Options\n      description: testing testing 123\n      items:\n      - name: test_option\n        title: Test Option\n        default: abc123_test-option-value\n        type: text\nlifecycle:\n  v1:\n    - render: {}\n")),
+						"images":          []string{},
+						"githubContents":  []string{},
+						"configSpec":      dsl.Like(dsl.String("v1:\n  - name: test_options\n    title: Test Options\n    description: testing testing 123\n    items:\n      - name: test_option\n        title: Test Option\n        default: abc123_test-option-value\n        type: text\n")),
 						"entitlementSpec": dsl.Like(dsl.String("---\n- name: Has Contract\n  key: has_contract\n  type: boolean\n  default: false\n- name: Is SAML Allowed\n  key: is_saml_allowed\n  type: boolean\n  default: false\n- name: Has Private Support\n  key: is_support_ticket_allowed\n  type: boolean\n  default: false\n")),
 						"entitlements": map[string]interface{}{
 							"values": [3]map[string]interface{}{
 								{
-									"key": "has_contract",
+									"key":   "has_contract",
 									"value": "false",
 									"labels": [2]map[string]interface{}{
 										{
-											"key": "replicated.default",
+											"key":   "replicated.default",
 											"value": "true",
 										},
 										{
-											"key": "entitlements.replicated.com/type",
+											"key":   "entitlements.replicated.com/type",
 											"value": "boolean",
 										},
 									},
 								},
 								{
-									"key": "is_saml_allowed",
+									"key":   "is_saml_allowed",
 									"value": "false",
 									"labels": [2]map[string]interface{}{
 										{
-											"key": "replicated.default",
+											"key":   "replicated.default",
 											"value": "true",
 										},
 										{
-											"key": "entitlements.replicated.com/type",
+											"key":   "entitlements.replicated.com/type",
 											"value": "boolean",
 										},
 									},
 								},
 								{
-									"key": "is_support_ticket_allowed",
+									"key":   "is_support_ticket_allowed",
 									"value": "false",
 									"labels": [2]map[string]interface{}{
 										{
-											"key": "replicated.default",
+											"key":   "replicated.default",
 											"value": "true",
 										},
 										{
-											"key": "entitlements.replicated.com/type",
+											"key":   "entitlements.replicated.com/type",
 											"value": "boolean",
 										},
 									},
@@ -126,14 +126,14 @@ func Test_GetSlugRelease(t *testing.T) {
 							},
 							"utilizations": []string{},
 							"meta": map[string]interface{}{
-								"lastUpdated": dsl.Like(dsl.String("Wed Jun 19 2019 21:12:23 GMT+0000 (Coordinated Universal Time)")),
-								"customerID": "release-with-specs-customer-0",
+								"lastUpdated":    dsl.Like(dsl.String("2019-06-19T21:12:23Z")),
+								"customerID":     "release-with-specs-customer-0",
 								"installationID": nil,
 							},
 							"serialized": dsl.Like(dsl.String("{\"customerID\":\"release-with-specs-customer-0\",\"lastUpdated\":\"2019-06-19T21:12:23.173Z\"}[]")),
-							"signature": dsl.Like(dsl.String("L5kLCgGP2OBZ0X54kZnOi1/4hG0geh/8JnQwV56fUwov9en9vrUscdK5LlIEw7PD8sWscqHZ7iNWgfJYKdTW2+zM+JgKAfQke02+Abx7qstjqJqZf/3RqeQweIIbppNLKRga4waD53br6REAyND6CQZENBz5ZXYSO6aJS+neblmICHn//4sbHTVv0SVz0szXcElvWztiZeLEekpl8xShCmCc23rlWgzml53UDPSM6E15/Erbryx4tzabJjxgFmGub3qp7b2c3eMPMVyFQp5fVvLGqsOXiBgvnpEWcn12e+vHks1gFhDyx9NtuVMjpYgeYXP3KHMOoAVrulREa2vAxGEOxYdRRjBATd5wm//fr9N4rY/WTH2oAesmHzizDGirD4wJYkHPKz3qv6hzB6D2Qix3+y/4dhO9nW8D6skK/c1XLTq4uhswrxT71xOuRU/c22Ee78Gy+Nq6RGigjclSFCWRABYP0MIoWKWH3UgW6RuSOyojEpbX2Wif9orZ3tenu1ne40zzZPQ5mDC6uOlDbUBg9GOB/QqEA90K5M9avBM14RWBXdJdFdmpXFiPtRdKzu2gsEjaMQVutI9dXe8M4U1Z1w5TIuym/1cXiNFe+YQBrUdk7bXUl7g+fj7kjtFqONm9DhR718IsdR0+QhodqglWwOTjDYXuIdGnrknG8n0=")),
+							"signature":  dsl.Like(dsl.String("L5kLCgGP2OBZ0X54kZnOi1/4hG0geh/8JnQwV56fUwov9en9vrUscdK5LlIEw7PD8sWscqHZ7iNWgfJYKdTW2+zM+JgKAfQke02+Abx7qstjqJqZf/3RqeQweIIbppNLKRga4waD53br6REAyND6CQZENBz5ZXYSO6aJS+neblmICHn//4sbHTVv0SVz0szXcElvWztiZeLEekpl8xShCmCc23rlWgzml53UDPSM6E15/Erbryx4tzabJjxgFmGub3qp7b2c3eMPMVyFQp5fVvLGqsOXiBgvnpEWcn12e+vHks1gFhDyx9NtuVMjpYgeYXP3KHMOoAVrulREa2vAxGEOxYdRRjBATd5wm//fr9N4rY/WTH2oAesmHzizDGirD4wJYkHPKz3qv6hzB6D2Qix3+y/4dhO9nW8D6skK/c1XLTq4uhswrxT71xOuRU/c22Ee78Gy+Nq6RGigjclSFCWRABYP0MIoWKWH3UgW6RuSOyojEpbX2Wif9orZ3tenu1ne40zzZPQ5mDC6uOlDbUBg9GOB/QqEA90K5M9avBM14RWBXdJdFdmpXFiPtRdKzu2gsEjaMQVutI9dXe8M4U1Z1w5TIuym/1cXiNFe+YQBrUdk7bXUl7g+fj7kjtFqONm9DhR718IsdR0+QhodqglWwOTjDYXuIdGnrknG8n0=")),
 						},
-						"created": dsl.Like(dsl.String("Tue Jan 01 2019 02:23:46 GMT+0000 (Coordinated Universal Time)")),
+						"created":        dsl.Like(dsl.String("Tue Jan 01 2019 02:23:46 GMT+0000 (Coordinated Universal Time)")),
 						"registrySecret": dsl.Like(dsl.String("3bfd99a69b5748fab756a593c7dcc852")),
 					},
 				},

--- a/integration/base/amazon-eks/expected/.ship/state.json
+++ b/integration/base/amazon-eks/expected/.ship/state.json
@@ -1,7 +1,7 @@
 {
   "v1": {
     "config": {},
-    "contentSHA": "5485b495bd18e183f6a180fb3f0934a3516bffa78d66c3330f6d6ffe0971ae98",
+    "contentSHA": "960dc0fcd154b339becd8838f9cc82d743f91c9b8b75ac6a80a4f58d3ad5b9fa",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/basic-stateless/expected/.ship/state.json
+++ b/integration/base/basic-stateless/expected/.ship/state.json
@@ -1,7 +1,7 @@
 {
   "v1": {
     "config": {},
-    "contentSHA": "773b65132552ac226dbbc723fd900e79c2d97164494c49e6fd385ecba2458794",
+    "contentSHA": "fb986fb5dcf5506efdec7a0516d75223d0e716cbd222af586dbbc05f609c484d",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/basic/expected/.ship/state.json
+++ b/integration/base/basic/expected/.ship/state.json
@@ -3,7 +3,7 @@
     "config": {
       "test_option": "abc123_test-option-value"
     },
-    "contentSHA": "773b65132552ac226dbbc723fd900e79c2d97164494c49e6fd385ecba2458794",
+    "contentSHA": "fb986fb5dcf5506efdec7a0516d75223d0e716cbd222af586dbbc05f609c484d",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/config-chain-override/expected/.ship/state.json
+++ b/integration/base/config-chain-override/expected/.ship/state.json
@@ -5,7 +5,7 @@
       "t2_option": "abc123_abc123",
       "t3_option": "abc123_abc123 + abc123"
     },
-    "contentSHA": "081a11a59097965a6f37fb43f6e819b91581ca44a0c22f16a126a8889a6d3a25",
+    "contentSHA": "2b8259057c1312333450132fd5523a4f59139986c6c7371aaa39256bfb67c481",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/config-chain/expected/.ship/state.json
+++ b/integration/base/config-chain/expected/.ship/state.json
@@ -5,7 +5,7 @@
       "t2_option": "abc123_abc123",
       "t3_option": "abc123_abc123 + abc123"
     },
-    "contentSHA": "081a11a59097965a6f37fb43f6e819b91581ca44a0c22f16a126a8889a6d3a25",
+    "contentSHA": "2b8259057c1312333450132fd5523a4f59139986c6c7371aaa39256bfb67c481",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/default-values/expected/.ship/state.json
+++ b/integration/base/default-values/expected/.ship/state.json
@@ -6,7 +6,7 @@
       "namespace": "Alpha",
       "scheduler": ""
     },
-    "contentSHA": "b096a3b7265744bb902067dc856fd90eb3a07853c01679c53fd20678c97d4f1f",
+    "contentSHA": "9a75d307334cf7257c2728da93803caa336ea17b020dfa4977764bf1ac77e02a",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/docker-layer/expected/.ship/state.json
+++ b/integration/base/docker-layer/expected/.ship/state.json
@@ -3,7 +3,7 @@
     "config": {
       "option": "value"
     },
-    "contentSHA": "7dc00a0c27d1d7e48b38fa668ac8d640d781a8ae0174a582cb17ac9d6e7c0324",
+    "contentSHA": "0ce5283c45d34248870963d0bdb7a7a2708ab4d3f7d7dc018f43513187832f70",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/docker/expected/.ship/state.json
+++ b/integration/base/docker/expected/.ship/state.json
@@ -3,7 +3,7 @@
     "config": {
       "test_option": "abc123_test-option-value"
     },
-    "contentSHA": "7a14f4e1c03eec6681659a9861241224dc9fffcd2a2d58fd71eacce09055291a",
+    "contentSHA": "651dd752112cbb0248deec91814121add82b9a042bfdd8b1450a4281fb681962",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/helm-nginx/expected/.ship/state.json
+++ b/integration/base/helm-nginx/expected/.ship/state.json
@@ -1,7 +1,7 @@
 {
   "v1": {
     "config": {},
-    "contentSHA": "1ed49d304e4649b80998a7fe3df4a948b331bc1602d5e62c8ff1249ac4ab4026",
+    "contentSHA": "2dcfb7d9685eddde588f5ae1f9282a7b85e89860f030ae9ee08d914f3c8accf8",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/base/web/expected/.ship/state.json
+++ b/integration/base/web/expected/.ship/state.json
@@ -4,7 +4,7 @@
       "methodType": "GET",
       "resourceURL": "https://raw.githubusercontent.com/replicatedhq/test-charts/5bf016aac1786cb74c678c3419bb8623f0388f8d/web-asset/web-asset"
     },
-    "contentSHA": "c914ad6c3972e186008cb3dc7bd11de3fa23150a18f0b94858cbcbc7e18906e2",
+    "contentSHA": "d0d955a1d3e5a2775b86f2e585252dc581f449b87a86aaf80f6428c039fe49d0",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/integration/init_app/amazon-eks-template/expected/.ship/state.json
+++ b/integration/init_app/amazon-eks-template/expected/.ship/state.json
@@ -2,7 +2,7 @@
   "v1": {
     "config": {},
     "upstream": "__upstream__",
-    "contentSHA": "733cc0bacfc5a6ab9cdd5a50a9b72a65a614cc832f824abf65f00452ba5a8d44",
+    "contentSHA": "8ceb6285ff8617f85cb61078fdd05c1096ed1996d2698a40cde1ca1333ff0344",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "__customerID__",

--- a/integration/init_app/basic/expected/.ship/state.json
+++ b/integration/init_app/basic/expected/.ship/state.json
@@ -2,7 +2,7 @@
   "v1": {
     "config": {},
     "upstream": "__upstream__",
-    "contentSHA": "2aaf62ff2fbf89fb4a1ec2d73f6bb02e082e041b9c925cff677e1622637b2aac",
+    "contentSHA": "674dfc6dbef7422277ad215e875f978f9c1d5d51429e1e231e461c3cee0954cb",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "__customerID__",

--- a/integration/init_app/bool-string-quoting/expected/.ship/state.json
+++ b/integration/init_app/bool-string-quoting/expected/.ship/state.json
@@ -46,6 +46,6 @@
         "arch": "amd64"
       }
     },
-    "contentSHA": "e84f92a45afefd50c548d664d0a6f32d474a84c416983b2a61d854f549ea6195"
+    "contentSHA": "780274fa1a9c10eae29416fc89d12d986afe189ee44037f5c9288126c22ac612"
   }
 }

--- a/integration/init_app/docker-asset-slug/expected/.ship/state.json
+++ b/integration/init_app/docker-asset-slug/expected/.ship/state.json
@@ -18,7 +18,7 @@
       "sequence": 0,
       "version": "0.0.1"
     },
-    "contentSHA": "93707ba161f8777e5db8f4b97215416f92ff2d9e2b0eb94cd7528333f241e3cf",
+    "contentSHA": "96bfc890d1966679e4d00c85b24f2afc53e1b2edc48fa975f014aa26d88b7eeb",
     "upstreamContents": {
       "appRelease": {
         "id": "oVSYJqtZnSew_8A3fFuwz0WPwn40zjn6",

--- a/integration/init_app/docker-asset/expected/.ship/state.json
+++ b/integration/init_app/docker-asset/expected/.ship/state.json
@@ -18,7 +18,7 @@
       "sequence": 0,
       "version": "1.0.0-SNAPSHOT"
     },
-    "contentSHA": "a7a367e40499c34031462f1eaba15c86947d1694b3a02fe56a1b37880d3b4aab",
+    "contentSHA": "f81b240e101fe229913a23cc3fc0ad59583ecd88711e280f5cd1971020249458",
     "upstreamContents": {
       "appRelease": {
         "id": "jDtI-DiraCbkN5euJHmbS3kIFw4N1Iw9",

--- a/integration/init_app/github-template-func/expected/.ship/state.json
+++ b/integration/init_app/github-template-func/expected/.ship/state.json
@@ -4,7 +4,7 @@
       "option": "abc123"
     },
     "upstream": "__upstream__",
-    "contentSHA": "e00d542a56bac2c850a73795c41336f1f68af52e6facc5d4fde6fd1e57eaa1a8",
+    "contentSHA": "6c76198ecbf868cf6968d5c8e047424ccd7952a99b13b6da65c4edb78a0a7b6d",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "__customerID__",

--- a/integration/init_app/helm-github/expected/.ship/state.json
+++ b/integration/init_app/helm-github/expected/.ship/state.json
@@ -1,7 +1,7 @@
 {
   "v1": {
     "config": {},
-    "contentSHA": "1a392e505d07d17ef6e63a7e0374bab74493ffb140362fefbeec8a85ca594fbc",
+    "contentSHA": "deaf3417dc3eb72f3d2bd7cf7434153cc555e8609e5e48ccb28795b39e2e5d87",
     "releaseName": "integration-replicated-app-helm-github",
     "upstream": "__upstream__",
     "metadata": {

--- a/integration/init_app/installation-template-func/expected/.ship/state.json
+++ b/integration/init_app/installation-template-func/expected/.ship/state.json
@@ -2,7 +2,7 @@
   "v1": {
     "config": {},
     "upstream": "__upstream__",
-    "contentSHA": "a81db772400b6e78a5520d2a8ba993845894a58dba68dd3930a454f370ba32c0",
+    "contentSHA": "bddc8932888aeedf0ed046eea44b93df6a7a5552e0bdea74e406789dd3c85c9b",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "__customerID__",

--- a/integration/init_app/license-info/expected/.ship/state.json
+++ b/integration/init_app/license-info/expected/.ship/state.json
@@ -34,8 +34,8 @@
         "registrySecret": "3bfd99a69b5748fab756a593c7dcc852",
         "entitlements": {
           "meta": {
-            "last_updated": "0001-01-01T00:00:00Z",
-            "customer_id": ""
+            "lastUpdated": "0001-01-01T00:00:00Z",
+            "customerID": ""
           },
           "signature": "eVlVacoh3aPSx+EvhmD+B8vG3QicsaWkJ+9vcFReB2xRgPtNgedfQkS7bmJxNwCHZlcOXX/m1io5IkFFXPdW4mXvIRO/5p6xJWFj/icU1iHOBPYf6Q2pEC9+ylXAj8upyPPGGJc+MN5X83Sxk/JumRJPMCNoykwgixkai7NtiZgEjvyfMLPZhYwZ5MBNEv6CJ5NCCw7JO1Ga8G6CDa6E3NLsFJLLLcYUQO+7+hDb9IMxkynHJCoazJ1587fVUgeZ1QLt+mWdJoILn+ioDH4TJ0XZMWvLdRDoV6JTugs1O3O9qh3sMu5C2fow0i3Cnr+K8DsWDpazXTBQzd2ZIuUFf02CgCEF+0M/o9DMbpocePjmHufxZXcEl3jv8rMv5wa6civwRA9W8dbv+eepMf4ngcUP/hxz4WkCSTWT5Zf6+JngXYylDZta+/HnzRMczhG9Laaa+TRhm+fsxApQ4wORvdms3xwcxg35FTzUy4gMoSCLFiNjN7e/GZWsb9NYlFoI/sfhqVsNljFJlN4+XgqEGyU1tn4ggdBeQ9J4/E6NUkvu8+lWqfvNrapGNm2+3J7hAIvfpNo/sOXLGfbHjXu+hM3RWkxgvVKecqMeEAO0MSNZouIRMKmT/qHz15Ds7vww0lkRKQG2xcXFitLVCglcAe2ApriNTAY19MWBVVMUKfY=",
           "values": [

--- a/integration/init_app/troubleshoot-ship-release/expected/.ship/state.json
+++ b/integration/init_app/troubleshoot-ship-release/expected/.ship/state.json
@@ -2,7 +2,7 @@
   "v1": {
     "config": {},
     "upstream": "__upstream__",
-    "contentSHA": "4f2573405df7fa89aa1b719db234e69e8332c356fa1bf8e0bacbf16a84529109",
+    "contentSHA": "9891fe3082c1abccbb13771004f397307e2cb084586e940c02bf6ca77f4e5944",
     "metadata": {
       "applicationType": "replicated.app",
       "license": {

--- a/integration/update/app-with-added-files/expected/.ship/state.json
+++ b/integration/update/app-with-added-files/expected/.ship/state.json
@@ -34,8 +34,8 @@
         "registrySecret": "3bfd99a69b5748fab756a593c7dcc852",
         "entitlements": {
           "meta": {
-            "last_updated": "0001-01-01T00:00:00Z",
-            "customer_id": ""
+            "lastUpdated": "0001-01-01T00:00:00Z",
+            "customerID": "a16_bcTnkNqFWs1UEcCJ3DQFYzfnLfVr"
           },
           "signature": "bdxCzBUoZaOwGF+Le03faHKUBbiPf63v7Hn80rlWpgRUYMWgxmANC2bMr441y5+DIA7N2GZlMsLk79Yaa+oQv+tgWPS7dcfI+YLsbf/2fRKOkliB5oOPd1VQCylUKKYxCRO3iXUA+ZMQH+2sgWXekvEy6JpUnclSDIyfnjrgXNkN65ht4iQEOsVQVXeVXk1KZGmGI2WBtCjZVtHoIwVgKemZE6M+3WcqLIitVT3wMVsfNI14THKiKAv1MccFhYXn1LnMybLMrVh1A6HRnZ/H9+3EujnjwyzHzMvpzbEVjrfQkMoNvhS445YkYqJPjll8E9POoeBawG5mY3wXhmDepystiNKxbEz0IZZnbMZ2gu9mbGlK5MRFzLjITyIgn1XJ9qQ+W3/fcy9u6enIrK6VA41JwX9UlIrZvX97+t5tiMIgYMuFbK3HPignomPnnctKzOCt+WGU4E+VnXkrtw8pDVaJVJF6NCA+2DdTVbHdWiP1P/hjB6+tvlz+YkOOYhXbSmHYV/fR+MmAIhcYLm7j4he9D3IuscxfBGx1KNsdxaPSIgHuqebLcRDs4deztRVrPAnlf1NyTeCd4cr/7mTbCzXtN7ZFWjMGE/Pp+bf6zlV9gGJDIowfjwXHpuAio9btM8hdKxqIjBsfyVhgJxjpbX3mIhLQ35RxU8Mi5hybb+s="
         },
@@ -58,6 +58,6 @@
         "arch": "amd64"
       }
     },
-    "contentSHA": "1a37b536911d0b33c7730ed5fe070800d424650293e3950b8822f51c7251f8f6"
+    "contentSHA": "251f17dc410c816470730c309d9304af29980150047b736cc7861271785410a1"
   }
 }

--- a/integration/update/app-with-added-files/input/.ship/state.json
+++ b/integration/update/app-with-added-files/input/.ship/state.json
@@ -34,8 +34,8 @@
         "registrySecret": "3bfd99a69b5748fab756a593c7dcc852",
         "entitlements": {
           "meta": {
-            "last_updated": "0001-01-01T00:00:00Z",
-            "customer_id": ""
+            "lastUpdated": "0001-01-01T00:00:00Z",
+            "customerID": "a16_bcTnkNqFWs1UEcCJ3DQFYzfnLfVr"
           },
           "signature": "pyT3OMJVavJ3u40TRMaiolFTnVJx1oj2vxfSZWsDAPSaLM8g1M9gX1HiRvzRvkm3HhA7olXXo8Ore8QXDpMBrpH4TFqMN3y0chC8rle4ORs/UYZdugLM2LJ1QsUwmBSbxTf7vS/fmXOPoAM2VcoJ8DS7cPpIDyrQ7dclR3l5yRJL5Vqhjx9CUMVQu8avRIYu2YUnFGADC+nfqNUabmIx7/5DUtZ/EaDSK98MD8pvhyB+2y2O9Q1zEgk6uXVlJ+DYgsb4rKGoVRRaVKlkGhR9NlFNGao9vjd/uSAoZ5OWSCTJub4Ys2SaWeIhj2P5LV/wHLuYEZaIVlrKqW/gKTKJ9HCFwiHbsi2zr48WxVAufkk0Q4m6hhQryz/qcBzcFA3Cnhl9y0dfR+8C39h8N5wEAXLz267SKpQfZQEOUmexeCzV+TcXoHasmFtKBhvgP5jQdiua1bpEumm+t3LhBlg7u3czPMkMuNluU3ovlZ9rxhjJK1aLmI9Eriigg94kKfAgr+ueNnsHZc4zNxAqXQnZ/7PipJjrLCs5o3+VwYVUrP09f71kocVQIreOhlB382CEPOzEsDZtUb3wV1z3TW0qUOf+wGP24jVj4CfY9AK3LvVUQkVvU7Xg8pJeIxlJ5DIVwun+zeeBjig4K9vQdIGeU1FTj+KewmjmO0lx7UO/CtM="
         },
@@ -58,6 +58,6 @@
         "arch": "amd64"
       }
     },
-    "contentSHA": "9e4b1247ff8bc186ade63a7d07fc25ad5bac07bf16f705c74b21d8b6183afea4"
+    "contentSHA": "251f17dc410c816470730c309d9304af29980150047b736cc7861271785410a1"
   }
 }

--- a/integration/update/app_basic/expected/.ship/state.json
+++ b/integration/update/app_basic/expected/.ship/state.json
@@ -2,7 +2,7 @@
   "v1": {
     "config": {},
     "upstream": "staging.replicated.app/some-cool-ci-tool?installation_id=3Z6uuPbVz6jTxRuXHn_l6UlYQz3hWz6-&customer_id=-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",
-    "contentSHA": "2aaf62ff2fbf89fb4a1ec2d73f6bb02e082e041b9c925cff677e1622637b2aac",
+    "contentSHA": "674dfc6dbef7422277ad215e875f978f9c1d5d51429e1e231e461c3cee0954cb",
     "metadata": {
       "applicationType": "replicated.app",
       "customerID": "-Am-_6i5pw0u4AbspOwKN4lZUCn49u_G",

--- a/pkg/api/entitlements.go
+++ b/pkg/api/entitlements.go
@@ -8,8 +8,8 @@ import "time"
 
 // Meta describes metadata about an entitlements payload
 type Meta struct {
-	LastUpdated time.Time `json:"last_updated"`
-	CustomerID  string    `json:"customer_id"`
+	LastUpdated time.Time `json:"lastUpdated"`
+	CustomerID  string    `json:"customerID"`
 }
 
 // EntitlementLabel is a single entitlement label

--- a/pkg/specs/interface_test.go
+++ b/pkg/specs/interface_test.go
@@ -356,7 +356,7 @@ func TestResolver_ReadContentSHAForWatch(t *testing.T) {
 					AppSlug:        "",
 				}).Return(&state2.ShipRelease{Spec: "its fake"}, nil)
 			},
-			expectSHA: "ef1a4329e78b65e847e7428c3427f99b02a2d6c04ab3adb3910b9473b8bc7edb", // sha256.Sum256(json.Marshal(state2.ShipRelease{Spec: "its fake"}))
+			expectSHA: "c28f8f4146e25744f36644d3ff1c0dfbae4898a34d581238057b1fce2448f13d", // sha256.Sum256(json.Marshal(state2.ShipRelease{Spec: "its fake"}))
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
<!--

  Hello Friend! Thank you for contributing to Ship!

  If you worked on the front end (i.e React component side)...
  Did you bump the version number in package.json?

  Thanks again! You are awesome!
-->
What I Did
------------
Ship entitlements metadata uses wrong json tags. Fields will always be empty in the release metadata.

How I Did it
------------
Changed the json tags to use the proper json property names

How to verify it
------------
All the content shas in the integration tests had to be updated because there is now non-zero values in the entitlements meta

Description for the Changelog
------------
Property entitlements.meta is now correctly included in the ship release metadata


Picture of a Ship (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

