### PR TITLE
persist custom json6902 patches in overlays dir

### DIFF
--- a/integration/update/k8s-new-files/expected/overlays/ship/container-name-patch.json
+++ b/integration/update/k8s-new-files/expected/overlays/ship/container-name-patch.json
@@ -1,0 +1,1 @@
+[{"op":"replace","path":"/spec/template/spec/containers/0/name","value":"replacedSlave"}]

--- a/integration/update/k8s-new-files/expected/overlays/ship/kustomization.yaml
+++ b/integration/update/k8s-new-files/expected/overlays/ship/kustomization.yaml
@@ -3,5 +3,12 @@ apiversion: ""
 patchesStrategicMerge:
 - redis-master-service.yaml
 - redis-slave-service.yaml
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: redis-slave
+  path: container-name-patch.json
 bases:
 - ../defaults

--- a/integration/update/k8s-new-files/expected/rendered.yaml
+++ b/integration/update/k8s-new-files/expected/rendered.yaml
@@ -128,7 +128,7 @@ spec:
         - name: GET_HOSTS_FROM
           value: dns
         image: gcr.io/google_samples/gb-redisslave:v1
-        name: slave
+        name: replacedSlave
         ports:
         - containerPort: 6379
         resources:

--- a/integration/update/k8s-new-files/input/overlays/ship/container-name-patch.json
+++ b/integration/update/k8s-new-files/input/overlays/ship/container-name-patch.json
@@ -1,0 +1,1 @@
+[{"op":"replace","path":"/spec/template/spec/containers/0/name","value":"replacedSlave"}]

--- a/integration/update/k8s-new-files/input/overlays/ship/kustomization.yaml
+++ b/integration/update/k8s-new-files/input/overlays/ship/kustomization.yaml
@@ -5,3 +5,10 @@ patchesStrategicMerge:
 - redis-slave-service.yaml
 bases:
 - ../defaults
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: redis-slave
+  path: container-name-patch.json

--- a/pkg/lifecycle/daemon/routes_navcycle_kustomize_test.go
+++ b/pkg/lifecycle/daemon/routes_navcycle_kustomize_test.go
@@ -164,7 +164,7 @@ func TestV2KustomizeSaveFile(t *testing.T) {
 					}
 					return true
 				},
-				Describe: fmt.Sprintf("expect state equal to %s", test.ExpectState),
+				Describe: fmt.Sprintf("expect state equal to %+v", test.ExpectState),
 			}).Return(nil).AnyTimes()
 
 			err := v2.kustomizeDoSaveOverlay(test.Body)
@@ -286,7 +286,7 @@ func TestV2KustomizeDeleteFile(t *testing.T) {
 					}
 					return true
 				},
-				Describe: fmt.Sprintf("expect state equal to %s", test.ExpectState),
+				Describe: fmt.Sprintf("expect state equal to %+v", test.ExpectState),
 			}).Return(nil).AnyTimes()
 
 			err := v2.deleteFile(test.DeleteFileParams.pathQueryParam, test.DeleteFileParams.getFiles)

--- a/pkg/lifecycle/kustomize/daemonless.go
+++ b/pkg/lifecycle/kustomize/daemonless.go
@@ -105,7 +105,7 @@ func (l *Kustomizer) Execute(ctx context.Context, release *api.Release, step api
 		return err
 	}
 
-	err = l.writeOverlay(step, relativePatchPaths, relativeResourcePaths)
+	err = l.writeOverlay(step, relativePatchPaths, relativeResourcePaths, shipOverlay.RawKustomize)
 	if err != nil {
 		return errors.Wrap(err, "write overlay")
 	}

