### PR TITLE
remove checkbox default

### DIFF
--- a/web/init/package.json
+++ b/web/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replicatedhq/ship-init",
-  "version": "1.6.12",
+  "version": "1.6.13",
   "description": "Shared component that contains the Ship Init app",
   "author": "Replicated, Inc.",
   "license": "Apache-2.0",

--- a/web/init/src/components/config_render/ConfigCheckbox.jsx
+++ b/web/init/src/components/config_render/ConfigCheckbox.jsx
@@ -28,7 +28,6 @@ export default class ConfigCheckbox extends React.Component {
             ref={(checkbox) => this.checkbox = checkbox}
             type="checkbox"
             name={this.props.name}
-            default={this.props.default}
             id={this.props.name}
             value="1"
             checked={checked}


### PR DESCRIPTION
Default is unused since value is always set, but default can still cause
error when not a boolean.

<!--

  Hello Friend! Thank you for contributing to Ship!

  If you worked on the front end (i.e React component side)...
  Did you bump the version number in package.json? Yes

  Thanks again! You are awesome!
-->
What I Did
------------
Fix console error about using string "true" as default to checkbox.

How I Did it
------------
Removed the default.

How to verify it
------------
Check for console errors with this config:
```
      items:
        - name: item_with_bool_default
          title: Item with bool default
          type: bool
          default: "true"
```

Description for the Changelog
------------
Removed unused default from checkbox config item.


Picture of a Ship (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

