### PR TITLE
Grayson/render markdown links

### DIFF
--- a/web/init/package.json
+++ b/web/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replicatedhq/ship-init",
-  "version": "1.6.19",
+  "version": "1.6.20",
   "description": "Shared component that contains the Ship Init app",
   "author": "Replicated, Inc.",
   "license": "Apache-2.0",

--- a/web/init/src/components/config_render/ConfigCheckbox.jsx
+++ b/web/init/src/components/config_render/ConfigCheckbox.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Markdown from "react-remarkable";
 
 export default class ConfigCheckbox extends React.Component {
 
@@ -44,7 +45,17 @@ export default class ConfigCheckbox extends React.Component {
                     <span className="field-label recommended">Recommended</span> :
                     null}
             </label>
-            {this.props.help_text !== "" ? <p className="field-section-help-text u-marginTop--small u-lineHeight--normal u-marginLeft--small">{this.props.help_text}</p> : null}
+            {this.props.help_text !== "" ? 
+              <p className="field-section-help-text u-marginTop--small u-lineHeight--normal u-marginLeft--small">
+                <Markdown
+                  options={{
+                    linkTarget: "_blank",
+                    linkify: true,
+                  }}>
+                  {this.props.help_text}
+                </Markdown>
+              </p>
+            : null}
           </div>
         </div>
       </div>

--- a/web/init/src/components/config_render/ConfigInput.jsx
+++ b/web/init/src/components/config_render/ConfigInput.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ConfigItemTitle from "./ConfigItemTitle";
+import Markdown from "react-remarkable";
 
 export default class ConfigInput extends React.Component {
 
@@ -58,7 +59,17 @@ export default class ConfigInput extends React.Component {
             error={this.props.error}
           />
           : null}
-        {this.props.help_text !== "" ? <p className="field-section-help-text u-marginTop--small u-lineHeight--normal">{this.props.help_text}</p> : null}
+        {this.props.help_text !== "" ? 
+          <p className="field-section-help-text u-marginTop--small u-lineHeight--normal u-marginLeft--small">
+            <Markdown
+              options={{
+                linkTarget: "_blank",
+                linkify: true,
+              }}>
+              {this.props.help_text}
+            </Markdown>
+          </p>
+        : null}
         <div className="field-input-wrapper u-marginTop--15">
           <input
             ref={this.inputRef}

--- a/web/init/src/components/config_render/ConfigSelectOne.jsx
+++ b/web/init/src/components/config_render/ConfigSelectOne.jsx
@@ -4,6 +4,7 @@ import isEmpty from "lodash/isEmpty";
 
 import ConfigItemTitle from "./ConfigItemTitle";
 import ConfigRadio from "./ConfigRadio";
+import Markdown from "react-remarkable";
 
 export default class ConfigSelectOne extends React.Component {
 
@@ -45,7 +46,17 @@ export default class ConfigSelectOne extends React.Component {
             error={this.props.error}
           />
           : null}
-        {this.props.help_text !== "" ? <p className="field-section-help-text u-marginTop--small u-lineHeight--normal">{this.props.help_text}</p> : null}
+        {this.props.help_text !== "" ? 
+          <p className="field-section-help-text u-marginTop--small u-lineHeight--normal u-marginLeft--small">
+            <Markdown
+              options={{
+                linkTarget: "_blank",
+                linkify: true,
+              }}>
+              {this.props.help_text}
+            </Markdown>
+          </p>
+        : null}
         <div className="field-input-wrapper u-marginTop--15 flex flexWrap--wrap">
           {options}
         </div>

--- a/web/init/src/components/config_render/ConfigTextarea.jsx
+++ b/web/init/src/components/config_render/ConfigTextarea.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ConfigItemTitle from "./ConfigItemTitle";
+import Markdown from "react-remarkable";
 
 export default class ConfigTextarea extends React.Component {
 
@@ -46,7 +47,17 @@ export default class ConfigTextarea extends React.Component {
             error={this.props.error}
           />
           : null}
-        {this.props.help_text !== "" ? <p className="field-section-help-text u-marginTop--small u-lineHeight--normal">{this.props.help_text}</p> : null}
+        {this.props.help_text !== "" ?
+          <p className="field-section-help-text u-marginTop--small u-lineHeight--normal u-marginLeft--small">
+            <Markdown
+              options={{
+                linkTarget: "_blank",
+                linkify: true,
+              }}>
+              {this.props.help_text}
+            </Markdown>
+          </p>
+         : null}
         <div className="field-input-wrapper u-marginTop--15">
           <textarea
             ref={this.textareaRef}


### PR DESCRIPTION
<!--

  Hello Friend! Thank you for contributing to Ship!

  If you worked on the front end (i.e React component side)...
  Did you bump the version number in package.json?

  Thanks again! You are awesome!
-->
What I Did
------------
Added markdown styling to config item help texts.

How I Did it
------------
Wrapped `help_text` of various config items in a `<Markdown>` component so that links and other styles will be rendered.

How to verify it
------------
Create a config item that contains a link in the `help_text`. That should be rendered as a clickable link when viewing the rendered version of the config.

Description for the Changelog
------------
Fix some config items types not rendering help text as markdown making links not clickable.


Picture of a Ship (not required but encouraged)
------------
![diamond-princess](https://user-images.githubusercontent.com/4110866/76113593-0f0fe380-5faa-11ea-8369-9642549da9a6.jpg)











<!-- (thanks https://github.com/docker/docker for this template) -->

