### PR TITLE
release ship even if the go.mod/go.sum files have changed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -602,6 +602,11 @@ jobs:
       - run: docker pull alpine:latest # make sure it's fresh
       - deploy:
           command: |
+            git diff go.mod
+            git update-index --assume-unchanged go.mod
+            git diff go.sum
+            git update-index --assume-unchanged go.sum
+
             if [ "${CIRCLE_PROJECT_USERNAME}" == "replicatedhq" ]; then
                docker login -u="$DOCKERHUB_DOCKER_USER" -p="$DOCKERHUB_DOCKER_PASS"
                curl -sL https://git.io/goreleaser | bash -s -- --config deploy/.goreleaser.yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -602,10 +602,7 @@ jobs:
       - run: docker pull alpine:latest # make sure it's fresh
       - deploy:
           command: |
-            git diff go.mod
-            git update-index --assume-unchanged go.mod
-            git diff go.sum
-            git update-index --assume-unchanged go.sum
+            git diff
 
             if [ "${CIRCLE_PROJECT_USERNAME}" == "replicatedhq" ]; then
                docker login -u="$DOCKERHUB_DOCKER_USER" -p="$DOCKERHUB_DOCKER_PASS"

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/go-test/deep v1.0.1
 	github.com/gobuffalo/packr v1.30.1 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
-	github.com/golang/mock v1.3.1
+	github.com/golang/mock v1.4.1
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect
 	github.com/google/certificate-transparency-go v1.0.21 // indirect
 	github.com/google/go-github/v18 v18.0.0

--- a/go.sum
+++ b/go.sum
@@ -197,6 +197,8 @@ github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4er
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.3.1 h1:qGJ6qTW+x6xX/my+8YUVl4WNpX9B7+/l2tRsHGZ7f2s=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
+github.com/golang/mock v1.4.1 h1:ocYkMQY5RrXTYgXl7ICpV0IXwlEQGwKIsery4gyXa1U=
+github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
@@ -618,6 +620,7 @@ golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 h1:gSbV7h1NRL2G1xTg/owz62CST1oJBmxy4QpMMregXVQ=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
@@ -705,6 +708,8 @@ k8s.io/kubernetes v1.14.3 h1:/FQkOJpjc1jGA37s7Rt3U10VwIKW685ejrgOp4UDRFE=
 k8s.io/kubernetes v1.14.3/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/utils v0.0.0-20190529001817-6999998975a7 h1:5UOdmwfY+7XsXvo26XeCDu9GhHJPkO1z8Mcz5AHMnOE=
 k8s.io/utils v0.0.0-20190529001817-6999998975a7/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
+rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
+rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=

--- a/integration/init/jaeger-helm/expected/base/charts/cassandra/templates/service.yaml
+++ b/integration/init/jaeger-helm/expected/base/charts/cassandra/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: jaeger-cassandra
   labels:
     app: cassandra
-    chart: cassandra-0.14.2
+    chart: cassandra-0.14.3
     release: jaeger
     heritage: Tiller
 spec:

--- a/integration/init/jaeger-helm/expected/base/charts/cassandra/templates/statefulset.yaml
+++ b/integration/init/jaeger-helm/expected/base/charts/cassandra/templates/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: jaeger-cassandra
   labels:
     app: cassandra
-    chart: cassandra-0.14.2
+    chart: cassandra-0.14.3
     release: jaeger
     heritage: Tiller
 spec:


### PR DESCRIPTION
What I Did
------------
Fixed the issue that prevented tag v0.53.0 from releasing, by ignoring it

How I Did it
------------


How to verify it
------------


Description for the Changelog
------------



Picture of a Ship (not required but encouraged)
------------

![USCGC Charles Sexton (WPC-1108)](https://upload.wikimedia.org/wikipedia/commons/2/23/Newly_delivered_USCGC_Charles_Sexton%2C_underway.jpg "USCGC Charles Sexton (WPC-1108)")










<!-- (thanks https://github.com/docker/docker for this template) -->

