### PR TITLE
Do not expand non string when values

### DIFF
--- a/web/init/package.json
+++ b/web/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replicatedhq/ship-init",
-  "version": "1.6.20",
+  "version": "1.6.21",
   "description": "Shared component that contains the Ship Init app",
   "author": "Replicated, Inc.",
   "license": "Apache-2.0",

--- a/web/init/src/services/ConfigService.js
+++ b/web/init/src/services/ConfigService.js
@@ -97,7 +97,7 @@ export const ConfigService = {
       value: "",
       negate: false,
     };
-    if (!when) {
+    if (!when || typeof when !== "string") {
       return expanded;
     }
     const parts = when.split("=");


### PR DESCRIPTION
What I Did
------------
Handle non string `when` field values when expanding

How I Did it
------------
check for `when` field type and do not try to expand it if it's not a string

How to verify it
------------
enter a non-string value for when

Description for the Changelog
------------



Picture of a Ship (not required but encouraged)
------------












<!-- (thanks https://github.com/docker/docker for this template) -->

