### PR TITLE
the cassandra version expected by the test has changed

### DIFF
--- a/integration/init/jaeger-helm/expected/base/charts/cassandra/templates/service.yaml
+++ b/integration/init/jaeger-helm/expected/base/charts/cassandra/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: jaeger-cassandra
   labels:
     app: cassandra
-    chart: cassandra-0.13.2
+    chart: cassandra-0.13.3
     release: jaeger
     heritage: Tiller
 spec:

--- a/integration/init/jaeger-helm/expected/base/charts/cassandra/templates/statefulset.yaml
+++ b/integration/init/jaeger-helm/expected/base/charts/cassandra/templates/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: jaeger-cassandra
   labels:
     app: cassandra
-    chart: cassandra-0.13.2
+    chart: cassandra-0.13.3
     release: jaeger
     heritage: Tiller
 spec:


### PR DESCRIPTION
we should really look into somehow pinning that version or removing the test

What I Did
------------
fixed integration tests

How I Did it
------------
bumping chart version expected in the test

How to verify it
------------
tests pass

Description for the Changelog
------------



Picture of a Ship (not required but encouraged)
------------

![USS Saratoga (CV-60)](https://upload.wikimedia.org/wikipedia/commons/7/71/USS_Saratoga_%28CV-60%29_underway_in_the_Adriatic_Sea_on_29_July_1992_%286480624%29.jpg "USS Saratoga (CV-60)")










<!-- (thanks https://github.com/docker/docker for this template) -->

