### PR TITLE
improve handling of docker url dests and add UrlPathEscape template function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ mockgen: _mockgen fmt
 deps:
 	dep ensure -v
 
-
+.state/fmt: GO111MODULE=off
 .state/fmt: $(SRC)
 	goimports -w pkg
 	goimports -w cmd

--- a/go.mod
+++ b/go.mod
@@ -117,7 +117,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20181120190819-8f65e3013eba
 	golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456 // indirect
 	golang.org/x/text v0.3.2 // indirect
-	golang.org/x/tools v0.0.0-20190827205025-b29f5f60c37a // indirect
+	golang.org/x/tools v0.0.0-20190828211409-a0cf054a4555 // indirect
 	google.golang.org/appengine v1.3.0 // indirect
 	google.golang.org/grpc v1.21.0
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -727,6 +727,8 @@ golang.org/x/tools v0.0.0-20190827152308-062dbaebb618 h1:WtF22n/HcPWMhvZm4KWiQ0F
 golang.org/x/tools v0.0.0-20190827152308-062dbaebb618/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190827205025-b29f5f60c37a h1:0JEq5ZQ3TgsRlFmz4BcD+E6U6cOk4pOImCQSyIG59ZM=
 golang.org/x/tools v0.0.0-20190827205025-b29f5f60c37a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20190828211409-a0cf054a4555 h1:WHKnEyRwPYpu/vTaU8HRdvnIceBN9IW7x2EIycXa6YQ=
+golang.org/x/tools v0.0.0-20190828211409-a0cf054a4555/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.0.0-20171005000305-7a7376eff6a5/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/appengine v0.0.0-20150527042145-b667a5000b08/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/pkg/lifecycle/render/planner/build.go
+++ b/pkg/lifecycle/render/planner/build.go
@@ -2,6 +2,7 @@ package planner
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -372,6 +373,14 @@ func planToDests(plan Plan, builder *templates.Builder) ([]string, error) {
 		if err != nil {
 			return nil, errors.Wrapf(err, "building dest %q", step.Dest)
 		}
+
+		// special case for docker URL dests - don't attempt to remove url paths
+		destinationURL, err := url.Parse(dest)
+		// if there was an error parsing the dest as a url, or the scheme was not 'docker', add to the dests list as normal
+		if err == nil && destinationURL.Scheme == "docker" {
+			continue
+		}
+
 		dests = append(dests, dest)
 	}
 

--- a/pkg/templates/static_context.go
+++ b/pkg/templates/static_context.go
@@ -62,6 +62,7 @@ func (ctx StaticCtx) FuncMap() template.FuncMap {
 	sprigMap["TrimSpace"] = strings.TrimSpace
 	sprigMap["Trim"] = ctx.trim
 	sprigMap["UrlEncode"] = url.QueryEscape
+	sprigMap["UrlPathEscape"] = url.PathEscape
 	sprigMap["Base64Encode"] = ctx.base64Encode
 	sprigMap["Base64Decode"] = ctx.base64Decode
 	sprigMap["Split"] = strings.Split


### PR DESCRIPTION
What I Did
------------
Fixed https://github.com/replicatedhq/ship/issues/1054
Added `UrlPathEscape` template function
Sped up `make build` and `make test` by using `GO111MODULE=off` for calls to `goimports`

How I Did it
------------
The template function just calls `url.PathEscape`, and parallels the existing `UrlEncode` template function (which calls `url.QueryEscape`)
Also handled an error where the update code could attempt to remove files from the URL's path within the filesystem. (dests are parsed as urls and checked for a scheme of "docker" - if the parsing passes and the scheme matches, the dest is not considered for removal)

How to verify it
------------
Modify the yaml in #1054 to use UrlPathEscape:
```
assets:
  v1:
    - docker:
        image: alpine:latest
        source: public
        dest: docker://{{repl ConfigOption "registry_auth"}}{{repl ConfigOption "registry_address"}}/alpine:latest

config:
  v1:
  - name: registry
    title: Docker Registry
    description: Configure the Docker Registry path and authentication information. This Docker Registry will store the Bugsnag images that are required for Clustered Edition.
    items:
    - name: registry_address
      title: Docker Registry path
      help_text: The path of the Docker Registry. The Registry should be addressable with the same path from both this machine and the Kubernetes cluster.
      type: text
      required: true
    - name: registry_username
      title: Username
      type: text
      default: ""
      affix: left
    - name: registry_password
      title: Password
      type: text
      default: ""
      affix: right
    - name: registry_auth
      readonly: true
      value: '{{repl ConfigOption "registry_username" | UrlPathEscape}}:{{repl ConfigOption "registry_password" | UrlPathEscape}}@'

lifecycle:
  v1:
    - config:
        invalidates: ["render"]
    - render:
        requires: ["config"]
        root: .
```
and push to a GCR repository as described

Description for the Changelog
------------
`UrlPathEscape`, template function to encode parts of a URL's path has been added


Picture of a Ship (not required but encouraged)
------------


![USS Forrestal (CVA-59)](https://upload.wikimedia.org/wikipedia/commons/thumb/0/0b/US_Navy_80-G-682046_USS_Forrestal_%28CVA-59%29_underway_on_trials_1955.jpg/1280px-US_Navy_80-G-682046_USS_Forrestal_%28CVA-59%29_underway_on_trials_1955.jpg "USS Forrestal (CVA-59)")









<!-- (thanks https://github.com/docker/docker for this template) -->