--- a/pkg/lifecycle/kustomize/kustomizer.go
+++ b/pkg/lifecycle/kustomize/kustomizer.go
@@ -174,19 +174,16 @@ func (l *Kustomizer) writeOverlay(
 	step api.Kustomize,
 	relativePatchPaths []patch.StrategicMerge,
 	relativeResourcePaths []string,
+	kustomization ktypes.Kustomization,
 ) error {
 	// just always make a new kustomization.yaml for now
 	basePath, err := filepath.Rel(step.OverlayPath(), constants.DefaultOverlaysPath)
 	if err != nil {
 		return err
 	}
-	kustomization := ktypes.Kustomization{
-		Bases: []string{
-			basePath,
-		},
-		PatchesStrategicMerge: relativePatchPaths,
-		Resources:             relativeResourcePaths,
-	}
+	kustomization.Bases = []string{basePath}
+	kustomization.PatchesStrategicMerge = relativePatchPaths
+	kustomization.Resources = relativeResourcePaths
 
 	marshalled, err := util.MarshalIndent(2, kustomization)
 	if err != nil {

--- a/pkg/lifecycle/kustomize/pre_kustomize.go
+++ b/pkg/lifecycle/kustomize/pre_kustomize.go
@@ -172,8 +172,9 @@ func (l *Kustomizer) resolveExistingKustomize(ctx context.Context, overlayDir st
 		currentKustomize.Overlays = map[string]state.Overlay{}
 	}
 	currentOverlay := currentKustomize.Ship()
-	fsResources := make(map[string]string)
+	currentOverlay.RawKustomize = kustomization
 
+	fsResources := make(map[string]string)
 	for _, kustomizeResource := range kustomization.Resources {
 		// read resource referred to by kustomize yaml
 		kustomizeResourceContents, err := l.FS.ReadFile(filepath.Join(overlayDir, kustomizeResource))
@@ -186,7 +187,6 @@ func (l *Kustomizer) resolveExistingKustomize(ctx context.Context, overlayDir st
 	currentOverlay.Resources = fsResources
 
 	fsPatches := make(map[string]string)
-
 	for _, kustomizePatch := range kustomization.PatchesStrategicMerge {
 		// read resource referred to by kustomize yaml
 		kustomizePatchContents, err := l.FS.ReadFile(filepath.Join(overlayDir, string(kustomizePatch)))

--- a/pkg/lifecycle/kustomize/pre_kustomize_test.go
+++ b/pkg/lifecycle/kustomize/pre_kustomize_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/kustomize/pkg/patch"
+	"sigs.k8s.io/kustomize/pkg/types"
 )
 
 type testFile struct {
@@ -430,6 +432,11 @@ patchesStrategicMerge:
 						Patches:       map[string]string{"/mypatch.yaml": "this is my patch"},
 						Resources:     map[string]string{"/myresource.yaml": "this is my resource"},
 						ExcludedBases: []string{"excludedBase"},
+						RawKustomize: types.Kustomization{
+							PatchesStrategicMerge: []patch.StrategicMerge{"mypatch.yaml"},
+							Resources:             []string{"myresource.yaml"},
+							Bases:                 []string{"../abc"},
+						},
 					},
 				},
 			},
@@ -468,6 +475,13 @@ resources:
 							"/myotherresource.yaml": "this is my other resource",
 						},
 						ExcludedBases: []string{},
+						RawKustomize: types.Kustomization{
+							Resources: []string{
+								"myresource.yaml",
+								"myotherresource.yaml",
+							},
+							Bases: []string{"../abc"},
+						},
 					},
 				},
 			},

--- a/pkg/state/models.go
+++ b/pkg/state/models.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform/terraform"
+	"sigs.k8s.io/kustomize/pkg/types"
 
 	"github.com/replicatedhq/ship/pkg/api"
 	"github.com/replicatedhq/ship/pkg/util"
@@ -107,9 +108,10 @@ func (l *Lifeycle) WithCompletedStep(step api.Step) *Lifeycle {
 }
 
 type Overlay struct {
-	ExcludedBases []string          `json:"excludedBases,omitempty" yaml:"excludedBases,omitempty" hcl:"excludedBases,omitempty"`
-	Patches       map[string]string `json:"patches,omitempty" yaml:"patches,omitempty" hcl:"patches,omitempty"`
-	Resources     map[string]string `json:"resources,omitempty" yaml:"resources,omitempty" hcl:"resources,omitempty"`
+	ExcludedBases []string            `json:"excludedBases,omitempty" yaml:"excludedBases,omitempty" hcl:"excludedBases,omitempty"`
+	Patches       map[string]string   `json:"patches,omitempty" yaml:"patches,omitempty" hcl:"patches,omitempty"`
+	Resources     map[string]string   `json:"resources,omitempty" yaml:"resources,omitempty" hcl:"resources,omitempty"`
+	RawKustomize  types.Kustomization `json:"-"`
 }
 
 func NewOverlay() Overlay {


### PR DESCRIPTION
What I Did
------------
`kustomization.yaml` within the overlays directory is stored and only the resources/bases/patches are modified. This allows PatchesJSON6902 (closes https://github.com/replicatedhq/ship/issues/1037, closes https://github.com/replicatedhq/ship/issues/730) to be persisted when running ship, among other things.

How I Did it
------------
The kustomization file is added to the ship state in a manner that will not be included in any jsonified versions of the state, and modifications are made to this stored file instead of starting from scratch.

How to verify it
------------
The json patch newly included within the `k8s-new-files` ship update integration test is persisted and applied within the rendered output.

Description for the Changelog
------------
`patchesJson6902` within user kustomization is persisted in `ship update` and `ship edit`


Picture of a Ship (not required but encouraged)
------------
![USS Wright (CVL-49)](https://upload.wikimedia.org/wikipedia/commons/0/09/USS_Leyte_%28CV-32%29_and_USS_Wright_%28CVL-49%29_at_Quonset_Point_c1950.jpg "USS Wright (CVL-49)")











<!-- (thanks https://github.com/docker/docker for this template) -->

