### PR TITLE
marshal boolstrings like 'no' with quotes in helm values file

### DIFF
--- a/pkg/helm/shared.go
+++ b/pkg/helm/shared.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/replicatedhq/ship/pkg/constants"
+	"github.com/replicatedhq/ship/pkg/util"
 	"google.golang.org/grpc/status"
 	yaml "gopkg.in/yaml.v3"
 	"k8s.io/helm/pkg/getter"
@@ -140,7 +141,7 @@ func vals(valueFiles valueFiles, values []string, stringValues []string, fileVal
 		}
 	}
 
-	return yaml.Marshal(base)
+	return util.MarshalIndent(2, base)
 }
 
 func generateName(nameTemplate string) (string, error) {

--- a/pkg/patch/patcher.go
+++ b/pkg/patch/patcher.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
-	yamlv3 "gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes/scheme"
 	kustomizepatch "sigs.k8s.io/kustomize/pkg/patch"
@@ -186,7 +185,7 @@ func (p *ShipPatcher) ApplyPatch(patch []byte, step api.Kustomize, resource stri
 		PatchesStrategicMerge: []kustomizepatch.StrategicMerge{TempYamlPath},
 	}
 
-	kustomizationYamlBytes, err := yamlv3.Marshal(kustomizationYaml)
+	kustomizationYamlBytes, err := util.MarshalIndent(2, kustomizationYaml)
 	if err != nil {
 		return nil, errors.Wrap(err, "marshal kustomization yaml")
 	}


### PR DESCRIPTION
What I Did
------------
Changed the yaml renderer for the helm settings file to render the string `no` as `"no"` and not `no` (which helm interprets as a boolean)

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Ship (not required but encouraged)
------------



![image](https://user-images.githubusercontent.com/2318911/74479831-bba3ed00-4e64-11ea-842c-4dcceb1ab04a.png)









<!-- (thanks https://github.com/docker/docker for this template) -->

