### PR TITLE
Ship has been superseded by Kots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+## Replicated Ship has been superseded by [Kots](https://www.github.com/replicatedhq/kots).
+
+Kots provides the core functionality of Ship, but with a different architecture.
+While Ship will continue to be supported, it is no longer under active development.
+
 Replicated Ship
 =======
 


### PR DESCRIPTION
What I Did
------------
Added a "use Kots" notice to the readme

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Ship (not required but encouraged)
------------
![USS Shoup (DDG-86)](https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/US_Navy_011211-N-0000X-007_The_Arleigh_Burke_%28Flight_III%29_class_guided_missile_Destroyer_USS_Shoup_%28DDG_86%29.jpg/1223px-US_Navy_011211-N-0000X-007_The_Arleigh_Burke_%28Flight_III%29_class_guided_missile_Destroyer_USS_Shoup_%28DDG_86%29.jpg "USS Shoup (DDG-86)")











<!-- (thanks https://github.com/docker/docker for this template) -->

