### PR TITLE
Updates to polish some of the config items

### DIFF
--- a/web/init/src/components/config_render/ConfigCheckbox.jsx
+++ b/web/init/src/components/config_render/ConfigCheckbox.jsx
@@ -24,7 +24,7 @@ export default class ConfigCheckbox extends React.Component {
     return (
       <div className={`field field-checkbox-wrapper u-marginTop--15 flex ${hidden ? "hidden" : ""}`}>
         <span className="u-marginTop--10 config-errblock" id={`${this.props.name}-errblock`}></span>
-        <div className="flex-auto flex u-marginRight--20">
+        <div className="flex1 flex u-marginRight--20">
           <input
             ref={(checkbox) => this.checkbox = checkbox}
             type="checkbox"

--- a/web/init/src/components/config_render/ConfigRadio.jsx
+++ b/web/init/src/components/config_render/ConfigRadio.jsx
@@ -19,7 +19,7 @@ export default class ConfigRadio extends React.Component {
     const checked = val === this.props.name;
 
     return (
-      <div className="flex-auto flex alignItems--center u-marginRight--20">
+      <div className="flex-auto flex alignItems--center u-marginRight--20 u-marginTop--10">
         <input
           type="radio"
           name={this.props.group}

--- a/web/init/src/components/config_render/ConfigSelectOne.jsx
+++ b/web/init/src/components/config_render/ConfigSelectOne.jsx
@@ -57,7 +57,7 @@ export default class ConfigSelectOne extends React.Component {
             </Markdown>
           </p>
         : null}
-        <div className="field-input-wrapper u-marginTop--15 flex flexWrap--wrap">
+        <div className="field-input-wrapper u-marginTop--5 flex flexWrap--wrap">
           {options}
         </div>
       </div>

--- a/web/init/src/components/config_render/FileInput.jsx
+++ b/web/init/src/components/config_render/FileInput.jsx
@@ -79,15 +79,12 @@ export default class FileInput extends React.Component {
               />
               <label htmlFor={`${this.props.name} selector`} className="u-position--relative">
                 <span className={`icon clickable ${this.state.fileAdded || this.props.value ? "u-smallCheckGreen" : "u-ovalIcon"} u-marginRight--normal u-top--3`}></span>
-                {this.state.fileAdded || this.props.value ? `${this.props.title} file selected` : `Browse files for ${this.props.title}`}
+                {this.state.fileAdded || this.props.value ? this.props.multiple ? this.state.fileNames.join(",") : this.state.fileName : `Browse files for ${this.props.title}`}
+                {this.state.fileAdded || this.props.value ? 
+                  <p className="u-color--astral u-textDecoration--underlineOnHover u-fontSize--small u-marginLeft--30 u-marginTop--5">Select a different file</p>
+                : null }
               </label>
             </div>
-            {this.state.fileAdded || this.props.value ?
-              <div className="u-color--tuna u-marginLeft--normal"> File uploaded:
-              <p className="Form-label-subtext"> {this.props.multiple ? this.state.fileNames.join(",") : this.state.fileName} </p>
-                <p className="Form-label-subtext"> {this.props.getFilenamesText} </p>
-              </div>
-              : null}
           </div>
         </div>
         <small className="text-danger"> {this.state.errText}</small>

--- a/web/init/src/scss/utilities/forms.scss
+++ b/web/init/src/scss/utilities/forms.scss
@@ -84,7 +84,6 @@ input[type="file"] {
   display: inline-block;
   padding: 15px 17px;
   cursor: pointer;
-  width: 249px;
   border-radius: 4px;
 }
 
@@ -93,7 +92,6 @@ input[type="file"] {
   display: inline-block;
   padding: 15px 17px;
   cursor: pointer;
-  width: 249px;
   border-radius: 4px;
   color: #323232;
 }


### PR DESCRIPTION
What I Did
------------
Add polish and update styles of some of the config renderer elements

How I Did it
------------


How to verify it
------------
Wrapping text for select_many config types
<img width="754" alt="Screen Shot 2020-04-29 at 5 01 25 PM" src="https://user-images.githubusercontent.com/4110866/80651222-26fc6480-8a3b-11ea-9f87-fb796aa715d9.png">


File upload updates:
<img width="839" alt="Screen Shot 2020-04-29 at 4 37 25 PM" src="https://user-images.githubusercontent.com/4110866/80651148-f87e8980-8a3a-11ea-9b6b-4c4faed1bd0f.png">


Description for the Changelog
------------
Improving how config items are rendered


Picture of a Ship (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

